### PR TITLE
Handle internationalization

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -25,6 +25,7 @@
             "integers",
             "maybe",
             "prelude",
+            "record-extra",
             "routing",
             "routing-duplex",
             "safe-coerce",
@@ -36,6 +37,7 @@
             "web-events",
             "web-file",
             "web-html",
+            "web-storage",
             "web-uievents"
           ],
           "build_plan": [

--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -28,6 +28,7 @@
             "routing",
             "routing-duplex",
             "safe-coerce",
+            "simple-i18n",
             "strings",
             "tailrec",
             "unsafe-coerce",
@@ -104,11 +105,13 @@
             "quickcheck",
             "random",
             "record",
+            "record-extra",
             "refs",
             "routing",
             "routing-duplex",
             "safe-coerce",
             "semirings",
+            "simple-i18n",
             "st",
             "strings",
             "tailrec",
@@ -1588,6 +1591,20 @@
         "unsafe-coerce"
       ]
     },
+    "record-extra": {
+      "type": "registry",
+      "version": "5.0.1",
+      "integrity": "sha256-7vnREK2fpGJ7exswSeA9UpZFuU+UXRt3SA7AFUldT/Y=",
+      "dependencies": [
+        "arrays",
+        "functions",
+        "lists",
+        "prelude",
+        "record",
+        "tuples",
+        "typelevel-prelude"
+      ]
+    },
     "refs": {
       "type": "registry",
       "version": "6.0.0",
@@ -1662,6 +1679,20 @@
         "lists",
         "newtype",
         "prelude"
+      ]
+    },
+    "simple-i18n": {
+      "type": "registry",
+      "version": "2.0.1",
+      "integrity": "sha256-UKhN4RzNA4VxqtGHohyIGaFryaAsHFbfzokSbBs+mqI=",
+      "dependencies": [
+        "foreign-object",
+        "maybe",
+        "prelude",
+        "record",
+        "record-extra",
+        "typelevel-prelude",
+        "unsafe-coerce"
       ]
     },
     "st": {

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -21,6 +21,7 @@ package:
     - integers
     - maybe
     - prelude
+    - record-extra
     - routing
     - routing-duplex
     - safe-coerce
@@ -32,6 +33,7 @@ package:
     - web-events
     - web-file
     - web-html
+    - web-storage
     - web-uievents
   test:
     main: Test.Main

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -24,6 +24,7 @@ package:
     - routing
     - routing-duplex
     - safe-coerce
+    - simple-i18n
     - strings
     - tailrec
     - unsafe-coerce

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -6,6 +6,8 @@ module FPO.Data.Store where
 
 import Data.Maybe (Maybe)
 import FPO.Data.Route (Route)
+import Translations.Labels (Labels)
+import Translations.Translator (EqTranslator)
 
 type User = { userName :: String, isAdmin :: Boolean }
 
@@ -14,6 +16,7 @@ type Store =
   { inputMail :: String -- ^ The email that was input in the login form (example state variable)
   , user :: Maybe User -- ^ The user's name
   , loginRedirect :: Maybe Route -- ^ The route to redirect to after login
+  , translator :: EqTranslator
   }
 
 data Action

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -4,10 +4,15 @@
 
 module FPO.Data.Store where
 
+import Prelude
+
 import Data.Maybe (Maybe)
+import Effect (Effect)
 import FPO.Data.Route (Route)
-import Translations.Labels (Labels)
 import Translations.Translator (EqTranslator)
+import Web.HTML (window)
+import Web.HTML.Window (localStorage)
+import Web.Storage.Storage (getItem, setItem) as LocalStorage
 
 type User = { userName :: String, isAdmin :: Boolean }
 
@@ -17,12 +22,14 @@ type Store =
   , user :: Maybe User -- ^ The user's name
   , loginRedirect :: Maybe Route -- ^ The route to redirect to after login
   , translator :: EqTranslator
+  , language :: String
   }
 
 data Action
   = SetMail String -- ^ Action to set the user's email.
   | SetUser (Maybe User) -- ^ Action to set the user's name.
   | SetLoginRedirect (Maybe Route) -- ^ Action to set the redirect route after login.
+  | SetLanguage String
 
 -- | Update the store based on the action.
 reduce :: Store -> Action -> Store
@@ -40,3 +47,16 @@ reduce store = case _ of
   --       when navigating to a different page (in general) and care must be taken regarding
   --       (re)setting the redirect route.
   SetLoginRedirect r -> store { loginRedirect = r }
+  SetLanguage s -> store { language = s }
+
+saveLanguage :: String -> Effect Unit
+saveLanguage lang = do
+  win <- window
+  storage <- localStorage win
+  LocalStorage.setItem "userLanguage" lang storage
+
+loadLanguage :: Effect (Maybe String)
+loadLanguage = do
+  win <- window
+  storage <- localStorage win
+  LocalStorage.getItem "userLanguage" storage

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -30,6 +30,7 @@ data Action
   | SetUser (Maybe User) -- ^ Action to set the user's name.
   | SetLoginRedirect (Maybe Route) -- ^ Action to set the redirect route after login.
   | SetLanguage String
