### PR TITLE
Add simple user login and logout to navbar

### DIFF
--- a/frontend/src/Components/Navbar.purs
+++ b/frontend/src/Components/Navbar.purs
@@ -9,59 +9,86 @@ module FPO.Components.Navbar where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
+import Effect.Aff.Class (class MonadAff)
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
+import FPO.Data.Store (User)
+import FPO.Data.Store as Store
+import Halogen (ClassName(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties (classes) as HP
 import Halogen.HTML.Properties (style)
-import Halogen.Themes.Bootstrap5
-  ( bgBodyTertiary
-  , btn
-  , btnLink
-  , containerFluid
-  , meAuto
-  , navItem
-  , navLink
-  , navbar
-  , navbarBrand
-  , navbarCollapse
-  , navbarExpandSm
-  , navbarNav
-  ) as HB
+import Halogen.Store.Connect (Connected, connect)
+import Halogen.Store.Monad (class MonadStore, updateStore)
+import Halogen.Store.Select (selectEq)
+import Halogen.Themes.Bootstrap5 (bgBodyTertiary, btn, btnLink, containerFluid, dropdown, dropdownItem, dropdownMenu, dropdownToggle, meAuto, msAuto, navItem, navLink, navbar, navbarBrand, navbarCollapse, navbarExpandSm, navbarNav) as HB
 
-data Action = Navigate Route
+type State = { user :: Maybe User, dropdownOpen :: Boolean }
 
-navbar :: forall query input output m. Navigate m => H.Component query input output m
-navbar = H.mkComponent
-  { initialState: \_ -> unit
+data Action
+  = Navigate Route
+  | Receive (Connected Store.Store Unit) -- Receive store updates
+  | ToggleDropdown
+  | Logout
+
+-- | The navbar component that renders the navigation bar.
+-- |
+-- | It subscribes to store changes to update the user information.
+navbar
+  :: forall query output m
+   . MonadAff m
+  => MonadStore Store.Action Store.Store m
+  => Navigate m
+  => H.Component query Unit output m
+navbar = connect (selectEq identity) $ H.mkComponent
+  { initialState: \{ context: store } -> { user: store.user, dropdownOpen: false }
   , render
   , eval: H.mkEval H.defaultEval
       { handleAction = handleAction
+      , receive = Just <<< Receive
       }
   }
   where
-  render :: Unit -> H.ComponentHTML Action () m
-  render _ = HH.nav [ HP.classes [ HB.navbar, HB.navbarExpandSm, HB.bgBodyTertiary ] ]
+  render :: State -> H.ComponentHTML Action () m
+  render state = HH.nav [ HP.classes [ HB.navbar, HB.navbarExpandSm, HB.bgBodyTertiary ] ]
     [ HH.div [ HP.classes [ HB.containerFluid ] ]
         [ HH.a [ HP.classes [ HB.navbarBrand ], HE.onClick (const $ Navigate Home), style "cursor: pointer" ] [ HH.text "FPO-Editor" ]
         , HH.div [ HP.classes [ HB.navbarCollapse ] ]
             [ HH.ul [ HP.classes [ HB.navbarNav, HB.meAuto ] ]
                 [ HH.li [ HP.classes [ HB.navItem ] ]
                     [ navButton "Home" Home ]
-                , HH.li [ HP.classes [ HB.navItem ] ]
-                    [ navButton "Login" Login ]
+                ]
+            -- Right side of the navbar
+            , HH.ul [ HP.classes [ HB.navbarNav, HB.msAuto ] ]
+                [ HH.li [ HP.classes [ HB.navItem ] ]
+                    [ case state.user of
+                        Nothing -> navButton "Login" Login
+                        Just user -> userDropdown user.userName state.dropdownOpen
+                    ]
                 ]
             ]
         ]
     ]
 
-  -- Handles the navigation action
-  handleAction :: forall s. Action -> H.HalogenM Unit Action s output m Unit
+  handleAction
+    :: forall slots
+     . Action
+    -> H.HalogenM State Action slots output m Unit
   handleAction (Navigate route) = do
     navigate route
-    pure unit
+  handleAction (Receive { context: store }) = do
+    H.modify_ _ { user = store.user }
+  handleAction ToggleDropdown = do
+    H.modify_ \s -> s { dropdownOpen = not s.dropdownOpen }
+  handleAction Logout = do
+    H.modify_ _ { dropdownOpen = false }
+    -- TODO: Perform logout logic, e.g., clear user session, redirect to login.
+    -- Notice how we do not have to change this component's user state here, because
+    -- updating the store will trigger a re-evaluation of the navbar component.
+    updateStore (Store.SetUser Nothing)
 
   -- Creates a navigation button
   navButton :: String -> Route -> H.ComponentHTML Action () m
@@ -71,3 +98,29 @@ navbar = H.mkComponent
       , HE.onClick (const $ Navigate route)
       ]
       [ HH.text label ]
+
+  -- Creates a user dropdown with user icon and logout option
+  userDropdown :: String -> Boolean -> H.ComponentHTML Action () m
+  userDropdown username dropdownOpen =
+    HH.div [ HP.classes [ HB.dropdown ] ]
+      [ HH.button
+          [ HP.classes [ HB.btn, HB.btnLink, HB.navLink, HB.dropdownToggle ]
+          , HE.onClick (const ToggleDropdown)
+          ]
+          [ HH.i [ HP.classes [ ClassName "bi", ClassName "bi-person" ] ] []
+          , HH.text username
+          ]
+      , HH.ul
+          [ HP.classes [ HB.dropdownMenu ]
+          , style $ if dropdownOpen then "display: block;" else "display: none;"
+          ]
+          [ HH.li_
+              [ HH.span
+                  [ HP.classes [ HB.dropdownItem ]
+                  , style "cursor: default;"
+                  , HE.onClick (const Logout)
+                  ]
+                  [ HH.text "Logout" ]
+              ]
+          ]
+      ]

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -4,16 +4,25 @@
 
 module FPO.Data.Store where
 
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
+
+type User = { userName :: String }
 
 -- | The Store type represents the global state of the application.
 type Store =
-  { userMail :: Maybe String -- ^ The user's email (example state variable)
+  { inputMail :: String -- ^ The email that was input in the login form
+  --   (example state variable)
+  , user :: Maybe User -- ^ The user's name
   }
 
-data Action = SetUserMail String -- ^ Action to set the user's email
+data Action
+  = SetMail String -- ^ Action to set the user's email.
+  | SetUser (Maybe User) -- ^ Action to set the user's name.
+
+--   Nothing means no user is logged in.
 
 -- | Update the store based on the action.
 reduce :: Store -> Action -> Store
 reduce store = case _ of
-  SetUserMail mail -> store { userMail = Just mail }
+  SetMail m -> store { inputMail = m }
+  SetUser u -> store { user = u }

--- a/frontend/src/Main.purs
+++ b/frontend/src/Main.purs
@@ -102,7 +102,7 @@ component =
 main :: Effect Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
-  let initialStore = { userMail: Nothing } :: Store.Store
+  let initialStore = { inputMail: "", user: Nothing } :: Store.Store
   rootComponent <- runAppM initialStore component
   halogenIO <- runUI rootComponent unit body
 

--- a/frontend/src/Page/Login.purs
+++ b/frontend/src/Page/Login.purs
@@ -10,7 +10,7 @@ module FPO.Page.Login (component) where
 
 import Prelude
 
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..))
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
@@ -80,17 +80,18 @@ component =
       -- When opening the login tab, we simply take the user's email 
       -- address from the store, provided that it exists (was 
       -- previously set).
-      mail <- fromMaybe "" <<< _.userMail <$> getStore
+      mail <- _.inputMail <$> getStore
       H.modify_ \state -> state { email = mail }
     UpdateEmail email -> do
       H.modify_ \state -> state { email = email, error = Nothing }
       -- In this example, we are simply storing the user's email in our
       -- store, every time the user clicks on the button (either login or
       -- register).
-      updateStore $ Store.SetUserMail email
+      updateStore $ Store.SetMail email
     UpdatePassword password -> do
       H.modify_ \state -> state { password = password, error = Nothing }
     EmitError error -> do
+      updateStore $ Store.SetUser $ Just { userName: "local invalid User" }
       H.modify_ \state -> state { error = Just error }
     NavigateToPasswordReset -> do
       navigate PasswordReset

--- a/frontend/src/Page/ResetPassword.purs
+++ b/frontend/src/Page/ResetPassword.purs
@@ -8,7 +8,7 @@ module FPO.Page.ResetPassword (component) where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..))
 import Data.String (null)
 import Data.String.Regex (regex, test)
 import Data.String.Regex.Flags (noFlags)
@@ -84,13 +84,13 @@ component =
   handleAction :: MonadAff m => Action -> H.HalogenM State Action () output m Unit
   handleAction = case _ of
     Initialize -> do
-      mail <- fromMaybe "" <<< _.userMail <$> getStore
+      mail <- _.inputMail <$> getStore
       H.modify_ \state -> state { email = mail }
     UpdateCode code -> do
       H.modify_ \state -> state { code = code, error = Nothing }
     UpdateEmail email -> do
       H.modify_ \state -> state { email = email, error = Nothing }
-      updateStore $ Store.SetUserMail email
+      updateStore $ Store.SetMail email
     UpdatePasswordPrimary password -> do
       H.modify_ \state -> state { passwordPrimary = password, error = Nothing }
     UpdatePasswordSecondary password -> do
@@ -113,7 +113,7 @@ component =
       H.modify_ \state -> state { error = Just error }
 
       when (not $ null mail) do
-        updateStore $ Store.SetUserMail mail
+        updateStore $ Store.SetMail mail
 
 renderResetForm :: forall w. State -> HH.HTML w Action
 renderResetForm state =


### PR DESCRIPTION
See #62. The navbar state subscribes to store changes using `Halogen.Store.Connect` (`connect`).