### PR TITLE
Backend VersionControl: Refactor Document API to Behave More Like the Commit API

### DIFF
--- a/backend/src/VersionControl.hs
+++ b/backend/src/VersionControl.hs
@@ -56,7 +56,7 @@ createDocument
     -> GroupID
     -- ^ The group which owns the document
     -> Context
-    -> IO (Either VersionControlError DocumentID)
+    -> IO (Either VersionControlError Document)
 createDocument = (runSession .) . Sessions.createDocument
 
 -- | creates a commit in the given version control context

--- a/backend/src/VersionControl/Sessions.hs
+++ b/backend/src/VersionControl/Sessions.hs
@@ -67,7 +67,7 @@ createCommit commit =
         $ Transactions.createCommit commit
 
 -- | session to create a new document
-createDocument :: Text -> GroupID -> Session DocumentID
+createDocument :: Text -> GroupID -> Session Document
 createDocument = curry $ flip statement Statements.createDocument
 
 -- | session to create a new commit in a document

--- a/backend/src/VersionControl/Statements.hs
+++ b/backend/src/VersionControl/Statements.hs
@@ -288,17 +288,17 @@ getCommitNode =
             |]
 
 -- | statement to create a node of a certain kind
-createDocument :: Statement (Text, GroupID) DocumentID
+createDocument :: Statement (Text, GroupID) Document
 createDocument =
     rmap
-        DocumentID
+        (\(docID, name, groupID) -> Document (DocumentID docID) name groupID Nothing)
         [singletonStatement|
             insert into documents
                 (name, group_id)
             values
                 ($1 :: text),
                 ($2 :: int4)
-            returning id :: int4
+            returning id :: int4, name :: text, group_id :: int4
         |]
 
 -- | statement to get a document by its corresponding 'DocumentID'


### PR DESCRIPTION
This PR aims to maintain a uniform behavior of all internal api functions of the `VersionControl` module.
All functions of the internal `VersionControl` api behaved the same in the way that functions creating new database objects always returned the whole object as a result. Until this PR, the only exception was the `createDocument` function. In order to avoid confusion, `createDocument` now behaves like all similar functions of the internal `VersionControl` api.