### PR TITLE
User page refining

### DIFF
--- a/frontend/src/Data/Email.purs
+++ b/frontend/src/Data/Email.purs
@@ -1,0 +1,16 @@
+module Data.Email where
+
+import Data.Either (Either(..))
+import Data.String.Regex (regex, test)
+import Data.String.Regex.Flags (noFlags)
+
+-- | Stricter email validation that requires a proper domain with TLD
+-- | This validates that the email has:
+-- | - A local part (before @)
+-- | - A domain name (after @)
+-- | - A top-level domain (at least 2 characters after the last dot)
+isValidEmailStrict :: String -> Boolean
+isValidEmailStrict email =
+  case regex "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$" noFlags of
+    Right r -> test r email
+    Left _ -> false

--- a/frontend/src/Data/UserForOverview.purs
+++ b/frontend/src/Data/UserForOverview.purs
@@ -12,6 +12,9 @@ newtype UserForOverview = UserForOverview
 getName :: UserForOverview -> String
 getName (UserForOverview { userName }) = userName
 
+getEmail :: UserForOverview -> String
+getEmail (UserForOverview { userEmail }) = userEmail
+
 derive instance newtypeAppUser :: Newtype UserForOverview _
 
 derive newtype instance encodeJsonAppUser :: EncodeJson UserForOverview

--- a/frontend/src/Dto/CreateUserDto.purs
+++ b/frontend/src/Dto/CreateUserDto.purs
@@ -1,4 +1,4 @@
-module Dto.CreateUserDto where
+module FPO.Dto.CreateUserDto where
 
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Newtype (class Newtype)
@@ -14,6 +14,10 @@ derive instance newtypeCreateUserDto :: Newtype CreateUserDto _
 
 derive newtype instance encodeJsonCreateUserDto :: EncodeJson CreateUserDto
 derive newtype instance decodeJsonCreateUserDto :: DecodeJson CreateUserDto
+
+empty :: CreateUserDto
+empty = CreateUserDto
+  { registerEmail: "", registerName: "", registerPassword: "", groupID: 1 }
 
 getName :: CreateUserDto -> String
 getName (CreateUserDto { registerName }) = registerName

--- a/frontend/src/Dto/CreateUserDto.purs
+++ b/frontend/src/Dto/CreateUserDto.purs
@@ -1,0 +1,37 @@
+module Dto.CreateUserDto where
+
+import Data.Argonaut (class DecodeJson, class EncodeJson)
+import Data.Newtype (class Newtype)
+
+newtype CreateUserDto = CreateUserDto
+  { registerEmail :: String
+  , registerName :: String
+  , registerPassword :: String
+  , groupID :: Int
+  }
+
+derive instance newtypeCreateUserDto :: Newtype CreateUserDto _
+
+derive newtype instance encodeJsonCreateUserDto :: EncodeJson CreateUserDto
+derive newtype instance decodeJsonCreateUserDto :: DecodeJson CreateUserDto
+
+getName :: CreateUserDto -> String
+getName (CreateUserDto { registerName }) = registerName
+
+getEmail :: CreateUserDto -> String
+getEmail (CreateUserDto { registerEmail }) = registerEmail
+
+getPassword :: CreateUserDto -> String
+getPassword (CreateUserDto { registerPassword }) = registerPassword
+
+withName :: String -> CreateUserDto -> CreateUserDto
+withName name (CreateUserDto { registerEmail, registerPassword, groupID }) =
+  CreateUserDto { registerEmail, registerName: name, registerPassword, groupID }
+
+withEmail :: String -> CreateUserDto -> CreateUserDto
+withEmail email (CreateUserDto { registerName, registerPassword, groupID }) =
+  CreateUserDto { registerEmail: email, registerName, registerPassword, groupID }
+
+withPassword :: String -> CreateUserDto -> CreateUserDto
+withPassword password (CreateUserDto { registerEmail, registerName, groupID }) =
+  CreateUserDto { registerEmail, registerName, registerPassword: password, groupID }

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -277,14 +277,14 @@ component =
               HP.InputText
               ChangeCreateUsername
           , addColumn
-              ""
+              (getEmail state.createUserDto)
               (translate (label :: _ "common_email") state.translator)
               (translate (label :: _ "common_email") state.translator)
               "bi-envelope-fill"
               HP.InputEmail
               ChangeCreateEmail
           , addColumn