+  | SetTranslator EqTranslator
 
 -- | Update the store based on the action.
 reduce :: Store -> Action -> Store
@@ -48,6 +49,7 @@ reduce store = case _ of
   --       (re)setting the redirect route.
   SetLoginRedirect r -> store { loginRedirect = r }
   SetLanguage s -> store { language = s }
+  SetTranslator t -> store { translator = t }
 
 saveLanguage :: String -> Effect Unit
 saveLanguage lang = do

--- a/frontend/src/Main.purs
+++ b/frontend/src/Main.purs
@@ -57,6 +57,7 @@ import Prelude
   )
 import Routing.Duplex as RD
 import Routing.Hash (getHash, matchesWith)
+import Translations.Translator (translator)
 import Type.Proxy (Proxy(..))
 
 --------------------------------------------------------------------------------
@@ -162,6 +163,7 @@ main = HA.runHalogenAff do
       { inputMail: ""
       , user: user
       , loginRedirect: Nothing
+      , translator: translator
       } :: Store.Store
   rootComponent <- runAppM initialStore component
   halogenIO <- runUI rootComponent unit body
@@ -179,3 +181,4 @@ handleInitialResponse = case _ of
   Right { status, body } -> case status of
     StatusCode 200 -> Just { userName: body, isAdmin: false }
     _ -> Nothing
+

--- a/frontend/src/Page/Login.purs
+++ b/frontend/src/Page/Login.purs
@@ -101,8 +101,12 @@ component =
       -- When opening the login tab, we simply take the user's email
       -- address from the store, provided that it exists (was
       -- previously set).
-      mail <- _.inputMail <$> getStore
-      H.modify_ \state -> state { email = mail }
+      store <- getStore
+      let translatorFromStore = fromEqTranslator store.translator
+      H.modify_ \state -> state
+        { email = store.inputMail
+        , translator = translatorFromStore
+        }
     UpdateEmail email -> do
       H.modify_ \state -> state { email = email, error = Nothing }
       -- In this example, we are simply storing the user's email in our

--- a/frontend/src/Page/Login.purs
+++ b/frontend/src/Page/Login.purs
@@ -21,7 +21,6 @@ import Effect.Aff.Class (class MonadAff)
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request (postString) as Request
 import FPO.Data.Route (Route(..))
-import FPO.Data.Store (Store)
 import FPO.Data.Store as Store
 import FPO.Page.HTML (addColumn)
 import Halogen as H

--- a/frontend/src/Page/Login.purs
+++ b/frontend/src/Page/Login.purs
@@ -29,6 +29,10 @@ import Halogen.HTML.Events (onClick, onSubmit) as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Store.Monad (class MonadStore, getStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
+import Simple.I18n.Translator (Translator, translate)
+import Translations.Labels (Labels)
+import Translations.Translator (fromEqTranslator, translator)
+import Type.Proxy (Proxy(Proxy))
 import Web.Event.Event (preventDefault)
 import Web.Event.Internal.Types (Event)
 
@@ -47,6 +51,7 @@ type State =
   { email :: String
   , password :: String
   , error :: Maybe String
+  , translator :: Translator Labels
   }
 
 -- | Login component.
@@ -74,6 +79,7 @@ component =
     { email: ""
     , password: ""
     , error: Nothing
+    , translator: fromEqTranslator translator
     }
 
   render :: State -> H.ComponentHTML Action () m
@@ -158,8 +164,8 @@ component =
                   UpdateEmail
               , addColumn
                   state.password
-                  "Password:"
-                  "Password"
+                  ((translate (Proxy :: _ "password") state.translator) <> ":")
+                  (translate (Proxy :: _ "password") state.translator)
                   "bi-lock-fill"
                   HP.InputPassword
                   UpdatePassword

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -1,15 +1,17 @@
 module Translations.Labels where
 
-import Prelude
-
 import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord)
 
--- Symbols should be in alphabetic order.
+-- Symbols MUST be in alphabetic order.
 type Labels =
   ( "home"
+      ::: "loginSuccessful"
       ::: "password"
       ::: "profile"
+      ::: "role"
+      ::: "userData"
+      ::: "userName"
       ::: SNil
   )
 
@@ -18,6 +20,10 @@ en = fromRecord
   { password: "Password"
   , home: "Home"
   , profile: "Profile"
+  , userData: "User data"
+  , userName: "User name"
+  , role: "Role"
+  , loginSuccessful: "Login successful"
   }
 
 de :: Translation Labels
