### PR TITLE
Add privilege handling and placeholder admin panel.

### DIFF
--- a/frontend/src/Components/Navbar.purs
+++ b/frontend/src/Components/Navbar.purs
@@ -15,6 +15,7 @@ import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store (User)
 import FPO.Data.Store as Store
+import FPO.Page.HTML (addClass)
 import Halogen (AttrName(..), ClassName(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -70,7 +71,7 @@ navbar = connect (selectEq identity) $ H.mkComponent
                 [ HH.li [ HP.classes [ HB.navItem ] ]
                     [ case state.user of
                         Nothing -> navButton "Login" Login
-                        Just user -> userDropdown user.userName
+                        Just user -> userDropdown user
                     ]
                 ]
             ]
@@ -86,10 +87,12 @@ navbar = connect (selectEq identity) $ H.mkComponent
   handleAction (Receive { context: store }) = do
     H.modify_ _ { user = store.user }
   handleAction Logout = do
-    -- TODO: Perform logout logic, e.g., clear user session, redirect to login.
+    -- TODO: Perform logout logic, e.g., clear user session, etc.
     -- Notice how we do not have to change this component's user state here, because
     -- updating the store will trigger a re-evaluation of the navbar component.
     updateStore (Store.SetUser Nothing)
+    -- We simply navigate to the Login page indiscriminately
+    navigate Login
 
   -- Creates a navigation button
   navButton :: String -> Route -> H.ComponentHTML Action () m
@@ -101,8 +104,8 @@ navbar = connect (selectEq identity) $ H.mkComponent
       [ HH.text label ]
 
   -- Creates a user dropdown with user icon and logout option
-  userDropdown :: String -> H.ComponentHTML Action () m
-  userDropdown username =
+  userDropdown :: User -> H.ComponentHTML Action () m
+  userDropdown user =
     HH.li
       [ HP.classes [ HB.navItem, HB.dropdown ] ]
       [ HH.a
@@ -112,19 +115,32 @@ navbar = connect (selectEq identity) $ H.mkComponent
           , HP.attr (AttrName "aria-expanded") "false"
           ]
           [ HH.i [ HP.classes [ ClassName "bi-person", HB.me1 ] ] []
-          , HH.text username
+          , HH.text user.userName
           ]
       , HH.ul
-          [ HP.classes [ HB.dropdownMenu ]
+          [ HP.classes [ HB.dropdownMenu, HB.dropdownMenuEnd ]
           , HP.attr (AttrName "aria-labelledby") "navbarDarkDropdownMenuLink"
           ]
-          [ HH.li_
-              [ HH.span
-                  [ HP.classes [ HB.dropdownItem ]
-                  , HP.style "cursor: default;"
-                  , HE.onClick (const Logout)
-                  ]
-                  [ HH.text "Logout" ]
-              ]
+          ( [ dropdownEntry "Profil" "person" (Navigate Login) ] -- TODO: navigate to profile page
+
+              <> -- TODO: navigate to admin panel 
+                ( if user.isAdmin then [ dropdownEntry "Adminpanel" "exclamation-octagon" (Navigate Login) `addClass` HB.bgWarningSubtle ]
+                  else []
+                )
+              <> [ dropdownEntry "Logout" "box-arrow-right" Logout ]
+          )
+      ]
+
+  -- Creates a dropdown entry with a label, bootstrap icon, and action. 
+  dropdownEntry :: String -> String -> Action -> H.ComponentHTML Action () m
+  dropdownEntry label icon action =
+    HH.li_
+      [ HH.span
+          [ HP.classes [ HB.dropdownItem, HB.dFlex, HB.alignItemsCenter ]
+          , HP.style "cursor: default;"
+          , HE.onClick (const action)
+          ]
+          [ HH.i [ HP.classes [ ClassName $ "bi-" <> icon, HB.flexShrink0, HB.me2 ] ] []
+          , HH.text label
           ]
       ]

--- a/frontend/src/Components/Navbar.purs
+++ b/frontend/src/Components/Navbar.purs
@@ -123,8 +123,8 @@ navbar = connect (selectEq identity) $ H.mkComponent
           ]
           ( [ dropdownEntry "Profil" "person" (Navigate Login) ] -- TODO: navigate to profile page
 
-              <> -- TODO: navigate to admin panel 
-                ( if user.isAdmin then [ dropdownEntry "Adminpanel" "exclamation-octagon" (Navigate Login) `addClass` HB.bgWarningSubtle ]
+              <>
+                ( if user.isAdmin then [ dropdownEntry "Adminpanel" "exclamation-octagon" (Navigate AdminPanel) `addClass` HB.bgWarningSubtle ]
                   else []
                 )
               <> [ dropdownEntry "Logout" "box-arrow-right" Logout ]

--- a/frontend/src/Data/Route.purs
+++ b/frontend/src/Data/Route.purs
@@ -14,6 +14,7 @@ data Route
   = Home
   | Login
   | PasswordReset
+  | AdminPanel
 
 derive instance genericRoute :: Generic Route _
 derive instance eqRoute :: Eq Route
@@ -25,6 +26,7 @@ routeCodec = root $ sum
   { "Home": noArgs
   , "Login": "login" / noArgs
   , "PasswordReset": "password-reset" / noArgs
+  , "AdminPanel": "admin-panel" / noArgs
   }
 
 -- | Converts a route to a string representation.
@@ -34,3 +36,4 @@ routeToString = case _ of
   Home -> "Home"
   Login -> "Login"
   PasswordReset -> "PasswordReset"
+  AdminPanel -> "AdminPanel"

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -6,7 +6,7 @@ module FPO.Data.Store where
 
 import Data.Maybe (Maybe)
 
-type User = { userName :: String }
+type User = { userName :: String, isAdmin :: Boolean }
 
 -- | The Store type represents the global state of the application.
 type Store =

--- a/frontend/src/Page/AdminPanel.purs
+++ b/frontend/src/Page/AdminPanel.purs
@@ -1,0 +1,69 @@
+-- | Simple admin panel page. Right now, this is just a placeholder.
+-- |
+-- | This page is only accessible to users with admin privileges.
+
+module FPO.Page.AdminPanel (component) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import FPO.Data.Store as Store
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Halogen.Store.Monad (class MonadStore)
+import Halogen.Themes.Bootstrap5 as HB
+
+data Action = Initialize
+
+type State =
+  { error :: Maybe String
+  }
+
+-- | Admin panel page component.
+component
+  :: forall query input output m
+   . MonadStore Store.Action Store.Store m
+  => H.Component query input output m
+component =
+  H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval H.defaultEval
+        { handleAction = handleAction
+        , initialize = Just Initialize
+        }
+    }
+  where
+  initialState :: input -> State
+  initialState _ =
+    { error: Nothing
+    }
+
+  render :: State -> H.ComponentHTML Action () m
+  render state =
+    HH.div
+      [ HP.classes [ HB.row, HB.justifyContentCenter, HB.my5 ] ]
+      [ renderAdminPanel state
+      , HH.div [ HP.classes [ HB.textCenter ] ]
+          [ case state.error of
+              Just err -> HH.div [ HP.classes [ HB.alert, HB.alertDanger ] ]
+                [ HH.text err ]
+              Nothing -> HH.text ""
+          ]
+      ]
+
+  handleAction :: Action -> H.HalogenM State Action () output m Unit
+  handleAction = case _ of
+    Initialize -> do
+      pure unit
+
+renderAdminPanel :: forall w. State -> HH.HTML w Action
+renderAdminPanel _ =
+  HH.div [ HP.classes [ HB.row, HB.justifyContentCenter, HB.my3 ] ]
+    [ HH.div [ HP.classes [ HB.colLg4, HB.colMd6, HB.colSm8 ] ]
+        [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
+            [ HH.text "Adminpanel" ]
+        , HH.text "Hier müsste jetzt ein Adminpanel sein, aber das ist noch nicht implementiert."
+        ]
+    ]

--- a/frontend/src/Page/HTML.purs
+++ b/frontend/src/Page/HTML.purs
@@ -37,3 +37,11 @@ addColumn val str placeholder bi for act =
             ]
         ]
     ]
