### PR TITLE
Added additional info to `GET /groups/{groupID}`

### DIFF
--- a/backend/src/UserManagement/Group.hs
+++ b/backend/src/UserManagement/Group.hs
@@ -1,17 +1,30 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module UserManagement.Group (GroupCreate (..), GroupID, GroupOverview (..)) where
+module UserManagement.Group (Group (..), GroupCreate (..), GroupID, GroupOverview (..)) where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.OpenApi (ToSchema)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import GHC.Int (Int32)
+import qualified UserManagement.User as User
+
+-- | Represents all information about a single group
+data Group = Group
+    { groupID :: GroupID
+    , groupName :: Text
+    , groupDescription :: Maybe Text
+    , groupMembers :: [User.UserInfo]
+    }
+    deriving (Generic)
+
+instance ToJSON Group
+instance ToSchema Group
 
 -- | List of GroupIds and GroupName pairs
 data GroupOverview = GroupOverview
-    { groupID :: GroupID
-    , groupName :: Text
+    { groupOverviewID :: GroupID
+    , groupOverviewName :: Text
     }
     deriving (Generic)
 

--- a/backend/src/UserManagement/Sessions.hs
+++ b/backend/src/UserManagement/Sessions.hs
@@ -13,6 +13,7 @@ module UserManagement.Sessions
     , getLoginRequirements
     , getAllUserRoles
     , addGroup
+    , getGroupInfo
     , getAllGroupsOverview
     , deleteGroup
     , addRole
@@ -85,6 +86,10 @@ updateUserPWHash uid pwhash = statement (pwhash, uid) Statements.updateUserName
 
 addGroup :: Text -> Maybe Text -> Session Group.GroupID
 addGroup group description = statement (group, description) Statements.addGroup
+
+-- | returns name and description of specified group
+getGroupInfo :: Group.GroupID -> Session Group.GroupCreate
+getGroupInfo groupID = statement groupID Statements.getGroupInfo
 
 getAllGroupsOverview :: Session [Group.GroupOverview]
 getAllGroupsOverview = statement () Statements.getAllGroupsOverview

--- a/backend/src/UserManagement/Statements.hs
+++ b/backend/src/UserManagement/Statements.hs
@@ -16,6 +16,7 @@ module UserManagement.Statements
     , updateUserEmail
     , updateUserPWHash
     , addGroup
+    , getGroupInfo
     , getAllGroupsOverview
     , deleteGroup
     , addRole
@@ -195,6 +196,15 @@ addGroup =
       insert into groups (name, description)
       values ($1 :: text, $2 :: text?)
       returning id :: int4
+    |]
+
+getGroupInfo :: Statement Group.GroupID Group.GroupCreate
+getGroupInfo =
+    uncurry Group.GroupCreate
+        <$> [singletonStatement|
+        select name :: text, description :: text?
+        from groups
+        where id = $1 :: int4
     |]
 
 getAllGroupsOverview :: Statement () [Group.GroupOverview]

--- a/backend/src/UserManagement/User.hs
+++ b/backend/src/UserManagement/User.hs
@@ -20,8 +20,8 @@ import Data.OpenApi (ToSchema)
 import Data.Text (Text, pack, unpack)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
+import GHC.Int (Int32)
 import Text.Read (readMaybe)
-import qualified UserManagement.Group as Group
 
 type UserID = UUID
 
@@ -42,12 +42,15 @@ data UserCreate = UserCreate
     , userCreatePWHash :: Text
     }
 
+-- | duplicate definition because of import cycle with UserManagement.Group :'(
+type GroupID = Int32
+
 data FullUser = FullUser
     { fullUserID :: UserID
     , fullUserName :: Text
     , fullUserEmail :: Text
     , fullUserIsSuperadmin :: Bool
-    , fullUserRoles :: [(Group.GroupID, Role)]
+    , fullUserRoles :: [(GroupID, Role)]
     }
     deriving (Show, Generic)
 


### PR DESCRIPTION
It also returns id, name and description of the group now.

Sadly the `groupID` is now redefined in `UserManagement.User`.

Closes #209 