### PR TITLE
Use group endpoint for group management

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -19,6 +19,7 @@
             "either",
             "enums",
             "foldable-traversable",
+            "foreign",
             "formatters",
             "halogen",
             "halogen-bootstrap5",

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -15,6 +15,7 @@ package:
     - either
     - enums
     - foldable-traversable
+    - foreign
     - formatters
     - halogen
     - halogen-bootstrap5

--- a/frontend/src/Data/JSON.purs
+++ b/frontend/src/Data/JSON.purs
@@ -3,9 +3,9 @@ module Data.JSON where
 
 import Prelude
 
-import Data.Argonaut (Json, JsonDecodeError, decodeJson, (.:))
+import Data.Argonaut (Json, JsonDecodeError, decodeJson, encodeJson, (.:))
 import Data.Either (Either)
-import FPO.Data.Store (User)
+import FPO.Data.Store (Group, GroupCreate, User)
 
 -- | TODO: It might be better to implement `instance DecodeJson User`, but
 -- |       this forces us to use Data instead of Type..
@@ -18,3 +18,14 @@ decodeUser json = do
   name <- obj .: "fullUserName"
   admin <- obj .: "fullUserIsSuperadmin"
   pure { userName: name, isAdmin: admin }
+
+-- | Decodes a JSON object into a `Group`.
+decodeGroup :: Json -> Either JsonDecodeError Group
+decodeGroup json = do
+  obj <- decodeJson json
+  name <- obj .: "groupName"
+  id <- obj .: "groupID"
+  pure { groupName: name, groupId: id }
+
+encodeGroupCreate :: GroupCreate -> Json
+encodeGroupCreate = encodeJson

--- a/frontend/src/Data/Store.purs
+++ b/frontend/src/Data/Store.purs
@@ -16,6 +16,10 @@ import Web.Storage.Storage (getItem, setItem) as LocalStorage
 
 type User = { userName :: String, isAdmin :: Boolean }
 