-              ""
+              (getPassword state.createUserDto)
               (translate (label :: _ "common_password") state.translator)
               (translate (label :: _ "common_password") state.translator)
               "bi-lock-fill"

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -154,7 +154,11 @@ component =
           [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
               [ HH.text $ translate (label :: _ "au_userManagement") state.translator
               ]
-          , renderUserListView state
+          , case state.users of
+              Loading ->
+                HH.div [ HP.classes [ HB.textCenter, HB.mt5 ] ]
+                  [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
+              Loaded _ -> renderUserListView state
           ]
       ]
 

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -172,13 +172,14 @@ component =
 
   renderFilterBy :: State -> H.ComponentHTML Action Slots m
   renderFilterBy state =
-    addCard "Filter by" [ HP.classes [ HB.col3 ] ] $ HH.div
+    addCard (translate (label :: _ "common_filterBy") state.translator)
+      [ HP.classes [ HB.col3 ] ] $ HH.div
       [ HP.classes [ HB.row ] ]
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
               state.filterUsername
-              "Username:"
-              "Username"
+              (translate (label :: _ "prof_userName") state.translator)
+              (translate (label :: _ "prof_userName") state.translator)
               "bi-person"
               HP.InputText
               ChangeFilterUsername
@@ -204,7 +205,8 @@ component =
   -- Creates a list of (dummy) users with pagination.
   renderUserList :: State -> H.ComponentHTML Action Slots m
   renderUserList state =
-    addCard "List of Users" [ HP.classes [ HB.col5 ] ] $ HH.div_
+    addCard (translate (label :: _ "admin_users_listOfUsers") state.translator)
+      [ HP.classes [ HB.col5 ] ] $ HH.div_
       [ HH.ul [ HP.classes [ HB.listGroup ] ]
           $ map createUserEntry usrs
               <> replicate (10 - length usrs)
@@ -225,19 +227,20 @@ component =
   -- Creates a form to create a new (dummy) user.
   renderNewUserForm :: forall w. State -> HH.HTML w Action
   renderNewUserForm state =
-    addCard "Create New User" [ HP.classes [ HB.col3 ] ] $ HH.div_
+    addCard (translate (label :: _ "admin_users_createNewUser") state.translator)
+      [ HP.classes [ HB.col3 ] ] $ HH.div_
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
               state.createUsername
-              "Username"
-              "Username"
+              (translate (label :: _ "prof_userName") state.translator)
+              (translate (label :: _ "prof_userName") state.translator)
               "bi-person"
               HP.InputText
               ChangeCreateUsername
           , addColumn
               ""
-              "Email"
-              "Email"
+              (translate (label :: _ "common_email") state.translator)
+              (translate (label :: _ "common_email") state.translator)
               "bi-envelope-fill"
               HP.InputEmail
               (const DoNothing)
@@ -246,7 +249,7 @@ component =
           [ HH.div [ HP.classes [ HB.dInlineBlock ] ]
               [ addButton
                   true
-                  "Create"
+                  (translate (label :: _ "admin_users_create") state.translator)
                   (Just "bi-plus-circle")
                   (const CreateUser)
               ]

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -185,8 +185,8 @@ component =
               ChangeFilterUsername
           , addColumn
               ""
-              "Email:"
-              "Email"
+              (translate (label :: _ "common_email") state.translator)
+              (translate (label :: _ "common_email") state.translator)
               "bi-envelope-fill"
               HP.InputEmail
               (const DoNothing)

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -258,7 +258,9 @@ component =
 
   -- Creates a (dummy) user entry for the list.
   createUserEntry :: forall w. UserForOverview -> HH.HTML w Action
-  createUserEntry (UserForOverview { userName }) =
-    HH.li [ HP.classes [ HB.listGroupItem ] ]
-      [ HH.text userName ]
+  createUserEntry (UserForOverview { userName, userEmail }) =
+    HH.li [ HP.classes [ HB.listGroupItem, HB.dFlex, HB.justifyContentBetween ] ]
+      [ HH.span [ HP.classes [ HB.col6 ] ] [ HH.text userName ]
+      , HH.span [ HP.classes [ HB.col6 ] ] [ HH.text userEmail ]
+      ]
 

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -178,8 +178,8 @@ component =
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
               state.filterUsername
-              (translate (label :: _ "prof_userName") state.translator)
-              (translate (label :: _ "prof_userName") state.translator)
+              (translate (label :: _ "common_userName") state.translator)
+              (translate (label :: _ "common_userName") state.translator)
               "bi-person"
               HP.InputText
               ChangeFilterUsername
@@ -232,8 +232,8 @@ component =
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
               state.createUsername
-              (translate (label :: _ "prof_userName") state.translator)
-              (translate (label :: _ "prof_userName") state.translator)
+              (translate (label :: _ "common_userName") state.translator)
+              (translate (label :: _ "common_userName") state.translator)
               "bi-person"
               HP.InputText
               ChangeCreateUsername

--- a/frontend/src/Page/Admin/PageUsers.purs
+++ b/frontend/src/Page/Admin/PageUsers.purs
@@ -65,6 +65,8 @@ type State = FPOState
   , filteredUsers :: Array UserForOverview
   , filterUsername :: String
   , createUsername :: String
+  , createEmail :: String
+  , createPassword :: String
   )
 
 -- | Admin panel page component.
@@ -94,19 +96,21 @@ component =
     , filteredUsers: []
     , filterUsername: ""
     , createUsername: ""
+    , createEmail: ""
+    , createPassword: ""
     }
 
   render :: State -> H.ComponentHTML Action Slots m
   render state =
     HH.div