@@ -25,4 +31,8 @@ de = fromRecord
   { password: "Passwort"
   , home: "Start"
   , profile: "Profil"
+  , userData: "Benutzerdaten"
+  , userName: "Benutzername"
+  , role: "Rolle"
+  , loginSuccessful: "Login erfolgreich"
   }

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -1,0 +1,28 @@
+module Translations.Labels where
+
+import Prelude
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+-- Symbols should be in alphabetic order.
+type Labels =
+  ( "home"
+      ::: "password"
+      ::: "profile"
+      ::: SNil
+  )
+
+en :: Translation Labels
+en = fromRecord
+  { password: "Password"
+  , home: "Home"
+  , profile: "Profile"
+  }
+
+de :: Translation Labels
+de = fromRecord
+  { password: "Passwort"
+  , home: "Start"
+  , profile: "Profil"
+  }

--- a/frontend/src/Translations/Translator.purs
+++ b/frontend/src/Translations/Translator.purs
@@ -2,15 +2,18 @@ module Translations.Translator where
 
 import Prelude
 
-import Halogen.Store.Monad (getStore)
-import Simple.I18n.Translator (Translator, createTranslator, translate)
+import Effect (Effect)
+import Simple.I18n.Translator (Translator, createTranslator)
 import Translations.Labels (Labels, de, en)
 import Type.Proxy (Proxy(Proxy))
+import Web.HTML (window)
+import Web.HTML.Navigator (language)
+import Web.HTML.Window (navigator)
 
 translator :: EqTranslator
 translator =
   EqTranslator $ createTranslator
-    (Proxy :: _ "de") -- Fallback language (and default language)
+    (Proxy :: _ "en") -- Fallback language (and default language)
     { en, de } -- Translations
 
 newtype EqTranslator = EqTranslator (Translator Labels)
@@ -19,4 +22,15 @@ instance eqEqTranslator :: Eq EqTranslator where
   eq _ _ = true
 
 fromEqTranslator :: EqTranslator -> Translator Labels
-fromEqTranslator (EqTranslator translator) = translator
+fromEqTranslator (EqTranslator trans) = trans
+
+detectBrowserLanguage :: Effect String
+detectBrowserLanguage = do
+  nav <- window >>= navigator
+  maybeLang <- language nav
+  pure $ maybeLang
+
+getTranslatorForLanguage :: String -> Translator Labels
+getTranslatorForLanguage lang = case lang of
+  "de-DE" -> createTranslator (Proxy :: _ "de") { en, de }
+  _ -> createTranslator (Proxy :: _ "en") { en, de }

--- a/frontend/src/Translations/Translator.purs
+++ b/frontend/src/Translations/Translator.purs
@@ -19,7 +19,7 @@ translator =
 newtype EqTranslator = EqTranslator (Translator Labels)
 
 instance eqEqTranslator :: Eq EqTranslator where
-  eq _ _ = true
+  eq _ _ = false
 
 fromEqTranslator :: EqTranslator -> Translator Labels
 fromEqTranslator (EqTranslator trans) = trans

--- a/frontend/src/Translations/Translator.purs
+++ b/frontend/src/Translations/Translator.purs
@@ -1,0 +1,22 @@
+module Translations.Translator where
+
+import Prelude
+
+import Halogen.Store.Monad (getStore)
+import Simple.I18n.Translator (Translator, createTranslator, translate)
+import Translations.Labels (Labels, de, en)
+import Type.Proxy (Proxy(Proxy))
+
+translator :: EqTranslator
+translator =
+  EqTranslator $ createTranslator
+    (Proxy :: _ "de") -- Fallback language (and default language)
+    { en, de } -- Translations
+
+newtype EqTranslator = EqTranslator (Translator Labels)
+
+instance eqEqTranslator :: Eq EqTranslator where
+  eq _ _ = true
+
+fromEqTranslator :: EqTranslator -> Translator Labels
+fromEqTranslator (EqTranslator translator) = translator

--- a/frontend/src/Translations/Util.purs
+++ b/frontend/src/Translations/Util.purs
@@ -1,0 +1,12 @@
+module Translations.Util where
+
+import FPO.Data.Store (Store) as Store
+import Halogen.Store.Select (Selector, selectEq)
+import Simple.I18n.Translator (Translator)
+import Translations.Labels (Labels)
+import Translations.Translator (EqTranslator)
+
+type FPOState r = { translator :: Translator Labels | r }
+
+selectTranslator :: Selector Store.Store EqTranslator
+selectTranslator = selectEq \store -> store.translator


### PR DESCRIPTION
In this PR there is a presented a way to handle german and english language in the application with a simple switch in the navbar. Maybe someone could make the code a bit more easier to use in a way that not every component needs its own translator handling or making the translation calls shorter. 

The profile page is completely implemented and in the login page you need to add a few strings, but for the beginning it should be okay. If it is accepted, we have to rewrite the application with this in mind and maybe split the label-file into more than one file for the sake of overviewness.