### PR TITLE
backend/ltml: Simplify word parsing

### DIFF
--- a/backend/src/Language/Ltml/AST/Text.hs
+++ b/backend/src/Language/Ltml/AST/Text.hs
@@ -19,7 +19,7 @@ import Data.Void (Void)
 import Language.Ltml.AST.Label (Label)
 
 data TextTree style enumItem special
-    = TextLeaf Text
+    = Word Text
     | Space
     | Special special
     | Reference Label

--- a/backend/src/Language/Ltml/Parser/Text.hs
+++ b/backend/src/Language/Ltml/Parser/Text.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Ltml.Parser.Text
@@ -15,6 +16,7 @@ import Control.Monad (void)
 import Control.Monad.State (StateT, get, put)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Char as Char (isControl)
+import Data.Proxy (Proxy (Proxy))
 import Data.Text (Text)
 import qualified Data.Text as Text (singleton)
 import Data.Void (Void)
@@ -69,12 +71,13 @@ textForestP
 textForestP t = miForest elementPF (childPF t)
 
 elementPF
-    :: (MonadParser m, StyleP style, SpecialP m special)
+    :: forall m style enumItem special
+     . (MonadParser m, StyleP style, SpecialP m special)
     => m [TextTree style enumItem special]
     -> m (TextTree style enumItem special)
 elementPF p =
     Special <$> specialP
-        <|> textLeafP
+        <|> Word <$> wordP (Proxy :: Proxy special)
         <|> Reference <$ char '{' <* char ':' <*> labelP <* char '}'
         <|> Styled <$ char '<' <*> styleP <*> p <* char '>'
 
@@ -135,15 +138,12 @@ instance EnumP EnumType EnumItem where
 
 class (ParserWrapper m) => SpecialP m special | special -> m where
     specialP :: m special
-    textLeafP :: m (TextTree a b special)
+    wordP :: Proxy special -> m Text
 
 instance SpecialP Parser Void where
     specialP = empty
 
-    textLeafP = TextLeaf <$> wordP
-      where
-        wordP :: Parser Text
-        wordP = gWordP isWordChar isWordSpecialChar
+    wordP _ = gWordP isWordChar isWordSpecialChar
 
 instance SpecialP ParagraphParser SentenceStart where
     specialP = do
@@ -182,7 +182,7 @@ instance SpecialP ParagraphParser SentenceStart where
                 isSpecialSuccChar '>' = True
                 isSpecialSuccChar _ = False
 
-    textLeafP = TextLeaf <$> (sentenceWordP <|> sentenceEndP)
+    wordP _ = sentenceWordP <|> sentenceEndP
       where
         sentenceWordP :: ParagraphParser Text
         sentenceWordP = gWordP isWordChar isSentenceSpecialChar


### PR DESCRIPTION
Previously, the ad-hoc-polymorphic textLeafP function returned a TextTree and was to always use the TextLeaf constructor.

What we actually would have always wanted was an ad-hoc-polymorphic function that returns a Text, but that is not possible because the type class we define it in depends on a type parameter of TextTree.

Instead, we now use Proxy.

Also, we renamed the TextLeaf constructor to Word, which is fitting now that whitespace is no longer encoded as a TextLeaf.