-      [ HP.classes [ HB.row, HB.justifyContentCenter, HB.my5 ] ]
+      [ HP.classes [ HB.container, HB.dFlex, HB.justifyContentCenter, HB.my5 ]
+      ]
       [ renderUserManagement state
-      , HH.div [ HP.classes [ HB.textCenter ] ]
-          [ case state.error of
-              Just err -> HH.div [ HP.classes [ HB.alert, HB.alertDanger, HB.mt5 ] ]
-                [ HH.text err ]
-              Nothing -> HH.text ""
-          ]
+      , case state.error of
+          Just err -> HH.div
+            [ HP.classes [ HB.alert, HB.alertDanger, HB.textCenter, HB.mt5 ] ]
+            [ HH.text err ]
+          Nothing -> HH.text ""
       ]
 
   handleAction :: Action -> H.HalogenM State Action Slots output m Unit
@@ -149,17 +153,15 @@ component =
 
   renderUserManagement :: State -> H.ComponentHTML Action Slots m
   renderUserManagement state =
-    HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
-      [ HH.div [ HP.classes [ HB.colSm12, HB.colMd10, HB.colLg9 ] ]
-          [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
-              [ HH.text $ translate (label :: _ "au_userManagement") state.translator
-              ]
-          , case state.users of
-              Loading ->
-                HH.div [ HP.classes [ HB.textCenter, HB.mt5 ] ]
-                  [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
-              Loaded _ -> renderUserListView state
+    HH.div [ HP.classes [ HB.w100 ] ]
+      [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
+          [ HH.text $ translate (label :: _ "au_userManagement") state.translator
           ]
+      , case state.users of
+          Loading ->
+            HH.div [ HP.classes [ HB.textCenter, HB.mt5 ] ]
+              [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
+          Loaded _ -> renderUserListView state
       ]
 
   renderUserListView :: State -> H.ComponentHTML Action Slots m
@@ -206,7 +208,7 @@ component =
   renderUserList :: State -> H.ComponentHTML Action Slots m
   renderUserList state =
     addCard (translate (label :: _ "admin_users_listOfUsers") state.translator)
-      [ HP.classes [ HB.col5 ] ] $ HH.div_
+      [ HP.classes [ HB.col6 ] ] $ HH.div_
       [ HH.ul [ HP.classes [ HB.listGroup ] ]
           $ map createUserEntry usrs
               <> replicate (10 - length usrs)

--- a/frontend/src/Page/Profile.purs
+++ b/frontend/src/Page/Profile.purs
@@ -94,7 +94,7 @@ component =
                             [ HH.li [ HP.classes [ HB.listGroupItem ] ]
                                 [ HH.strong_
                                     [ HH.text $
-                                        ( translate (label :: _ "prof_userName")
+                                        ( translate (label :: _ "common_userName")
                                             state.translator
                                         ) <> ": "
                                     ]

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -11,6 +11,7 @@ import Record (merge)
 import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord, toRecord)
 import Translations.Components.Editor (deEditor, enEditor)
+import Translations.Page.Admin.PageUsers (deAdminUserPage, enAdminUserPage)
 import Translations.Page.Page404 (dePage404, enPage404)
 
 -- | Übersetzungen zusammenführen
@@ -18,7 +19,7 @@ en :: Translation Labels
 en = fromRecord $
   merge (toRecord enAdminPanel)
     ( merge
-        ( merge (toRecord enCommon)
+        ( merge (merge (toRecord enAdminUserPage) (toRecord enCommon))
             (merge (toRecord enEditor) (toRecord enHome))
         )
         ( merge
@@ -31,7 +32,7 @@ de :: Translation Labels
 de = fromRecord $
   merge (toRecord deAdminPanel)
     ( merge
-        ( merge (toRecord deCommon)
+        ( merge (merge (toRecord deAdminUserPage) (toRecord deCommon))
             (merge (toRecord deEditor) (toRecord deHome))
         )
         ( merge
@@ -47,12 +48,18 @@ de = fromRecord $
 -- | Because of this constraint, it's sensible to use
 -- | appropriate prefixes for strongly related labels.
 type Labels =
-  ( -- | Admin Panel
-    "au_groupManagement"
+  ( "admin_users_create"
+      ::: "admin_users_createNewUser"
+      ::: "admin_users_listOfUsers"
+
+      -- | Admin Panel
+      ::: "au_groupManagement"
       ::: "au_userManagement"
+
       -- | Common Phrases
       ::: "common_email"
       ::: "common_emailAddress"
+      ::: "common_filterBy"
       ::: "common_home"
       ::: "common_password"
       ::: "common_submit"

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -50,7 +50,10 @@ de = fromRecord $
 type Labels =
   ( "admin_users_create"
       ::: "admin_users_createNewUser"
+      ::: "admin_users_failedToCreateUser"
+      ::: "admin_users_failedToLoadUsers"
       ::: "admin_users_listOfUsers"
+      ::: "admin_users_successfullyCreatedUser"
 
       -- | Admin Panel
       ::: "au_groupManagement"

--- a/frontend/src/Translations/Labels.purs
+++ b/frontend/src/Translations/Labels.purs
@@ -63,6 +63,7 @@ type Labels =
       ::: "common_home"
       ::: "common_password"
       ::: "common_submit"
+      ::: "common_userName"
 
       -- | Editor Page
       ::: "editor_comment"
@@ -92,7 +93,6 @@ type Labels =
       ::: "prof_profile"
       ::: "prof_role"
       ::: "prof_userData"
-      ::: "prof_userName"
 
       -- | Reset Password Page
       ::: "rp_ConfirmationCode"

--- a/frontend/src/Translations/Page/Admin/PageUsers.purs
+++ b/frontend/src/Translations/Page/Admin/PageUsers.purs
@@ -6,7 +6,10 @@ import Simple.I18n.Translation (Translation, fromRecord)
 type AdminUserPageLabels =
   ( "admin_users_create"
       ::: "admin_users_createNewUser"
+      ::: "admin_users_failedToCreateUser"
+      ::: "admin_users_failedToLoadUsers"
       ::: "admin_users_listOfUsers"
+      ::: "admin_users_successfullyCreatedUser"
       ::: SNil
   )
 
@@ -14,6 +17,9 @@ enAdminUserPage :: Translation AdminUserPageLabels
 enAdminUserPage = fromRecord
   { admin_users_listOfUsers: "List of Users"
   , admin_users_createNewUser: "Create New User"
+  , admin_users_failedToCreateUser: "Failed to create user"
+  , admin_users_failedToLoadUsers: "Failed to load users"
+  , admin_users_successfullyCreatedUser: "Successfully created user"
   , admin_users_create: "Create"
   }
 
@@ -21,6 +27,9 @@ deAdminUserPage :: Translation AdminUserPageLabels
 deAdminUserPage = fromRecord
   { admin_users_listOfUsers: "Liste der Nutzer"
   , admin_users_createNewUser: "Neuen Nutzer erstellen"
+  , admin_users_failedToCreateUser: "Fehler beim Erstellen des Nutzers"
+  , admin_users_failedToLoadUsers: "Fehler beim Laden der Nutzer"
+  , admin_users_successfullyCreatedUser: "Nutzer erfolgreich erstellt"
   , admin_users_create: "Erstellen"
   }
 

--- a/frontend/src/Translations/Page/Admin/PageUsers.purs
+++ b/frontend/src/Translations/Page/Admin/PageUsers.purs
@@ -1,0 +1,26 @@
+module Translations.Page.Admin.PageUsers where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type AdminUserPageLabels =
+  ( "admin_users_create"
+      ::: "admin_users_createNewUser"
+      ::: "admin_users_listOfUsers"
+      ::: SNil
+  )
+
+enAdminUserPage :: Translation AdminUserPageLabels
+enAdminUserPage = fromRecord
+  { admin_users_listOfUsers: "List of Users"
+  , admin_users_createNewUser: "Create New User"
+  , admin_users_create: "Create"
+  }
+
+deAdminUserPage :: Translation AdminUserPageLabels
+deAdminUserPage = fromRecord
+  { admin_users_listOfUsers: "Liste der Nutzer"
+  , admin_users_createNewUser: "Neuen Nutzer erstellen"
+  , admin_users_create: "Erstellen"
+  }
+

--- a/frontend/src/Translations/Page/Common.purs
+++ b/frontend/src/Translations/Page/Common.purs
@@ -10,6 +10,7 @@ type CommonLabels =
       ::: "common_home"
       ::: "common_password"
       ::: "common_submit"
+      ::: "common_userName"
       ::: SNil
   )
 
@@ -20,6 +21,7 @@ enCommon = fromRecord
   , common_filterBy: "Filter by"
   , common_home: "Home"
   , common_password: "Password"
+  , common_userName: "User name"
   , common_submit: "Submit"
   }
 
@@ -30,6 +32,7 @@ deCommon = fromRecord
   , common_filterBy: "Filtern nach"
   , common_home: "Start"
   , common_password: "Passwort"
+  , common_userName: "Benutzername"
   , common_submit: "Absenden"
   }
 

--- a/frontend/src/Translations/Page/Common.purs
+++ b/frontend/src/Translations/Page/Common.purs
@@ -6,6 +6,7 @@ import Simple.I18n.Translation (Translation, fromRecord)
 type CommonLabels =
   ( "common_email"
       ::: "common_emailAddress"
+      ::: "common_filterBy"
       ::: "common_home"
       ::: "common_password"
       ::: "common_submit"
@@ -16,6 +17,7 @@ enCommon :: Translation CommonLabels
 enCommon = fromRecord
   { common_email: "Email"
   , common_emailAddress: "Email address"
+  , common_filterBy: "Filter by"
   , common_home: "Home"
   , common_password: "Password"
   , common_submit: "Submit"
@@ -25,6 +27,7 @@ deCommon :: Translation CommonLabels
 deCommon = fromRecord
   { common_email: "E-Mail"
   , common_emailAddress: "E-Mail Addresse"
+  , common_filterBy: "Filtern nach"
   , common_home: "Start"
   , common_password: "Passwort"
   , common_submit: "Absenden"

--- a/frontend/src/Translations/Page/Profile.purs
+++ b/frontend/src/Translations/Page/Profile.purs
@@ -8,7 +8,6 @@ type ProfileLabels =
       ::: "prof_profile"
       ::: "prof_role"
       ::: "prof_userData"
-      ::: "prof_userName"
       ::: SNil
   )
 
@@ -17,7 +16,6 @@ enProfile = fromRecord
   { prof_loginSuccessful: "Login successful"
   , prof_role: "Role"
   , prof_profile: "Profile"
-  , prof_userName: "User name"
   , prof_userData: "User data"
   }
 
@@ -26,6 +24,5 @@ deProfile = fromRecord
   { prof_loginSuccessful: "Login erfolgreich"
   , prof_role: "Rolle"
   , prof_profile: "Profil"
-  , prof_userName: "Benutzername"
   , prof_userData: "Nutzerdaten"
   }


### PR DESCRIPTION
This PR contains changes to the user page to connect it fully to the backend and have full functionality to the page.
It contains:

- Having a full name, email, password creation form for creating users (we still need to talk about if this is needed on this page)
- filtering works with name and email togehter (implemented such that one of both have to match)
- loading animation similar to the group page (this should maybe be implemented after the user creation as well)
- translation for the whole page