### PR TITLE
ltml: Change reference syntax

### DIFF
--- a/backend/src/Language/Ltml/Parser/Text.hs
+++ b/backend/src/Language/Ltml/Parser/Text.hs
@@ -46,7 +46,7 @@ elementPF
 elementPF p =
     Special <$> specialP
         <|> textLeafP
-        <|> Reference <$ char '{' <*> labelP <* char '}'
+        <|> Reference <$ char '{' <* char ':' <*> labelP <* char '}'
         <|> Styled <$ char '<' <*> styleP <*> p <* char '>'
 
 childPF


### PR DESCRIPTION
From `{LABEL}` to `{:LABEL}`.

closes: #132