### PR TITLE
api: added `/users/{userID}/documents` endpoint

### DIFF
--- a/backend/src/Server/HandlerUtil.hs
+++ b/backend/src/Server/HandlerUtil.hs
@@ -85,7 +85,7 @@ addRoleInGroup conn userID groupID role = do
         Left _ -> throwError errFailedToSetRole
 
 -- | Check if User is Member (or Admin) of the group that owns the specified document
---   or return external DocPermission. Members will always get `Edit` permission.
+--   or return external DocPermission. Members will always get `Editor` permission.
 -- Nothing            -> both paths failed (no permission)
 -- Just DocPermission -> User has given access rights
 checkDocPermission

--- a/backend/src/Server/HandlerUtil.hs
+++ b/backend/src/Server/HandlerUtil.hs
@@ -3,7 +3,7 @@
 
 module Server.HandlerUtil
     ( ifSuperOrAdminDo
-    , ifGroupMemberDo
+    , ifSuperOrGroupMemberDo
     , tryGetDBConnection
     , addRoleInGroup
     , checkDocPermission
@@ -52,17 +52,20 @@ ifSuperOrAdminDo conn (Auth.Token {..}) groupID callback =
                         else
                             throwError errNoAdminOfThisGroup
 
--- | Checks if user is Member (or Admin) in specified group.
+-- | Checks if user is Member (or Admin) in specified group or Superadmin.
 --   If so, it calls the given callback Handler;
 -- Otherwise, it throws a 403 error.
-ifGroupMemberDo
+ifSuperOrGroupMemberDo
     :: Connection -> Auth.Token -> Group.GroupID -> Handler a -> Handler a
-ifGroupMemberDo conn (Auth.Token {..}) groupID callback = do
-    eMembership <- liftIO $ run (Sessions.checkGroupMembership subject groupID) conn
-    case eMembership of
-        Left _ -> throwError errDatabaseAccessFailed
-        Right False -> throwError errNoMemberOfThisGroup
-        Right True -> callback
+ifSuperOrGroupMemberDo conn (Auth.Token {..}) groupID callback = do
+    if isSuperadmin
+        then callback
+        else do
+            eMembership <- liftIO $ run (Sessions.checkGroupMembership subject groupID) conn
+            case eMembership of
+                Left _ -> throwError errDatabaseAccessFailed
+                Right False -> throwError errNoMemberOfThisGroup
+                Right True -> callback
 
 -- | Gets DB Connection and throws 500 error if it fails
 tryGetDBConnection :: Handler Connection

--- a/backend/src/Server/Handlers/GroupHandlers.hs
+++ b/backend/src/Server/Handlers/GroupHandlers.hs
@@ -140,7 +140,7 @@ getAllGroupDocumentsHandler
     :: AuthResult Auth.Token -> Group.GroupID -> Handler [Document.Document]
 getAllGroupDocumentsHandler (Authenticated token) groupID = do
     conn <- tryGetDBConnection
-    ifGroupMemberDo conn token groupID (getAllDocs conn)
+    ifSuperOrGroupMemberDo conn token groupID (getAllDocs conn)
   where
     getAllDocs :: Connection -> Handler [Document.Document]
     getAllDocs conn = do

--- a/backend/src/Server/Handlers/UserHandlers.hs
+++ b/backend/src/Server/Handlers/UserHandlers.hs
@@ -15,7 +15,7 @@ module Server.Handlers.UserHandlers
 import Control.Monad.IO.Class
 import Data.Password.Argon2
 import Data.Text (Text)
-import DocumentManagement.Document as Document (Document)
+import DocumentManagement.Document as Document
 import Hasql.Connection (Connection)
 import qualified Hasql.Session as Session
 import Servant
@@ -23,6 +23,7 @@ import Servant.Auth.Server
 import Server.Auth (AuthMethod)
 import qualified Server.Auth as Auth
 import Server.HandlerUtil
+import qualified UserManagement.DocumentPermission as Permission
 import qualified UserManagement.Sessions as Sessions
 import qualified UserManagement.User as User
 import Prelude hiding (readFile)
@@ -37,7 +38,7 @@ type UserAPI =
                     :> Get '[JSON] User.FullUser
                     :<|> Auth AuthMethod Auth.Token
                         :> "documents"
-                        :> Get '[JSON] [Document]
+                        :> Get '[JSON] [Permission.DocumentWithPermission]
                     :<|> Auth AuthMethod Auth.Token
                         :> "reset-password"
                         :> ReqBody '[JSON] Text
@@ -59,7 +60,7 @@ type UserAPI =
                     :<|> Auth AuthMethod Auth.Token
                         :> Capture "userId" User.UserID
                         :> "documents"
-                        :> Get '[JSON] [Document]
+                        :> Get '[JSON] [Permission.DocumentWithPermission]
                )
 
 userServer :: Server UserAPI
