### PR TITLE
ci: Do not lint migrations on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
     permissions: write-all
     runs-on: self-hosted
     needs: job-spec
-    if: ${{ needs.job-spec.outputs.migrations == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && needs.job-spec.outputs.migrations == 'true' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,10 +166,9 @@ jobs:
 
           # Only check test jobs if they were supposed to run
           if [[ "${{ needs.job-spec.outputs.backend }}" == "true" ]]; then
-            [[ "${{ needs.check-backend.result }}"       != 'success' ]] && { RET_CODE=1; echo "Backend checks failed"; }
+            [[ "${{ needs.check-backend.result }}"      != 'success' ]] && { RET_CODE=1; echo "Backend checks failed"; }
+            [[ "${{ needs.test-backend.result }}"       != 'success' ]] && { RET_CODE=1; echo "Backend tests failed"; }
           fi
-
-          [[ "${{ needs.test-backend.result }}"       != 'success' ]] && { RET_CODE=1; echo "Backend tests failed"; }
 
           if [[ "${{ needs.job-spec.outputs.frontend }}" == "true" ]]; then
             [[ "${{ needs.check-frontend.result }}"      != 'success' ]] && { RET_CODE=1; echo "Frontend tests failed"; }

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   run-tests:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/ci.yaml
     secrets: inherit
 
   deploy:


### PR DESCRIPTION
This PR ensures squawk lints do not occur on main and corrects an incorrect path.