### PR TITLE
Added endpoint to set new user password

### DIFF
--- a/backend/src/Server/Handlers/UserHandlers.hs
+++ b/backend/src/Server/Handlers/UserHandlers.hs
@@ -14,6 +14,7 @@ module Server.Handlers.UserHandlers
 
 import Control.Monad.IO.Class
 import Data.Password.Argon2
+import Data.Text ( Text )
 import DocumentManagement.Document as Document (Document)
 import Hasql.Connection (Connection)
 import qualified Hasql.Session as Session
@@ -31,13 +32,17 @@ type UserAPI =
         :> "register"
         :> ReqBody '[JSON] Auth.UserRegisterData
         :> Post '[JSON] NoContent
-        :<|> Auth AuthMethod Auth.Token
-            :> "me"
-            :> Get '[JSON] User.FullUser
-        :<|> Auth AuthMethod Auth.Token
-            :> "me"
-            :> "documents"
-            :> Get '[JSON] [Document]
+        :<|> "me"
+            :> ( Auth AuthMethod Auth.Token
+                :> Get '[JSON] User.FullUser
+            :<|> Auth AuthMethod Auth.Token
+                :> "documents"
+                :> Get '[JSON] [Document]
+            :<|> Auth AuthMethod Auth.Token
+                :> "reset-password"
+                :> ReqBody '[JSON] Text
+                :> Patch '[JSON] NoContent
+               )
         :<|> "users"
             :> ( Auth AuthMethod Auth.Token
                     :> Get '[JSON] [User.User]
@@ -56,8 +61,9 @@ type UserAPI =
 userServer :: Server UserAPI
 userServer =
     registerHandler
-        :<|> meHandler
+        :<|> (meHandler
         :<|> getMyDocumentsHandler
+        :<|> updateMyPasswordHandler)
         :<|> getAllUsersHandler
         :<|> getUserHandler
         :<|> deleteUserHandler
@@ -108,6 +114,16 @@ getMyDocumentsHandler (Authenticated Auth.Token {..}) = do
         Left _ -> throwError errDatabaseAccessFailed
         Right list -> return list
 getMyDocumentsHandler _ = throwError errNotLoggedIn
+
+updateMyPasswordHandler :: AuthResult Auth.Token -> Text -> Handler NoContent
+updateMyPasswordHandler (Authenticated Auth.Token {..}) newPassword = do
+    conn <- tryGetDBConnection
+    PasswordHash hashedText <- liftIO $ hashPassword $ mkPassword newPassword
+    eAction <- liftIO $ Session.run (Sessions.updateUserPWHash subject hashedText) conn
+    case eAction of
+        Left _ -> throwError errDatabaseAccessFailed
+        Right _ -> return NoContent
+updateMyPasswordHandler _ _ = throwError errNotLoggedIn
 
 -- | Returns a list of all users to anyone thats logged in.
 getAllUsersHandler :: AuthResult Auth.Token -> Handler [User.User]

--- a/backend/src/Server/Handlers/UserHandlers.hs
+++ b/backend/src/Server/Handlers/UserHandlers.hs
@@ -14,7 +14,7 @@ module Server.Handlers.UserHandlers
 
 import Control.Monad.IO.Class
 import Data.Password.Argon2
-import Data.Text ( Text )
+import Data.Text (Text)
 import DocumentManagement.Document as Document (Document)
 import Hasql.Connection (Connection)
 import qualified Hasql.Session as Session
@@ -34,14 +34,14 @@ type UserAPI =
         :> Post '[JSON] NoContent
         :<|> "me"
             :> ( Auth AuthMethod Auth.Token
-                :> Get '[JSON] User.FullUser
-            :<|> Auth AuthMethod Auth.Token
-                :> "documents"
-                :> Get '[JSON] [Document]
-            :<|> Auth AuthMethod Auth.Token
-                :> "reset-password"
-                :> ReqBody '[JSON] Text
-                :> Patch '[JSON] NoContent
+                    :> Get '[JSON] User.FullUser
+                    :<|> Auth AuthMethod Auth.Token
+                        :> "documents"
+                        :> Get '[JSON] [Document]
+                    :<|> Auth AuthMethod Auth.Token
+                        :> "reset-password"
+                        :> ReqBody '[JSON] Text
+                        :> Patch '[JSON] NoContent
                )
         :<|> "users"
             :> ( Auth AuthMethod Auth.Token
@@ -61,9 +61,10 @@ type UserAPI =
 userServer :: Server UserAPI
 userServer =
     registerHandler
-        :<|> (meHandler
-        :<|> getMyDocumentsHandler
-        :<|> updateMyPasswordHandler)
+        :<|> ( meHandler
+                :<|> getMyDocumentsHandler
+                :<|> updateMyPasswordHandler
+             )
         :<|> getAllUsersHandler
         :<|> getUserHandler
         :<|> deleteUserHandler
@@ -119,7 +120,8 @@ updateMyPasswordHandler :: AuthResult Auth.Token -> Text -> Handler NoContent
 updateMyPasswordHandler (Authenticated Auth.Token {..}) newPassword = do
     conn <- tryGetDBConnection
     PasswordHash hashedText <- liftIO $ hashPassword $ mkPassword newPassword
-    eAction <- liftIO $ Session.run (Sessions.updateUserPWHash subject hashedText) conn
+    eAction <-
+        liftIO $ Session.run (Sessions.updateUserPWHash subject hashedText) conn
     case eAction of
         Left _ -> throwError errDatabaseAccessFailed
         Right _ -> return NoContent


### PR DESCRIPTION
New endpoint to set the user password. Can only be done by the user themselves via `/me/reset-password`. Currently the backend does not check if the password is "secure" enough and just sets it. This may require some tuning in the future, but will at least give the option to set the password for now.