### PR TITLE
backend: Fix cabal export list

### DIFF
--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -22,9 +22,9 @@ library
       Control.Applicative.Utils
       Data.Text.FromWhitespace
       Database
+      Language.Lsd.AST.Format
       Language.Ltml.AST.Block
       Language.Ltml.AST.Document
-      Language.Ltml.AST.Format
       Language.Ltml.AST.Label
       Language.Ltml.AST.Node
       Language.Ltml.AST.Paragraph


### PR DESCRIPTION
A module was previously renamed, without fixing the cabal export list.