### PR TITLE
backend/ltml: Add sentence continuation

### DIFF
--- a/backend/src/Language/Ltml/Parser/MiTree.hs
+++ b/backend/src/Language/Ltml/Parser/MiTree.hs
@@ -86,7 +86,7 @@ nli' = fromWhitespace <$> nli
 miForest
     :: forall m a
      . (MonadParser m, FromWhitespace [a])
-    => (m [a] -> m (MiElementConfig, a))
+    => (m [a] -> m (MiElementConfig, [a]))
     -> m a
     -> m [a]
 miForest elementPF childP = L.indentLevel >>= miForestFrom elementPF childP
@@ -94,7 +94,7 @@ miForest elementPF childP = L.indentLevel >>= miForestFrom elementPF childP
 miForestFrom
     :: forall m a
      . (MonadParser m, FromWhitespace [a])
-    => (m [a] -> m (MiElementConfig, a))
+    => (m [a] -> m (MiElementConfig, [a]))
     -> m a
     -> Pos
     -> m [a]
@@ -120,7 +120,7 @@ miForestFrom elementPF childP lvl = go True
                         else const id
             let wC = when $ miecPermitChild cfg
             let wEnd = when $ miecPermitEnd cfg
-            (e :)
+            (e ++)
                 <$> ( (nli' >>= \s -> f s <$> goE' <|> wC goC' <|> wEnd goEnd')
                         <|> f <$> sp' <*> goE
                         <|> wEnd goEnd
@@ -160,7 +160,7 @@ miForestFrom elementPF childP lvl = go True
 hangingBlock
     :: (MonadParser m, FromWhitespace [a])
     => m ([a] -> b)
-    -> (m [a] -> m (MiElementConfig, a))
+    -> (m [a] -> m (MiElementConfig, [a]))
     -> m a
     -> m b
 hangingBlock keywordP elementPF childP = do
@@ -174,7 +174,7 @@ hangingBlock keywordP elementPF childP = do
 hangingBlock'
     :: (MonadParser m, FromWhitespace [a])
     => m b
-    -> (m [a] -> m (MiElementConfig, a))
+    -> (m [a] -> m (MiElementConfig, [a]))
     -> m a
     -> m (b, [a])
 hangingBlock' = hangingBlock . fmap (,)
@@ -184,7 +184,7 @@ hangingBlock' = hangingBlock . fmap (,)
 hangingBlock_
     :: (MonadParser m, FromWhitespace [a])
     => m ()
-    -> (m [a] -> m (MiElementConfig, a))
+    -> (m [a] -> m (MiElementConfig, [a]))
     -> m a
     -> m [a]
 hangingBlock_ = hangingBlock . fmap (const id)

--- a/docs/language/ltml/paragraph.md
+++ b/docs/language/ltml/paragraph.md
@@ -49,6 +49,13 @@ Sentences are generally terminated by a single period (`.`), exclamation mark
 Additionally, they are terminated by enumeration items (with the next sentence
 starting after the sequence of enumeration items).
 
+Sentence terminatation can be undone by inserting the continuation token `{>}`
+where otherwise a new sentence might start.
+This is meant for continuing a sentence after an enumeration, where it is to
+be inserted at the start of the first line after the enumeration.
+Otherwise, one may also simply escape the line terminator,
+s.t., e.g., `X\. Y.` is equivalent to `X. {>} Y.`).
+
 Sentences are not full nodes; in particular, [styling](./text.md#styling) may
 overlap with sentences.
 


### PR DESCRIPTION
Sentences that would otherwise end can now be continued via `{>}`.  This was originally only intended for use after enumerations (which otherwise terminate sentences), but was now implemented more generally, which happens to be easier, and is deemed to be useful from a user's perspective.

closes: #147