### PR TITLE
Disallow duplicate group names

### DIFF
--- a/backend/src/UserManagement/Sessions.hs
+++ b/backend/src/UserManagement/Sessions.hs
@@ -24,6 +24,7 @@ module UserManagement.Sessions
     , removeSuperadmin
     , checkSuperadmin
     , checkGroupDocPermission
+    , checkGroupNameExistence
     , getExternalDocPermission
     , getDocumentGroupID
     , getAllExternalUsersOfDocument
@@ -127,6 +128,9 @@ checkSuperadmin uid = statement uid Statements.checkSuperadmin
 
 checkGroupDocPermission :: User.UserID -> Document.DocumentID -> Session Bool
 checkGroupDocPermission uid did = statement (uid, did) Statements.checkGroupDocPermission
+
+checkGroupNameExistence :: Text -> Session Bool
+checkGroupNameExistence name = statement name Statements.checkGroupNameExistence
 
 getExternalDocPermission
     :: User.UserID -> Document.DocumentID -> Session (Maybe Permission.DocPermission)

--- a/backend/src/UserManagement/Statements.hs
+++ b/backend/src/UserManagement/Statements.hs
@@ -27,6 +27,7 @@ module UserManagement.Statements
     , removeSuperadmin
     , checkSuperadmin
     , checkGroupDocPermission
+    , checkGroupNameExistence
     , getExternalDocPermission
     , getDocumentGroupID
     , getAllExternalUsersOfDocument
@@ -306,6 +307,16 @@ checkGroupDocPermission =
                 from roles r
                 join documents d on d.group_id = r.group_id
                 where r.user_id = $1 :: uuid and d.id = $2 :: int4
+            ) :: bool
+        |]
+
+checkGroupNameExistence :: Statement Text Bool
+checkGroupNameExistence =
+    [singletonStatement|
+            select exists (
+                select 1
+                from groups
+                where name = $1 :: text
             ) :: bool
         |]
 


### PR DESCRIPTION
modified `/groups` such that `POST` requests dont allow for duplicate group names