### PR TITLE
Improve project list UI

### DIFF
--- a/frontend/src/Components/Table/Head.purs
+++ b/frontend/src/Components/Table/Head.purs
@@ -1,7 +1,16 @@
 -- | Generic table head component.
 --   Allows for sorting by clicking on the header.
 
-module FPO.Components.Table.Head where
+module FPO.Components.Table.Head
+  ( Order(..)
+  , Output(..)
+  , SortingStyle(..)
+  , Title
+  , component
+  , createTableColumns
+  , sortByF
+  , toggleSorting
+  ) where
 
 import Prelude
 
@@ -48,6 +57,12 @@ sortByF sorting f arr =
   case sorting of
     Asc -> sortBy f arr
     Desc -> sortBy (flip f) arr
+
+-- | Switches the sorting direction.
+toggleSorting :: Order -> Order
+toggleSorting sorting = case sorting of
+  Asc -> Desc
+  Desc -> Asc
 
 component :: forall query m. H.Component query Input Output m
 component =
@@ -144,12 +159,6 @@ component =
   getColumnStyle state column =
     if state.active == column.title then HB.bgSecondarySubtle
     else HB.bgBodySecondary
-
-  -- Switches the sorting direction.
-  toggleSorting :: Order -> Order
-  toggleSorting sorting = case sorting of
-    Asc -> Desc
-    Desc -> Asc
 
   -- Toggles the sorting state of a column.
   toggleColumnSorting :: Column -> Column


### PR DESCRIPTION
This PR...
- improves table sizing depending on window/browser width
- prevents the table from changing column size ratios / resizing on content change
- adds a table entry message if no projects are found (empty table)