### PR TITLE
Update nginx config to support SPA routing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*Dockerfile,*.sql,*.hs}]
+[{*Dockerfile,*.sql,*.hs,*.conf}]
 indent_size = 4

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -4,7 +4,16 @@ server {
 
     location / {
         root /home;
-        index index.html;
+        index this-file-does-not-exist.html;
+
+        try_files $uri @index;
+    }
+
+    location @index {
+        root /home;
+        add_header Cache-Control no-cache;
+        expires 0;
+        try_files /index.html =404;
     }
 
     location /dev/ {


### PR DESCRIPTION
This pr updates the nginx config to serve `index.html` for all routes in order to support SPA routing.