### PR TITLE
backend/ltml: Add space token

### DIFF
--- a/backend/src/Language/Ltml/AST/Text.hs
+++ b/backend/src/Language/Ltml/AST/Text.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Ltml.AST.Text
@@ -19,6 +20,7 @@ import Language.Ltml.AST.Label (Label)
 
 data TextTree style enumItem special
     = TextLeaf Text
+    | Space
     | Special special
     | Reference Label
     | Styled style [TextTree style enumItem special]
@@ -26,9 +28,9 @@ data TextTree style enumItem special
     | Footnote [FootnoteTextTree]
     deriving (Show)
 
-instance FromWhitespace (TextTree a b c) where
-    fromWhitespace "" = TextLeaf ""
-    fromWhitespace _ = TextLeaf " "
+instance FromWhitespace [TextTree a b c] where
+    fromWhitespace "" = []
+    fromWhitespace _ = [Space]
 
 type PlainTextTree = TextTree Void Void Void
 


### PR DESCRIPTION
Previously, space was encoded as `TextLeaf " "`, and we also often parsed `TextLeaf ""`; instead, we now parse `[Space]` and `[]`, respectively.

This also better matches Pandoc's AST.