### PR TITLE
backend/lang: Move format from Ltml to Lsd

### DIFF
--- a/backend/src/Language/Lsd/AST/Document.hs
+++ b/backend/src/Language/Lsd/AST/Document.hs
@@ -1,0 +1,6 @@
+module Language.Lsd.AST.Document
+    ( DocumentFormat
+    )
+where
+
+data DocumentFormat = DocumentFormat

--- a/backend/src/Language/Lsd/AST/Format.hs
+++ b/backend/src/Language/Lsd/AST/Format.hs
@@ -1,4 +1,4 @@
-module Language.Ltml.AST.Format (HeadingFormat, IdentifierFormat) where
+module Language.Lsd.AST.Format (HeadingFormat, IdentifierFormat) where
 
 newtype FormatString a = FormatString [FormatAtom a]
 

--- a/backend/src/Language/Lsd/AST/Paragraph.hs
+++ b/backend/src/Language/Lsd/AST/Paragraph.hs
@@ -1,0 +1,10 @@
+module Language.Lsd.AST.Paragraph
+    ( ParagraphFormat
+    )
+where
+
+import Language.Lsd.AST.Format (IdentifierFormat)
+
+newtype ParagraphFormat
+    = ParagraphFormat
+        IdentifierFormat

--- a/backend/src/Language/Lsd/AST/Section.hs
+++ b/backend/src/Language/Lsd/AST/Section.hs
@@ -1,0 +1,11 @@
+module Language.Lsd.AST.Section
+    ( SectionFormat
+    )
+where
+
+import Language.Lsd.AST.Format (HeadingFormat, IdentifierFormat)
+
+data SectionFormat
+    = SectionFormat
+        IdentifierFormat
+        HeadingFormat

--- a/backend/src/Language/Ltml/AST/Document.hs
+++ b/backend/src/Language/Ltml/AST/Document.hs
@@ -1,5 +1,6 @@
 module Language.Ltml.AST.Document (Document) where
 
+import Language.Lsd.AST.Document (DocumentFormat)
 import Language.Ltml.AST.Node (Node)
 import Language.Ltml.AST.Section (Section)
 
@@ -8,8 +9,6 @@ data Document
         DocumentFormat
         DocumentHeader
         DocumentBody
-
-data DocumentFormat = DocumentFormat
 
 data DocumentHeader = DocumentHeader
 

--- a/backend/src/Language/Ltml/AST/Paragraph.hs
+++ b/backend/src/Language/Ltml/AST/Paragraph.hs
@@ -6,7 +6,7 @@ import Control.Applicative ((<|>))
 import qualified Data.Char as Char (isAlpha)
 import Data.Text (Text)
 import Data.Text.FromWhitespace (FromWhitespace, fromWhitespace)
-import Language.Ltml.AST.Format (IdentifierFormat)
+import Language.Lsd.AST.Paragraph (ParagraphFormat)
 import Language.Ltml.AST.Label (Label)
 import Language.Ltml.Parser (Parser)
 import Language.Ltml.Parser.MiTree (hangingBlock', miForest)
@@ -17,10 +17,6 @@ data Paragraph
     = Paragraph
         ParagraphFormat
         [RichTextTree]
-
-newtype ParagraphFormat
-    = ParagraphFormat
-        IdentifierFormat
 
 data RichTextTree
     = TextLeaf Text

--- a/backend/src/Language/Ltml/AST/Section.hs
+++ b/backend/src/Language/Ltml/AST/Section.hs
@@ -1,8 +1,8 @@
 module Language.Ltml.AST.Section (Section) where
 
 import Data.Text (Text)
+import Language.Lsd.AST.Section (SectionFormat)
 import Language.Ltml.AST.Block (Block)
-import Language.Ltml.AST.Format (HeadingFormat, IdentifierFormat)
 import Language.Ltml.AST.Node (Node)
 
 -- sectionKind = Section
@@ -12,11 +12,6 @@ data Section
         SectionFormat
         Heading
         [Node SectionChild]
-
-data SectionFormat
-    = SectionFormat
-        IdentifierFormat
-        HeadingFormat
 
 -- TODO: Use PlainText (yet to be defined).
 newtype Heading = Heading Text


### PR DESCRIPTION
The LSD defines the format, which is used by the LTML parser.