### PR TITLE
api: wrapped exposed tuple types into own data type

### DIFF
--- a/backend/src/DocumentManagement/Document.hs
+++ b/backend/src/DocumentManagement/Document.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module DocumentManagement.Document
     ( Document (..)
     , DocumentID (..)
     , withNewDocumentHead
+    , DocumentCreate (..)
     ) where
 
 import Control.Lens ((&), (.~), (?~))
@@ -28,6 +30,7 @@ import DocumentManagement.Commit (CommitID)
 import GHC.Int (Int32)
 import UserManagement.Group (GroupID)
 import Web.HttpApiData (FromHttpApiData (..))
+import GHC.Generics (Generic)
 
 -- | id type for documents
 newtype DocumentID = DocumentID
@@ -104,3 +107,12 @@ instance ToSchema Document where
 -- | Update the document head for the given document
 withNewDocumentHead :: Document -> CommitID -> Document
 withNewDocumentHead doc c = doc {documentHead = Just c}
+
+data DocumentCreate = DocumentCreate
+    { documentCreateName :: Text
+    , documentCreateGroupId :: GroupID
+    }
+    deriving (Generic)
+
+instance FromJSON DocumentCreate
+instance ToSchema DocumentCreate

--- a/backend/src/DocumentManagement/Document.hs
+++ b/backend/src/DocumentManagement/Document.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module DocumentManagement.Document
     ( Document (..)
@@ -27,10 +27,10 @@ import Data.OpenApi
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import DocumentManagement.Commit (CommitID)
+import GHC.Generics (Generic)
 import GHC.Int (Int32)
 import UserManagement.Group (GroupID)
 import Web.HttpApiData (FromHttpApiData (..))
-import GHC.Generics (Generic)
 
 -- | id type for documents
 newtype DocumentID = DocumentID

--- a/backend/src/DocumentManagement/Statements.hs
+++ b/backend/src/DocumentManagement/Statements.hs
@@ -296,8 +296,7 @@ createDocument =
             insert into documents
                 (name, group_id)
             values
-                ($1 :: text),
-                ($2 :: int4)
+                ($1 :: text, $2 :: int4)
             returning id :: int4, name :: text, group_id :: int4
         |]
 

--- a/backend/src/Server/Handlers/DocumentHandlers.hs
+++ b/backend/src/Server/Handlers/DocumentHandlers.hs
@@ -12,11 +12,10 @@ module Server.Handlers.DocumentHandlers
     ) where
 
 import Control.Monad.IO.Class
-import Data.Text (Text)
 import Data.Vector (Vector)
 import DocumentManagement
 import DocumentManagement.Commit
-import DocumentManagement.Document as Document (Document, DocumentID)
+import DocumentManagement.Document as Document
 import Hasql.Connection (Connection)
 import qualified Hasql.Session as Session
 import Servant
@@ -26,7 +25,6 @@ import qualified Server.Auth as Auth
 import Server.HandlerUtil
 import Server.Handlers.RenderHandlers (RenderAPI, renderServer)
 import qualified UserManagement.DocumentPermission as Permission
-import qualified UserManagement.Group as Group
 import qualified UserManagement.Sessions as Sessions
 import qualified UserManagement.User as User
 import Prelude hiding (readFile)
@@ -37,7 +35,7 @@ type DocumentAPI =
                 :> Capture "documentID" Document.DocumentID
                 :> Get '[JSON] Document
                 :<|> Auth AuthMethod Auth.Token
-                    :> ReqBody '[JSON] (Text, Group.GroupID)
+                    :> ReqBody '[JSON] Document.DocumentCreate
                     :> Post '[JSON] Document
                 :<|> Auth AuthMethod Auth.Token
                     :> Capture "documentID" Document.DocumentID
@@ -59,7 +57,7 @@ type DocumentAPI =
                 :<|> Auth AuthMethod Auth.Token
                     :> Capture "documentID" Document.DocumentID
                     :> "external"
-                    :> Get '[JSON] [(User.UserID, Permission.DocPermission)]
+                    :> Get '[JSON] [Permission.UsersPermission]
                 :<|> Auth AuthMethod Auth.Token
                     :> Capture "documentID" Document.DocumentID
                     :> "external"
