### PR TITLE
backend/lang: Disallow mixing para's and subsec's

### DIFF
--- a/backend/src/Language/Lsd/AST/Type/Section.hs
+++ b/backend/src/Language/Lsd/AST/Type/Section.hs
@@ -20,12 +20,13 @@ newtype SectionFormat
     deriving (Show)
 
 data SectionType
-    = SectionType
+    = -- | Section type
+      SectionType
         Keyword
         HeadingType
         SectionFormat
-        -- | children's type(s)
         (Either ParagraphType (SimpleRegex SectionType))
+        -- ^ children's type(s)
 
 data PreSectionType
     = PreSectionType

--- a/backend/src/Language/Lsd/AST/Type/Section.hs
+++ b/backend/src/Language/Lsd/AST/Type/Section.hs
@@ -4,7 +4,6 @@ module Language.Lsd.AST.Type.Section
     , PreSectionType (..)
     , HeadingType (..)
     , PreHeadingType (..)
-    , SectionChildType (..)
     )
 where
 
@@ -25,7 +24,8 @@ data SectionType
         Keyword
         HeadingType
         SectionFormat
-        (SimpleRegex SectionChildType)
+        -- | children's type(s)
+        (Either ParagraphType (SimpleRegex SectionType))
 
 data PreSectionType
     = PreSectionType
@@ -43,7 +43,3 @@ data PreHeadingType
     = PreHeadingType
         HeadingFormat
         (PreTextType Void)
-
-data SectionChildType
-    = SectionChildSectionType SectionType
-    | SectionChildParagraphType ParagraphType

--- a/backend/src/Language/Lsd/Example/Fpo.hs
+++ b/backend/src/Language/Lsd/Example/Fpo.hs
@@ -50,13 +50,14 @@ superSectionT =
         ( SectionFormat
             (FormatString [PlaceholderAtom Arabic])
         )
-        ( SimpleRegex
-            (Sequence [])
-            ( Disjunction
-                [ Star $ Disjunction [SectionChildSectionType sectionT]
-                ]
-            )
-            (Sequence [])
+        ( Right $
+            SimpleRegex
+                (Sequence [])
+                ( Disjunction
+                    [ Star $ Disjunction [sectionT]
+                    ]
+                )
+                (Sequence [])
         )
 
 sectionT :: SectionType
@@ -76,13 +77,7 @@ sectionT =
         ( SectionFormat
             (FormatString [PlaceholderAtom Arabic])
         )
-        ( SimpleRegex
-            (Sequence [])
-            ( Disjunction
-                [Star $ Disjunction [SectionChildParagraphType paragraphT]]
-            )
-            (Sequence [])
-        )
+        (Left paragraphT)
 
 paragraphT :: ParagraphType
 paragraphT =

--- a/backend/src/Language/Ltml/AST/Section.hs
+++ b/backend/src/Language/Ltml/AST/Section.hs
@@ -11,11 +11,12 @@ import Language.Ltml.AST.Paragraph (Paragraph)
 import Language.Ltml.AST.Text (PlainTextTree)
 
 data Section
-    = Section
+    = -- | Section
+      Section
         SectionFormat
         Heading
-        -- | children
         (Either [Node Paragraph] [Node Section])
+        -- ^ children
     deriving (Show)
 
 data Heading

--- a/backend/src/Language/Ltml/AST/Section.hs
+++ b/backend/src/Language/Ltml/AST/Section.hs
@@ -1,7 +1,6 @@
 module Language.Ltml.AST.Section
     ( Section (..)
     , Heading (..)
-    , SectionChild (..)
     )
 where
 
@@ -15,16 +14,12 @@ data Section
     = Section
         SectionFormat
         Heading
-        [SectionChild]
+        -- | children
+        (Either [Node Paragraph] [Node Section])
     deriving (Show)
 
 data Heading
     = Heading
         HeadingFormat
         [PlainTextTree]
-    deriving (Show)
-
-data SectionChild
-    = SectionChildSection (Node Section)
-    | SectionChildParagraph (Node Paragraph)
     deriving (Show)

--- a/backend/src/Language/Ltml/Parser/Section.hs
+++ b/backend/src/Language/Ltml/Parser/Section.hs
@@ -3,39 +3,39 @@ module Language.Ltml.Parser.Section
     )
 where
 
+import Data.Bitraversable (bitraverse)
 import Language.Lsd.AST.Common (Keyword)
+import Language.Lsd.AST.SimpleRegex (SimpleRegex)
+import Language.Lsd.AST.Type.Paragraph (ParagraphType)
 import Language.Lsd.AST.Type.Section
     ( HeadingType (HeadingType)
-    , SectionChildType (SectionChildParagraphType, SectionChildSectionType)
     , SectionType (SectionType)
     )
 import Language.Ltml.AST.Label (Label)
 import Language.Ltml.AST.Node (Node (Node))
+import Language.Ltml.AST.Paragraph (Paragraph)
 import Language.Ltml.AST.Section
     ( Heading (Heading)
     , Section (Section)
-    , SectionChild (SectionChildParagraph, SectionChildSection)
     )
 import Language.Ltml.Parser (Parser)
 import Language.Ltml.Parser.Common.Lexeme (nLexeme)
 import Language.Ltml.Parser.Common.SimpleRegex (simpleRegexP)
 import Language.Ltml.Parser.Paragraph (paragraphP)
 import Language.Ltml.Parser.Text (hangingTextP')
+import Text.Megaparsec (many)
 
 sectionP :: SectionType -> Parser (Node Section)
-sectionP (SectionType kw headingT fmt childrenTR) = do
+sectionP (SectionType kw headingT fmt childrenT) = do
     (mLabel, heading) <- headingP kw headingT
-    Node mLabel . Section fmt heading <$> childrenP
+    Node mLabel . Section fmt heading <$> bitraverse parsP secsP childrenT
   where
-    childrenP :: Parser [SectionChild]
-    childrenP = simpleRegexP sectionChildP childrenTR
+    parsP :: ParagraphType -> Parser [Node Paragraph]
+    parsP t = many $ nLexeme $ paragraphP t
+
+    secsP :: SimpleRegex SectionType -> Parser [Node Section]
+    secsP = simpleRegexP sectionP
 
 headingP :: Keyword -> HeadingType -> Parser (Maybe Label, Heading)
 headingP kw (HeadingType fmt tt) =
     nLexeme $ fmap (Heading fmt) <$> hangingTextP' kw tt
-
-sectionChildP :: SectionChildType -> Parser SectionChild
-sectionChildP (SectionChildSectionType t) =
-    SectionChildSection <$> sectionP t
-sectionChildP (SectionChildParagraphType t) =
-    nLexeme $ SectionChildParagraph <$> paragraphP t


### PR DESCRIPTION
Why?
 - 1. Avoid ambiguity when parsing (see #117).
 - 2. Simplify output (e.g., HTML) generation.

If we want to have some paragraphs before a subsection (which is the typical case we "broke"), we can encode that as follows:

    [super-section] title

    [section-intro]
    Some paragraph(s).

    [subsection] title
    Something.

(This assumes support for untitled sections, which we want.)

closes: #117