### PR TITLE
Backend: `GET /users` now returns id, name, email

### DIFF
--- a/backend/src/UserManagement/Sessions.hs
+++ b/backend/src/UserManagement/Sessions.hs
@@ -1,5 +1,5 @@
 module UserManagement.Sessions
-    ( getUsers
+    ( getAllUsers
     , getUserByEmail
     , getUserByID
     , getUserID
@@ -34,15 +34,14 @@ where
 
 import qualified Data.Bifunctor (second)
 import Data.Text (Text)
-import Data.Vector (Vector)
 import Hasql.Session (Session, statement)
 import qualified UserManagement.Document as Document
 import qualified UserManagement.Group as Group
 import qualified UserManagement.Statements as Statements
 import qualified UserManagement.User as User
 
-getUsers :: Session (Vector User.User)
-getUsers = statement () Statements.getUsers
+getAllUsers :: Session [User.User]
+getAllUsers = statement () Statements.getAllUsers
 
 getUserID :: Text -> Session User.UserID
 getUserID userEmail = statement userEmail Statements.getUserID
@@ -69,7 +68,7 @@ getUserRoleInGroup uid group =
     maybe Nothing User.textToRole
         <$> statement (uid, group) Statements.getUserRoleInGroup
 
-putUser :: User.User -> Session User.UserID
+putUser :: User.UserCreate -> Session User.UserID
 putUser user = statement user Statements.putUser
 
 deleteUser :: User.UserID -> Session ()

--- a/backend/src/UserManagement/User.hs
+++ b/backend/src/UserManagement/User.hs
@@ -5,6 +5,7 @@
 
 module UserManagement.User
     ( User (..)
+    , UserCreate (..)
     , FullUser (..)
     , UserInfo (..)
     , Role (..)
@@ -25,15 +26,22 @@ import qualified UserManagement.Group as Group
 type UserID = UUID
 
 data User = User
-    { userName :: Text
+    { userID :: UserID
+    , userName :: Text
     , userEmail :: Text
-    , userPwhash :: Text
     }
     deriving (Eq, Show, Generic)
 
 instance ToJSON User
 instance FromJSON User
 instance ToSchema User
+
+data UserCreate = UserCreate
+    {
+    userCreateName :: Text
+    , userCreateEmail :: Text
+    , userCreatePWHash :: Text
+    }
 
 data FullUser = FullUser
     { fullUserID :: UserID

--- a/backend/src/UserManagement/User.hs
+++ b/backend/src/UserManagement/User.hs
@@ -37,8 +37,7 @@ instance FromJSON User
 instance ToSchema User
 
 data UserCreate = UserCreate
-    {
-    userCreateName :: Text
+    { userCreateName :: Text
     , userCreateEmail :: Text
     , userCreatePWHash :: Text
     }


### PR DESCRIPTION
Before this PR `GET /users` returned some other user data including the users password hash.
Now the user endpoint was moved inside the existing Handler structure and returns a list of ids, names and emails. 

Closes #206 ;)