@@ -68,8 +66,7 @@ type DocumentAPI =
                 :<|> Auth AuthMethod Auth.Token
                     :> Capture "documentID" Document.DocumentID
                     :> "external"
-                    :> Capture "userID" User.UserID
-                    :> ReqBody '[JSON] Permission.DocPermission
+                    :> ReqBody '[JSON] Permission.UsersPermission
                     :> Put '[JSON] NoContent
                 :<|> Auth AuthMethod Auth.Token
                     :> Capture "documentID" Document.DocumentID
@@ -111,14 +108,15 @@ getDocumentHandler (Authenticated Auth.Token {..}) docID = do
 getDocumentHandler _ _ = throwError errNotLoggedIn
 
 postDocumentHandler
-    :: AuthResult Auth.Token -> (Text, Group.GroupID) -> Handler Document
-postDocumentHandler (Authenticated token) (name, groupID) = do
+    :: AuthResult Auth.Token -> Document.DocumentCreate -> Handler Document
+postDocumentHandler (Authenticated token) Document.DocumentCreate {..} = do
     conn <- tryGetDBConnection
-    ifSuperOrAdminDo conn token groupID (postDocument conn)
+    ifSuperOrAdminDo conn token documentCreateGroupId (postDocument conn)
   where
     postDocument :: Connection -> Handler Document
     postDocument conn = do
-        eAction <- liftIO $ createDocument name groupID (Context conn)
+        eAction <-
+            liftIO $ createDocument documentCreateName documentCreateGroupId (Context conn)
         case eAction of
             Left _ -> throwError errDatabaseAccessFailed
             Right doc -> return doc
@@ -192,19 +190,19 @@ getCommitHandler _ _ _ = throwError errNotLoggedIn
 getAllExternalUsersDocumentHandler
     :: AuthResult Auth.Token
     -> Document.DocumentID
-    -> Handler [(User.UserID, Permission.DocPermission)]
+    -> Handler [Permission.UsersPermission]
 getAllExternalUsersDocumentHandler (Authenticated token) docID = do
     conn <- tryGetDBConnection
     groupID <- getGroupOfDocument conn docID
     ifSuperOrAdminDo conn token groupID (getUsers conn)
   where
-    getUsers :: Connection -> Handler [(User.UserID, Permission.DocPermission)]
+    getUsers :: Connection -> Handler [Permission.UsersPermission]
     getUsers conn = do
         eUserlist <-
             liftIO $ Session.run (Sessions.getAllExternalUsersOfDocument docID) conn
         case eUserlist of
             Left _ -> throwError errDatabaseAccessFailed
-            Right userList -> return userList
+            Right userList -> return $ uncurry Permission.UsersPermission <$> userList
 getAllExternalUsersDocumentHandler _ _ = throwError errNotLoggedIn
 
 getExternalUserDocumentHandler
@@ -229,10 +227,9 @@ getExternalUserDocumentHandler _ _ _ = throwError errNotLoggedIn
 putExternalUserDocumentHandler
     :: AuthResult Auth.Token
     -> Document.DocumentID
-    -> User.UserID
-    -> Permission.DocPermission
+    -> Permission.UsersPermission
     -> Handler NoContent
-putExternalUserDocumentHandler (Authenticated token) docID userID perm = do
+putExternalUserDocumentHandler (Authenticated token) docID Permission.UsersPermission {..} = do
     conn <- tryGetDBConnection
     groupID <- getGroupOfDocument conn docID
     ifSuperOrAdminDo conn token groupID (postUser conn)
@@ -245,18 +242,18 @@ putExternalUserDocumentHandler (Authenticated token) docID userID perm = do
             Left _ -> throwError errDatabaseAccessFailed
             Right Nothing -> do
                 eAction <-
-                    liftIO $ Session.run (Sessions.addExternalDocPermission userID docID perm) conn
+                    liftIO $ Session.run (Sessions.addExternalDocPermission userID docID permission) conn
                 case eAction of
                     Left _ -> throwError errDatabaseAccessFailed
                     Right _ -> return NoContent
             Right (Just _) -> do
                 eAction <-
                     liftIO $
-                        Session.run (Sessions.updateExternalDocPermission userID docID perm) conn
+                        Session.run (Sessions.updateExternalDocPermission userID docID permission) conn
                 case eAction of
                     Left _ -> throwError errDatabaseAccessFailed
                     Right _ -> return NoContent