@@ -111,12 +112,15 @@ meHandler :: AuthResult Auth.Token -> Handler User.FullUser
 meHandler auth@(Authenticated Auth.Token {..}) = getUserHandler auth subject
 meHandler _ = throwError errNotLoggedIn
 
-getMyDocumentsHandler :: AuthResult Auth.Token -> Handler [Document]
+getMyDocumentsHandler
+    :: AuthResult Auth.Token -> Handler [Permission.DocumentWithPermission]
 getMyDocumentsHandler auth@(Authenticated Auth.Token {..}) = getUsersDocumentsHandler auth subject
 getMyDocumentsHandler _ = throwError errNotLoggedIn
 
 getUsersDocumentsHandler
-    :: AuthResult Auth.Token -> User.UserID -> Handler [Document]
+    :: AuthResult Auth.Token
+    -> User.UserID
+    -> Handler [Permission.DocumentWithPermission]
 getUsersDocumentsHandler (Authenticated Auth.Token {..}) requestedUserID = do
     if isSuperadmin || subject == requestedUserID
         then do
@@ -124,7 +128,17 @@ getUsersDocumentsHandler (Authenticated Auth.Token {..}) requestedUserID = do
             eList <- liftIO $ Session.run (Sessions.getAllVisibleDocuments subject) conn
             case eList of
                 Left _ -> throwError errDatabaseAccessFailed
-                Right list -> return list
+                Right docList -> do
+                    mapM
+                        ( \doc -> do
+                            mPerm <- checkDocPermission conn subject (Document.documentID doc)
+                            case mPerm of
+                                -- this should not happen, since the document is listed in visible documents,
+                                -- so the user should have atleast read permissions
+                                Nothing -> throwError errDatabaseAccessFailed
+                                Just perm -> return $ Permission.DocumentWithPermission perm doc
+                        )
+                        docList
         else throwError errSuperAdminOnly
 getUsersDocumentsHandler _ _ = throwError errNotLoggedIn
 

--- a/backend/src/UserManagement/DocumentPermission.hs
+++ b/backend/src/UserManagement/DocumentPermission.hs
@@ -11,11 +11,13 @@ module UserManagement.DocumentPermission
     , permissionToText
     , textToPermission
     , UsersPermission (..)
+    , DocumentWithPermission (..)
     ) where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.OpenApi (ToSchema)
 import Data.Text (Text, pack, unpack)
+import DocumentManagement.Document as Document
 import GHC.Generics (Generic)
 import Text.Read (readMaybe)
 import UserManagement.User as User (UserID)
@@ -72,3 +74,12 @@ data UsersPermission = UsersPermission
 instance ToJSON UsersPermission
 instance FromJSON UsersPermission
 instance ToSchema UsersPermission
+
+data DocumentWithPermission = DocumentWithPermission
+    { documentPermission :: DocPermission
+    , document :: Document.Document
+    }
+    deriving (Generic)
+
+instance ToJSON DocumentWithPermission
+instance ToSchema DocumentWithPermission

--- a/backend/src/UserManagement/Statements.hs
+++ b/backend/src/UserManagement/Statements.hs
@@ -393,7 +393,7 @@ getAllVisibleDocuments =
             . toList
         )
         [vectorStatement|
-      (select 
+      (select
         d.id :: int4,
         d.name :: text,
         d.group_id :: int4,
@@ -402,13 +402,13 @@ getAllVisibleDocuments =
       join documents d on d.group_id = r.group_id
       where r.user_id = $1 :: uuid)
       union
-      (select 
+      (select
         d.id :: int4,
         d.name :: text,
         d.group_id :: int4,
         d.head :: int4?
       from documents d
-      join external_document_rights e on d.document_id = e.document_id
+      join external_document_rights e on d.id = e.document_id
       where e.user_id = $1 :: uuid)
     |]
 
@@ -426,7 +426,7 @@ getAllDocumentsOfGroup =
             . toList
         )
         [vectorStatement|
-      select 
+      select
         id :: int4,
         name :: text,
         group_id :: int4,


### PR DESCRIPTION
I generalized the `/me/documents` endpoint to `/users/{userID}/documents` and fixed a small bug in the database query for it. #205 
Those two endpoints also return the access permission for every returned document.

I also fixed the access for superadmins to `/groups/{groupID}/documents` for any group.