### PR TITLE
Implement ToParamSchema and FromHttpApiData for Version Control IDs

### DIFF
--- a/backend/src/VersionControl/Commit.hs
+++ b/backend/src/VersionControl/Commit.hs
@@ -23,8 +23,11 @@ import qualified Data.HashMap.Strict.InsOrd as InsOrd
 import Data.OpenApi
     ( NamedSchema (..)
     , OpenApiType (..)
+    , ToParamSchema (..)
     , ToSchema (..)
     , declareSchemaRef
+    , exclusiveMinimum
+    , minimum_
     , properties
     , required
     , type_
@@ -37,6 +40,7 @@ import GHC.Generics
 import GHC.Int
 import VersionControl.Hash
 import VersionControl.Tree
+import Web.HttpApiData (FromHttpApiData (..))
 
 -- | represents the id of a commit
 newtype CommitID = CommitID
@@ -52,6 +56,16 @@ instance FromJSON CommitID where
 
 instance ToSchema CommitID where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Int32)
+
+instance ToParamSchema CommitID where
+    toParamSchema _ =
+        mempty
+            & type_ ?~ OpenApiInteger
+            & minimum_ ?~ 0
+            & exclusiveMinimum ?~ False
+
+instance FromHttpApiData CommitID where
+    parseUrlPiece = (CommitID <$>) . parseUrlPiece
 
 -- | represents a reference to a commit or the commit itself
 type CommitRef = Ref CommitID ExistingCommit

--- a/backend/src/VersionControl/Hash.hs
+++ b/backend/src/VersionControl/Hash.hs
@@ -22,6 +22,7 @@ import qualified Data.HashMap.Strict.InsOrd as InsOrd
 import Data.OpenApi
     ( NamedSchema (..)
     , OpenApiType (..)
+    , ToParamSchema (..)
     , ToSchema (..)
     , declareSchemaRef
     , properties
@@ -32,6 +33,7 @@ import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text.Encoding as TE
 import GHC.Int
+import Web.HttpApiData (FromHttpApiData (..))
 
 -- | represents the hash of a value
 newtype Hash = Hash
@@ -50,6 +52,16 @@ instance FromJSON Hash where
 
 instance ToSchema Hash where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy String)
+
+instance ToParamSchema Hash where
+    toParamSchema _ =
+        mempty
+            & type_ ?~ OpenApiString
+
+instance FromHttpApiData Hash where
+    parseUrlPiece t = case decode (TE.encodeUtf8 t) of
+        Right bs -> Right (Hash bs)
+        Left _ -> Left "Invalid base16 encoding in Hash"
 
 -- | a hashable value
 class Hashable a where

--- a/backend/src/VersionControl/Tree.hs
+++ b/backend/src/VersionControl/Tree.hs
@@ -34,8 +34,11 @@ import qualified Data.HashMap.Strict.InsOrd as InsOrd
 import Data.OpenApi
     ( NamedSchema (..)
     , OpenApiType (..)
+    , ToParamSchema (..)
     , ToSchema (..)
     , declareSchemaRef
+    , exclusiveMinimum
+    , minimum_
     , properties
     , required
     , type_
@@ -45,6 +48,7 @@ import Data.Text (Text)
 import GHC.Generics
 import GHC.Int
 import VersionControl.Hash (Hash (..), Hashable (..), Hashed (..))
+import Web.HttpApiData (FromHttpApiData (..))
 
 -- | represents the id of a `Node`
 newtype NodeID = NodeID
@@ -60,6 +64,16 @@ instance FromJSON NodeID where
 
 instance ToSchema NodeID where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Int32)
+
+instance ToParamSchema NodeID where
+    toParamSchema _ =
+        mempty
+            & type_ ?~ OpenApiInteger
+            & minimum_ ?~ 0
+            & exclusiveMinimum ?~ False
+
+instance FromHttpApiData NodeID where
+    parseUrlPiece = (NodeID <$>) . parseUrlPiece
 
 instance Hashable NodeID where
     updateHash ctx nodeID = updateHash ctx $ unNodeID nodeID


### PR DESCRIPTION
This PR implementes `ToParamSchema` and `FromHttpApiData` instances for the id types in the `VersionControl` module (`CommitID`, `NodeID` and `Hash`). This is required to use these ids in api paths for implementing a REST wrapper around the internal `VersionControl` api.