### PR TITLE
Backend VersionControl: Add Missing Doc Comments

### DIFF
--- a/backend/src/VersionControl/Document.hs
+++ b/backend/src/VersionControl/Document.hs
@@ -27,6 +27,7 @@ import GHC.Int (Int32)
 import UserManagement.Group (GroupID)
 import VersionControl.Commit (CommitID)
 
+-- | id type for documents
 newtype DocumentID = DocumentID
     { unDocumentID :: Int32
     }
@@ -41,6 +42,7 @@ instance FromJSON DocumentID where
 instance ToSchema DocumentID where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Int32)
 
+-- | represents a document
 data Document = Document
     { documentID :: DocumentID
     , documentName :: Text

--- a/backend/src/VersionControl/Error.hs
+++ b/backend/src/VersionControl/Error.hs
@@ -21,6 +21,8 @@ class ToVersionControlError a where
 instance ToVersionControlError DocumentError where
     toVersionControlError = DocumentError
 
+-- | flattens a nested either where the outer error is a 'VersionControlError'
+--   and the inner error is mappable to a 'VersionControlError'
 flattenVersionControlError
     :: (ToVersionControlError a)
     => Either VersionControlError (Either a b)

--- a/backend/src/VersionControl/Merge.hs
+++ b/backend/src/VersionControl/Merge.hs
@@ -9,17 +9,23 @@ import VersionControl.Commit (CommitHeader, CreateCommit, ExistingCommit)
 import VersionControl.Hash (Hashed)
 import VersionControl.Tree (NodeWithRef, TreeRef)
 
+-- TODO: implement merge :)
+
+-- | represents the result of a merge.
 data MergeResult
     = NoMerge ExistingCommit
     | AutoMerge CreateCommit
     | MergeConflict ConflictTree
 
+-- | a tree ref together with the commit it belongs to
 data TreeRefWithOrigin
     = TreeRefWithOrigin CommitHeader (TreeRef (Hashed NodeWithRef))
 
+-- | represents conflicts of a failed merge
 data ConflictTree
     = DivergentTrees [TreeRefWithOrigin]
     | ConvergentTree (TreeRef (Hashed NodeWithRef))
     | AutoMerged [CommitHeader] NodeWithRef [ConflictTreeEdge]
 
+-- | edge of a conflict tree
 data ConflictTreeEdge = ConflictTreeEdge Text ConflictTree

--- a/backend/src/VersionControl/Tree.hs
+++ b/backend/src/VersionControl/Tree.hs
@@ -308,6 +308,7 @@ data DataEdge = DataEdge
     , dataEdgeChildTitle :: Text
     }
 
+-- | obtains a list of relational-style edges from a tree.
 dataEdges :: Tree (Hashed NodeWithRef) -> [DataEdge]
 dataEdges (Tree (Hashed parentHash _) children) =
     zipWith fromEdge [1, 2 ..] children


### PR DESCRIPTION
This PR adds missing doc comments to the backends `VersionControl` module.