### PR TITLE
ltml: Add general labeling parser

### DIFF
--- a/backend/src/Language/Ltml/Parser/Label.hs
+++ b/backend/src/Language/Ltml/Parser/Label.hs
@@ -2,6 +2,7 @@
 
 module Language.Ltml.Parser.Label
     ( labelP
+    , labelingP
     )
 where
 
@@ -11,11 +12,15 @@ import qualified Data.Text as Text (unpack)
 import Language.Ltml.AST.Label (Label (..))
 import Language.Ltml.Parser (MonadParser)
 import Text.Megaparsec (satisfy, takeWhileP, (<?>))
+import Text.Megaparsec.Char (char)
 
 labelP :: (MonadParser m) => m Label
 labelP = Label <$> (headP <:> tailP) <?> "label"
   where
     isFirst = Char.isAsciiLower
-    isLater c = Char.isAsciiLower c || Char.isDigit c || c `elem` "_-:"
+    isLater c = Char.isAsciiLower c || Char.isDigit c || c `elem` "_-"
     headP = satisfy isFirst
     tailP = Text.unpack <$> takeWhileP (Just "label character") isLater
+
+labelingP :: (MonadParser m) => m Label
+labelingP = char '{' *> labelP <* char ':' <* char '}'

--- a/backend/src/Language/Ltml/Parser/Paragraph.hs
+++ b/backend/src/Language/Ltml/Parser/Paragraph.hs
@@ -3,13 +3,18 @@ module Language.Ltml.Parser.Paragraph
     )
 where
 
+import Control.Applicative (optional)
 import Language.Lsd.AST.Type.Paragraph (ParagraphType (..))
 import Language.Ltml.AST.Node (Node (..))
 import Language.Ltml.AST.Paragraph (Paragraph (..))
 import Language.Ltml.Parser (Parser)
+import Language.Ltml.Parser.Label (labelingP)
 import Language.Ltml.Parser.Text (textForestP)
+import Text.Megaparsec (try)
+import Text.Megaparsec.Char (char)
 
--- TODO: Parse node label.
+-- TODO: Avoid `try`.
 paragraphP :: ParagraphType -> Parser (Node Paragraph)
-paragraphP (ParagraphType fmt tt) =
-    Node Nothing . Paragraph fmt <$> textForestP tt
+paragraphP (ParagraphType fmt tt) = do
+    label <- optional $ try $ labelingP <* char '\n'
+    Node label . Paragraph fmt <$> textForestP tt

--- a/docs/language/ltml/document.md
+++ b/docs/language/ltml/document.md
@@ -4,6 +4,7 @@ An LTML document is composed of a [header](#header) and a [body](#body),
 where the former contains some metadata and the latter is a tree of *nodes*.
 The permitted header nodes, body nodes, and their composability are determined
 by an [LTML Schema Definition](../lsd.md).
+Body nodes can be [labeled](./general/label.md).
 
 Generally, only parts of an LTML document are represented as human-readable
 text; the nodes close to the root are generally only editable via a GUI.  This

--- a/docs/language/ltml/enumeration.md
+++ b/docs/language/ltml/enumeration.md
@@ -39,7 +39,7 @@ the text within an enumeration may contain an enumeration (as text children).
 ```
 Some sentence with
   # one enumeration item,
-  #{itm} a labeled item ({:itm}),
+  #{itm:} a labeled item ({:itm}),
   # another item,
     which spans
     multiple lines,

--- a/docs/language/ltml/general/label.md
+++ b/docs/language/ltml/general/label.md
@@ -1,10 +1,25 @@
 # Labels
 
-* TODO: Define label syntax (e.g., `[a-z]...`).
-* TODO: Once decided on a generic labeling syntax (`{LABEL:}`), document here.
-
 Body nodes may generally be labeled, in which case one may
 [reference](../text.md#references) them.
 
 Labeling is only possible if the respective node has an
 [output identifier](./identifier.md#output-identifiers).
+
+
+## Label syntax
+
+A label must start with a lower-case ASCII letter, and is otherwise composed
+of lower-case ASCII letters, ASCII digits, `_`, and `-`.
+
+
+## Labeling syntax
+
+A labeled node is written as `KEYWORD{LABEL:} CONTENT`, where
+
+* `KEYWORD` is empty if the respective node does not have a keyword, and
+* `CONTENT` is separated from the labeling by either a newline character (plus
+  indentation), or a non-empty sequence of ASCII spaces.
+
+Special rules apply for [paragraphs](../paragraph.md#labeling) and
+[sentences](../paragraph.md#sentences).

--- a/docs/language/ltml/paragraph.md
+++ b/docs/language/ltml/paragraph.md
@@ -50,10 +50,11 @@ Exceptions apply in the context of enumerations (TODO).
 Sentences are not full nodes; in particular, [styling](./text.md#styling) may
 overlap with sentences.
 
-However, sentences may be [labeled](./general/label.md)
-(and [referenced](./text.md#references)), by prefixing a sentence with
-`{LABEL:}` (followed by any number of ASCII spaces), where `LABEL` is the
-respective label.
+However, sentences may be [labeled](./general/label.md) at their beginning
+(and [referenced](./text.md#references)).
+[Paragraph labeling](#labeling) takes precedence over sentence labeling; to
+label a sentence at the start of a paragraph (and best always), write the
+labeling on the same line as the start of the sentence.
 
 Further, sentences introduce a context w.r.t.
 [identifiers](./general/identifier.md);

--- a/docs/language/ltml/section.md
+++ b/docs/language/ltml/section.md
@@ -20,29 +20,24 @@ Heading [text](./text.md) permits neither [styling](./text.md#styling) nor
 [enumerations](./enumeration.md).
 
 Further, heading text is [headed](./text.md#keyword-headed-text) by the
-section keyword (i.e., one level of indentation is implicitly
-added---noticeable with heading text that spans multiple lines).
-
-
-## Labeling
-
-A section may be labeled by appending `{LABEL}` to the keyword (without extra
-whitespace), for a label `LABEL`.
+(possibly [labeled](./general/label.md)) section keyword
+(i.e., one level of indentation is implicitly added---noticeable with heading
+text that spans multiple lines).
 
 
 ## Example
 
 ```
-={main} Main
+={main:} Main
 
-§{sectionA} Some section
+§{sectionA:} Some section
 
 This paragraph is in {:sectionA} in super-section {:main}.
 
 This is another paragraph in {:sectionA}.
 Paragraphs don't have keywords and are just separated by empty lines.
 
-§{sectionB} Another section, with a title
+§{sectionB:} Another section, with a title
   spanning
   several lines
     ^ Also, a footnote.


### PR DESCRIPTION
We removed `:` from the set of acceptable label characters.  This is to keep parsing simple, and maybe avoid confusing users.

Also,
 - update docs on label and labeling syntax
 - use labeling parser for paragraphs (addresses #135 w.r.t. paragraphs)