-putExternalUserDocumentHandler _ _ _ _ = throwError errNotLoggedIn
+putExternalUserDocumentHandler _ _ _ = throwError errNotLoggedIn
 
 deleteExternalUserDocumentHandler
     :: AuthResult Auth.Token

--- a/backend/src/Server/Handlers/DocumentHandlers.hs
+++ b/backend/src/Server/Handlers/DocumentHandlers.hs
@@ -242,7 +242,8 @@ putExternalUserDocumentHandler (Authenticated token) docID Permission.UsersPermi
             Left _ -> throwError errDatabaseAccessFailed
             Right Nothing -> do
                 eAction <-
-                    liftIO $ Session.run (Sessions.addExternalDocPermission userID docID permission) conn
+                    liftIO $
+                        Session.run (Sessions.addExternalDocPermission userID docID permission) conn
                 case eAction of
                     Left _ -> throwError errDatabaseAccessFailed
                     Right _ -> return NoContent

--- a/backend/src/Server/Handlers/UserHandlers.hs
+++ b/backend/src/Server/Handlers/UserHandlers.hs
@@ -138,7 +138,7 @@ getUserHandler (Authenticated Auth.Token {..}) requestedUserID = do
                             case eAction' of
                                 Left _ -> throwError errDatabaseAccessFailed
                                 Right roles ->
-                                    let roles' = [(group, role) | (group, Just role) <- roles]
+                                    let roles' = [User.GroupRole group role | (group, Just role) <- roles]
                                      in return $ User.FullUser requestedUserID userName userEmail isSuper roles'
         else
             throwError errSuperAdminOnly

--- a/backend/src/UserManagement/DocumentPermission.hs
+++ b/backend/src/UserManagement/DocumentPermission.hs
@@ -10,6 +10,7 @@ module UserManagement.DocumentPermission
     , hasPermission
     , permissionToText
     , textToPermission
+    , UsersPermission (..)
     ) where
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -17,6 +18,7 @@ import Data.OpenApi (ToSchema)
 import Data.Text (Text, pack, unpack)
 import GHC.Generics (Generic)
 import Text.Read (readMaybe)
+import UserManagement.User as User (UserID)
 
 data DocPermission = Reader | Reviewer | Editor
     deriving (Eq, Generic)
@@ -60,3 +62,13 @@ permissionToText = pack . show
 
 textToPermission :: Text -> Maybe DocPermission
 textToPermission = readMaybe . unpack
+
+data UsersPermission = UsersPermission
+    { userID :: User.UserID
+    , permission :: DocPermission
+    }
+    deriving (Generic)
+
+instance ToJSON UsersPermission
+instance FromJSON UsersPermission
+instance ToSchema UsersPermission

--- a/backend/src/UserManagement/User.hs
+++ b/backend/src/UserManagement/User.hs
@@ -7,6 +7,7 @@ module UserManagement.User
     ( User (..)
     , UserCreate (..)
     , FullUser (..)
+    , GroupRole (..)
     , UserInfo (..)
     , Role (..)
     , UserID
@@ -50,12 +51,20 @@ data FullUser = FullUser
     , fullUserName :: Text
     , fullUserEmail :: Text
     , fullUserIsSuperadmin :: Bool
-    , fullUserRoles :: [(GroupID, Role)]
+    , fullUserRoles :: [GroupRole]
     }
-    deriving (Show, Generic)
+    deriving (Generic)
+
+data GroupRole = GroupRole
+    { groupID :: GroupID
+    , role :: Role
+    }
+    deriving (Generic)
+
+instance ToJSON GroupRole
+instance ToSchema GroupRole
 
 instance ToJSON FullUser
-instance FromJSON FullUser
 instance ToSchema FullUser
 
 -- | used for necessary user info inside a group


### PR DESCRIPTION
I wrapped all API exposed tuple types into their own data type. This ensures a precise swagger documentation.
This effects: 
- `POST /documents`
- `FullUser` data type (e.g. in `GET /users/{userID}`)
- `GET /documents/{docID}/external`

I also moved `PUT /documents/{docID}/external/{userID}` to `PUT /documents/{docID}/external` and captured the `userID` via the request body.

In addition i fixed a small bug in the `createDocument` statement.