### PR TITLE
Translate navbar and admin panel

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -eu
 
 TEMPLATE=/etc/nginx/templates/ssl.conf.template

--- a/frontend/src/Components/Navbar.purs
+++ b/frontend/src/Components/Navbar.purs
@@ -97,7 +97,7 @@ navbar = connect (selectEq identity) $ H.mkComponent
                 , HH.li [ HP.classes [ HB.navItem ] ]
                     [ case state.user of
                         Nothing -> navButton "Login" Login
-                        Just user -> userDropdown user
+                        Just user -> userDropdown state user
                     ]
                 ]
             ]
@@ -146,8 +146,8 @@ navbar = connect (selectEq identity) $ H.mkComponent
       [ HH.text label ]
 
   -- Creates a user dropdown with user icon and logout option.
-  userDropdown :: User -> H.ComponentHTML Action () m
-  userDropdown user =
+  userDropdown :: State -> User -> H.ComponentHTML Action () m
+  userDropdown state user =
     HH.li
       [ HP.classes [ HB.navItem, HB.dropdown ] ]
       [ HH.a
@@ -168,7 +168,9 @@ navbar = connect (selectEq identity) $ H.mkComponent
             ]
               <>
                 ( if user.isAdmin then
-                    [ dropdownEntry "Admin Panel" "exclamation-octagon"
+                    [ dropdownEntry
+                        (translate (label :: _ "ap_adminPanel") state.translator)
+                        "exclamation-octagon"
                         (Navigate AdminPanel) `addClass` HB.bgWarningSubtle
                     ]
                   else []

--- a/frontend/src/Components/Navbar.purs
+++ b/frontend/src/Components/Navbar.purs
@@ -163,7 +163,9 @@ navbar = connect (selectEq identity) $ H.mkComponent
           [ HP.classes [ HB.dropdownMenu, HB.dropdownMenuEnd ]
           , HP.attr (AttrName "aria-labelledby") "navbarDarkDropdownMenuLink"
           ]
-          ( [ dropdownEntry "Profile" "person"
+          ( [ dropdownEntry
+                (translate (label :: _ "prof_profile") state.translator)
+                "person"
                 (Navigate (Profile { loginSuccessful: Nothing }))
             ]
               <>

--- a/frontend/src/Page/Page404.purs
+++ b/frontend/src/Page/Page404.purs
@@ -68,4 +68,5 @@ component =
     GoHome -> do
       navigate Home
       pure unit
-    Receive { context } -> H.modify_ _ { translator = fromFpoTranslator context }
+    Receive { context } -> do
+      H.modify_ _ { translator = fromFpoTranslator context }

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -1,6 +1,7 @@
 module FPO.Translations.Labels where
 
 import Data.Function (($))
+import FPO.Translations.AdminPanel (deAdminPanel, enAdminPanel)
 import FPO.Translations.Common (deCommon, enCommon)
 import FPO.Translations.Home (deHome, enHome)
 import FPO.Translations.Login (deLogin, enLogin)
@@ -14,20 +15,24 @@ import Translations.Page.Page404 (dePage404, enPage404)
 -- | Übersetzungen zusammenführen
 en :: Translation Labels
 en = fromRecord $
-  merge
-    (merge (toRecord enCommon) (toRecord enHome))
+  merge (toRecord enAdminPanel)
     ( merge
-        (merge (toRecord enLogin) (toRecord enPage404))
-        (merge (toRecord enPasswordReset) (toRecord enProfile))
+        (merge (toRecord enCommon) (toRecord enHome))
+        ( merge
+            (merge (toRecord enLogin) (toRecord enPage404))
+            (merge (toRecord enPasswordReset) (toRecord enProfile))
+        )
     )
 
 de :: Translation Labels
 de = fromRecord $
-  merge
-    (merge (toRecord deCommon) (toRecord deHome))
+  merge (toRecord deAdminPanel)
     ( merge
-        (merge (toRecord deLogin) (toRecord dePage404))
-        (merge (toRecord dePasswordReset) (toRecord deProfile))
+        (merge (toRecord deCommon) (toRecord deHome))
+        ( merge
+            (merge (toRecord deLogin) (toRecord dePage404))
+            (merge (toRecord dePasswordReset) (toRecord deProfile))
+        )
     )
 
 -- | All kinds of abstract labels representing UI texts,
@@ -37,8 +42,10 @@ de = fromRecord $
 -- | Because of this constraint, it's sensible to use
 -- | appropriate prefixes for strongly related labels.
 type Labels =
-  ( -- | Common Phrases
-    "common_email"
+  ( -- | Admin Panel
+    "ap_adminPanel"
+      -- | Common Phrases
+      ::: "common_email"
       ::: "common_emailAddress"
       ::: "common_home"
       ::: "common_password"

--- a/frontend/src/Translations/Page/AdminPanel.purs
+++ b/frontend/src/Translations/Page/AdminPanel.purs
@@ -1,0 +1,20 @@
+module FPO.Translations.AdminPanel where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type AdminPanelLabels =
+  ( "ap_adminPanel"
+      ::: SNil
+  )
+
+enAdminPanel :: Translation AdminPanelLabels
+enAdminPanel = fromRecord
+  { ap_adminPanel: "Admin Panel"
+  }
+
+deAdminPanel :: Translation AdminPanelLabels
+deAdminPanel = fromRecord
+  { ap_adminPanel: "Adminpanel"
+  }
+


### PR DESCRIPTION
This PR...

- adds translations to the admin panel (title) and navbar user dropdown entries (see #94)
- prevents the _password reset form_ from accidentally resetting the page when submitting reset requests