+type Group = { groupName :: String, groupId :: Int }
+
+type GroupCreate = { groupCreateName :: String, groupCreateDescription :: String }
+
 -- | The Store type represents the global state of the application.
 type Store =
   { inputMail :: String -- ^ The email that was input in the login form (example state variable)

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -189,6 +189,7 @@ component =
       , HH.div [ HP.classes [ HB.col12, HB.textCenter ] ]
           [ HH.div [ HP.classes [ HB.dInlineBlock ] ]
               [ addButton
+                  true
                   "Filter"
                   (Just "bi-funnel")
                   (const Filter)
@@ -240,6 +241,7 @@ component =
       , HH.div [ HP.classes [ HB.col12, HB.textCenter ] ]
           [ HH.div [ HP.classes [ HB.dInlineBlock ] ]
               [ addButton
+                  true
                   "Create"
                   (Just "bi-plus-circle")
                   (const CreateUser)

--- a/frontend/src/Page/HTML.purs
+++ b/frontend/src/Page/HTML.purs
@@ -51,16 +51,18 @@ addColumn val str placeholder bi for act =
 -- | Creates a button with an icon.
 addButton
   :: forall w a
-   . String -- ^ button text
+   . Boolean -- ^ whether the button is enabled
+  -> String -- ^ button text
   -> Maybe String -- ^ optional, prepended icon
   -> (MouseEvent -> a) -- ^ action
   -> HH.HTML w a
-addButton text bi act =
+addButton enabled text bi act =
   HH.div [ HP.classes [ HB.inputGroup ] ]
     [ HH.button
         [ HP.type_ HP.ButtonButton
         , HP.classes [ HB.btn, HB.btnPrimary ]
         , HE.onClick act
+        , HP.disabled (not enabled)
         ]
         [ case bi of
             Just icon

--- a/frontend/src/Page/HTML.purs
+++ b/frontend/src/Page/HTML.purs
@@ -96,6 +96,59 @@ addCard title e content =
         ]
     ]
 
+addModal
+  :: forall w i
+   . String -- ^ title of the modal
+  -> (MouseEvent -> i) -- ^ action for the cancel button
+  -> Array (HH.HTML w i) -- ^ content of the modal
+  -> HH.HTML w i
+addModal title cancelAction content =
+  HH.div_
+    [ HH.div
+        [ HP.classes
+            [ HB.modal, HB.fade, HB.show ]
+        , HP.id "deleteModal"
+        , HP.attr (HH.AttrName "data-bs-backdrop") "static"
+        , HP.attr (HH.AttrName "data-bs-keyboard") "false"
+        , HP.attr (HH.AttrName "tabindex") "-1"
+        -- , HP.attr (HH.AttrName "aria-labelledby") "deleteModalLabel"
+        , HP.attr (HH.AttrName "aria-hidden") "false"
+        , HP.style "display: block;"
+        ]
+        [ HH.div
+            [ HP.classes [ HH.ClassName "modal-dialog" ] ]
+            [ HH.div
+                [ HP.classes [ HH.ClassName "modal-content" ] ]
+                ( [ HH.div
+                      [ HP.classes [ HH.ClassName "modal-header" ] ]
+                      [ HH.h1
+                          [ HP.classes
+                              [ HH.ClassName "modal-title", HH.ClassName "fs-5" ]
+                          -- , HP.id "deleteModalLabel"
+                          ]
+                          [ HH.text title ]
+                      , HH.button
+                          [ HP.type_ HP.ButtonButton
+                          , HP.classes [ HB.btnClose ]
+                          , HP.attr (HH.AttrName "data-bs-dismiss") "modal"
+                          , HP.attr (HH.AttrName "aria-label") "Close"
+                          , HE.onClick cancelAction
+                          ]
+                          []
+                      ]
+                  ] <> content
+                )
+            ]
+        ]
+    , HH.div
+        [ HP.classes
+            [ HH.ClassName "modal-backdrop"
+            , HH.ClassName "show"
+            ]
+        ]
+        []
+    ]
+
 -- | Creates an empty entry for text-based lists.
 -- | Used for padding.
 emptyEntryText :: forall w a. HH.HTML w a

--- a/frontend/src/Page/Profile.purs
+++ b/frontend/src/Page/Profile.purs
@@ -7,7 +7,7 @@ import Prelude
 import Data.Maybe (Maybe(..), fromMaybe)
 import Effect.Aff.Class (class MonadAff)
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request (getUser)
+import FPO.Data.Request (LoadState(..), getUser)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store (User)
 import FPO.Data.Store as Store
@@ -23,21 +23,19 @@ import Halogen.Themes.Bootstrap5 as HB
 import Simple.I18n.Translator (label, translate)
 import Type.Proxy (Proxy(Proxy))
 
--- | State of an asynchronous load operation.
--- | It can either be in a loading state or have successfully loaded data.
--- |
+data Action
+  = Initialize
+  | Receive (Connected FPOTranslator Input)
+
 -- | TODO: Because `handleAction` handles the case of failing to load the user
 -- |       explicitly (by navigating to the login page), we do not care about
 -- |       the error case here. We should look for a more general approach to
 -- |       handle loading entities in the future. Right now, this is at least
 -- |       more descriptive than using `Maybe`.
-data LoadState a = Loading | Loaded a
-
-data Action
-  = Initialize
-  | Receive (Connected FPOTranslator Input)
-
-type State = FPOState (user :: LoadState User, loginSuccessfulBanner :: Boolean)
+type State = FPOState
+  ( user :: LoadState User
+  , loginSuccessfulBanner :: Boolean
+  )
 
 type Input = { loginSuccessfulBanner :: Maybe Boolean }
 


### PR DESCRIPTION
.. and actually use the groups stored on the server!

Some things still have to be done:

- [x] After creating a new group, retrieve the actual group id (instead of 42...) and store this locally. Otherwise, we can't properly remove the group without reloading the page (and reloading all group information).
- [x] Investigate: Hitting the endpoint with an invalid request (i.e., invalid group id) does not yield an error (should be a frontend issue).
- [x] Remove boilerplate code and repetition. Try to clean up the never-ending nesting of code in `handleAction`...