### PR TITLE
backend/ltml: Add sentence start parsing

### DIFF
--- a/backend/package.yaml
+++ b/backend/package.yaml
@@ -60,6 +60,8 @@ dependencies:
   - uuid
   - megaparsec
   - parser-combinators
+  - mtl
+  - transformers
   - pretty-simple
 
 ghc-options:

--- a/backend/src/Language/Ltml/Parser.hs
+++ b/backend/src/Language/Ltml/Parser.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Language.Ltml.Parser
     ( Parser
     , MonadParser
+    , ParserWrapper (wrapParser)
     , nli
     , nextIndentLevel
     , checkIndent
@@ -31,6 +33,12 @@ import qualified Text.Megaparsec.Char.Lexer as L (indentLevel)
 type Parser = Parsec Void Text
 
 type MonadParser m = (MonadParsec Void Text m, MonadFail m)
+
+class ParserWrapper m where
+    wrapParser :: Parser a -> m a
+
+instance ParserWrapper Parser where
+    wrapParser = id
 
 nextIndentLevel :: Pos -> Pos
 nextIndentLevel = (<> mkPos 2)

--- a/backend/src/Language/Ltml/Parser/MiTree.hs
+++ b/backend/src/Language/Ltml/Parser/MiTree.hs
@@ -54,7 +54,9 @@ nli' = fromWhitespace <$> nli
 --   newline or EOF.
 --   Typically, @p@ is enclosed in some kind of bracketing parsers.
 --   For leaf nodes, 'elementPF' may simply ignore @p@.
---   @'elementPF' p@ is further expected to not accept the empty input.
+--   @'elementPF' p@ is further expected to not accept the empty input, at
+--   least after sufficiently repeated application; i.e.
+--   @'Text.Megaparsec.many' ('elementPF' p)@ is expected to halt.
 --
 --   Unlike 'elementPF', 'childP' is expected to take care of indentation
 --   itself--except at the very beginning, where it may expect that any

--- a/backend/src/Language/Ltml/Parser/Paragraph.hs
+++ b/backend/src/Language/Ltml/Parser/Paragraph.hs
@@ -4,6 +4,7 @@ module Language.Ltml.Parser.Paragraph
 where
 
 import Control.Applicative (optional)
+import Control.Monad.State (evalStateT)
 import Language.Lsd.AST.Type.Paragraph (ParagraphType (..))
 import Language.Ltml.AST.Node (Node (..))
 import Language.Ltml.AST.Paragraph (Paragraph (..))
@@ -15,6 +16,6 @@ import Text.Megaparsec.Char (char)
 
 -- TODO: Avoid `try`.
 paragraphP :: ParagraphType -> Parser (Node Paragraph)
-paragraphP (ParagraphType fmt tt) = do
+paragraphP (ParagraphType fmt tt) = flip evalStateT True $ do
     label <- optional $ try $ labelingP <* char '\n'
     Node label . Paragraph fmt <$> textForestP tt

--- a/docs/language/ltml/paragraph.md
+++ b/docs/language/ltml/paragraph.md
@@ -44,7 +44,8 @@ Additionally, paragraph text extends text with [sentences](#sentences).
 ## Sentences
 
 Text within a paragraph is split into sentences,
-Sentences are generally terminated by a single period (`.`), each.
+Sentences are generally terminated by a single period (`.`), exclamation mark
+(`!`), or question mark (`?`), each.
 Exceptions apply in the context of enumerations (TODO).
 
 Sentences are not full nodes; in particular, [styling](./text.md#styling) may


### PR DESCRIPTION
There is still work to do; notably, we currently accept
* a sentence start token at the end of a paragraph, and
* a paragraph composed of nothing but a sentence start token.

Closes: #103
Closes: #152

Opens: #168
Opens: #169