+
+-- | Wraps the given HTML in a div with the specified class.
+addClass
+  :: forall w i
+   . H.HTML w i
+  -> H.ClassName
+  -> H.HTML w i
+addClass html c = HH.div [ HP.classes [ c ] ] [ html ]

--- a/frontend/src/Page/Login.purs
+++ b/frontend/src/Page/Login.purs
@@ -11,6 +11,7 @@ module FPO.Page.Login (component) where
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Data.String.CodeUnits (takeWhile)
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
@@ -91,7 +92,14 @@ component =
     UpdatePassword password -> do
       H.modify_ \state -> state { password = password, error = Nothing }
     EmitError error -> do
-      updateStore $ Store.SetUser $ Just { userName: "local invalid User" }
+      -- TODO: For testing purposes, we "log in" a user where the name
+      --       is simply the local part of the email address.
+      --       Iff the user is "admin", we set the isAdmin flag to true.
+
+      email <- _.inputMail <$> getStore
+      let name = takeWhile (_ /= '@') email
+      updateStore $ Store.SetUser $ Just { userName: name, isAdmin: name == "admin" }
+
       H.modify_ \state -> state { error = Just error }
     NavigateToPasswordReset -> do
       navigate PasswordReset

--- a/frontend/src/Page/Page404.purs
+++ b/frontend/src/Page/Page404.purs
@@ -1,0 +1,52 @@
+-- | Simple admin panel page. Right now, this is just a placeholder.
+-- |
+-- | This page is only accessible to users with admin privileges.
+
+module FPO.Page.Page404 (component) where
+
+import Prelude
+
+import FPO.Data.Navigate (class Navigate, navigate)
+import FPO.Data.Route (Route(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Halogen.Themes.Bootstrap5 as HB
+
+data Action = GoHome -- ^ Navigate to the home page.
+
+-- | 404 page component.
+component
+  :: forall query input output m
+   . Navigate m
+  => H.Component query input output m
+component =
+  H.mkComponent
+    { initialState: const unit
+    , render
+    , eval: H.mkEval H.defaultEval
+        { handleAction = handleAction
+        }
+    }
+  where
+  render :: Unit -> H.ComponentHTML Action () m
+  render _ =
+    HH.div
+      [ HP.classes [ HB.row, HB.justifyContentCenter, HB.my5 ] ]
+      [ HH.div [ HP.classes [ HB.col, HB.textCenter ] ]
+          [ HH.h1 [] [ HH.text "404" ]
+          , HH.p [] [ HH.text "Diese Seite existiert nicht, wurde verschoben, oder erfordert Privilegien, die Sie nicht besitzen." ]
+          , HH.button
+              [ HP.classes [ HB.btn, HB.btnPrimary ]
+              , HE.onClick (const GoHome)
+              ]
+              [ HH.text "Startseite" ]
+          ]
+      ]
+
+  handleAction :: Action -> H.HalogenM Unit Action () output m Unit
+  handleAction = case _ of
+    GoHome -> do
+      navigate Home
+      pure unit


### PR DESCRIPTION
Implements a very simple placeholder admin panel and 404 page. 
Routing is now more reactive and updates the view on any
route change, even invalid ones. This allows for a more
consistent user experience. A dedicated 404 page has been
added to handle cases where the user navigates to a non-existent route.
Also, the the routing logic now contains privileged routes
that are only accessible to users with admin status.

See #62.