### PR TITLE
backend/ltml: Fix greedy paragraph parser

### DIFF
--- a/backend/src/Language/Lsd/AST/SimpleRegex/Utils.hs
+++ b/backend/src/Language/Lsd/AST/SimpleRegex/Utils.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Language.Lsd.AST.SimpleRegex.Utils
+    ( Heads (..)
+    , mapWithSuccs
+    )
+where
+
+import Language.Lsd.AST.SimpleRegex
+    ( Disjunction (Disjunction)
+    , Sequence (Sequence)
+    , SimpleRegex (SimpleRegex)
+    , Star (Star)
+    )
+
+-- | The possible first tokens of a regex.  The boolean flag signifies whether
+--   the regex accepts the empty input (is nullable).
+--   Notably also used for the successors of a leaf in a regex.
+data Heads a = Heads
+    { nHeads :: Bool
+    , rHeads :: [a]
+    }
+
+unpack :: Heads a -> (Bool, [a])
+unpack (Heads b xs) = (b, xs)
+
+-- (<>) corresponds to concatenation of the regexes.
+-- I.e., 'heads x <> heads y = heads (x <> y)' (pretending that our regexes
+-- can be concatenated via '<>').
+instance Semigroup (Heads a) where
+    Heads True xs <> Heads b ys = Heads b (xs ++ ys)
+    succs@(Heads False _) <> _ = succs
+
+instance Monoid (Heads a) where
+    mempty = Heads True []
+
+class GetHeads a fa where
+    heads :: fa -> Heads a
+
+class (GetHeads a fa) => MapWithSuccs a b fa fb where
+    mapWithSuccs' :: (a -> Heads a -> b) -> Heads a -> fa -> fb
+
+mapWithSuccs
+    :: (MapWithSuccs a b fa fb)
+    => (a -> Heads a -> b)
+    -> fa
+    -> fb
+mapWithSuccs f = mapWithSuccs' f mempty
+
+instance GetHeads a a where
+    heads x = Heads False [x]
+
+instance MapWithSuccs a b a b where
+    mapWithSuccs' f succs x = f x succs
+
+instance (GetHeads a fa) => GetHeads a (Star fa) where
+    heads (Star x) = Heads True (rHeads $ heads x)
+
+instance
+    (MapWithSuccs a b fa fb)
+    => MapWithSuccs a b (Star fa) (Star fb)
+    where
+    mapWithSuccs' f succs (Star x) = Star $ mapWithSuccs' f succs' x
+      where
+        succs' = Heads True $ rHeads (heads x) ++ rHeads succs
+
+instance (GetHeads a fa) => GetHeads a (Disjunction fa) where
+    heads (Disjunction xs) = f $ map heads xs
+      where
+        f :: [Heads a] -> Heads a
+        f zss = Heads (or as) (concat bs)
+          where
+            (as, bs) = unzip $ fmap unpack zss
+
+instance
+    (MapWithSuccs a b fa fb)
+    => MapWithSuccs a b (Disjunction fa) (Disjunction fb)
+    where
+    mapWithSuccs' f succs (Disjunction xs) =
+        Disjunction $ map (mapWithSuccs' f succs) xs
+
+instance (GetHeads a fa) => GetHeads a (Sequence fa) where
+    heads (Sequence xs) = mconcat $ map heads xs
+
+instance
+    (MapWithSuccs a b fa fb)
+    => MapWithSuccs a b (Sequence fa) (Sequence fb)
+    where
+    mapWithSuccs' f succs (Sequence xs) = Sequence (g xs)
+      where
+        g :: [fa] -> [fb]
+        g = snd . foldr h (succs, [])
+          where
+            h :: fa -> (Heads a, [fb]) -> (Heads a, [fb])
+            h x (succs', ys) =
+                (heads x <> succs', mapWithSuccs' f succs' x : ys)
+
+instance GetHeads a (SimpleRegex a) where
+    heads (SimpleRegex prefix middle suffix) =
+        heads prefix <> heads middle <> heads suffix
+
+instance MapWithSuccs a b (SimpleRegex a) (SimpleRegex b) where
+    mapWithSuccs' f succs (SimpleRegex prefix middle suffix) =
+        SimpleRegex prefix' middle' suffix'
+      where
+        prefix' = mapWithSuccs' f succsPrefix prefix
+        middle' = mapWithSuccs' f succsMiddle middle
+        suffix' = mapWithSuccs' f succsSuffix suffix
+
+        succsPrefix = heads middle <> succsMiddle
+        succsMiddle = heads suffix <> succsSuffix
+        succsSuffix = succs

--- a/backend/src/Language/Ltml/Parser/Common/SimpleRegex.hs
+++ b/backend/src/Language/Ltml/Parser/Common/SimpleRegex.hs
@@ -12,30 +12,39 @@ import Language.Lsd.AST.SimpleRegex
     , SimpleRegex (SimpleRegex)
     , Star (Star)
     )
+import Language.Lsd.AST.SimpleRegex.Utils (Heads, mapWithSuccs)
 import Language.Ltml.Parser (MonadParser)
 import Text.Megaparsec (many)
 
-simpleRegexP :: (MonadParser m) => (t -> m a) -> SimpleRegex t -> m [a]
-simpleRegexP f (SimpleRegex prefix middle suffix) =
+-- | Parse input according to a 'SimpleRegex', taking into account not only
+--   the respective types, but also the respective possible successors.
+simpleRegexP
+    :: (MonadParser m)
+    => (t -> Heads t -> m a)
+    -> SimpleRegex t
+    -> m [a]
+simpleRegexP f sre =
     concat
         <$> sequence
-            [ sequenceP f prefix
-            , middleP f middle
-            , sequenceP f suffix
+            [ sequenceP id prefix
+            , middleP id middle
+            , sequenceP id suffix
             ]
+  where
+    SimpleRegex prefix middle suffix = mapWithSuccs f sre
 
-starP :: (MonadParser m) => (t -> m a) -> Star t -> m [a]
-starP f (Star t) = many $ f t
+starP :: (MonadParser m) => (a -> m b) -> Star a -> m [b]
+starP f (Star x) = many $ f x
 
-disjunctionP :: (MonadParser m) => (t -> m a) -> Disjunction t -> m a
-disjunctionP f (Disjunction ts) = choice (fmap f ts)
+disjunctionP :: (MonadParser m) => (a -> m b) -> Disjunction a -> m b
+disjunctionP f (Disjunction xs) = choice (fmap f xs)
 
-sequenceP :: (MonadParser m) => (t -> m a) -> Sequence t -> m [a]
-sequenceP f (Sequence ts) = mapM f ts
+sequenceP :: (MonadParser m) => (a -> m b) -> Sequence a -> m [b]
+sequenceP f (Sequence xs) = mapM f xs
 
 middleP
     :: (MonadParser m)
-    => (t -> m a)
-    -> Disjunction (Star (Disjunction t))
-    -> m [a]
+    => (a -> m b)
+    -> Disjunction (Star (Disjunction a))
+    -> m [b]
 middleP = disjunctionP . starP . disjunctionP

--- a/backend/src/Language/Ltml/Parser/Section.hs
+++ b/backend/src/Language/Ltml/Parser/Section.hs
@@ -3,9 +3,13 @@ module Language.Ltml.Parser.Section
     )
 where
 
+import Control.Alternative.Utils (whenAlt)
+import Control.Applicative ((<|>))
+import Control.Monad (void)
 import Data.Bitraversable (bitraverse)
 import Language.Lsd.AST.Common (Keyword)
 import Language.Lsd.AST.SimpleRegex (SimpleRegex)
+import Language.Lsd.AST.SimpleRegex.Utils (Heads (Heads))
 import Language.Lsd.AST.Type.Paragraph (ParagraphType)
 import Language.Lsd.AST.Type.Section
     ( HeadingType (HeadingType)
@@ -21,21 +25,31 @@ import Language.Ltml.AST.Section
 import Language.Ltml.Parser (Parser, nonIndented)
 import Language.Ltml.Parser.Common.Lexeme (nLexeme)
 import Language.Ltml.Parser.Common.SimpleRegex (simpleRegexP)
+import Language.Ltml.Parser.Keyword (keywordP)
 import Language.Ltml.Parser.Paragraph (paragraphP)
 import Language.Ltml.Parser.Text (hangingTextP')
-import Text.Megaparsec (many)
+import Text.Megaparsec (choice, many)
 
-sectionP :: SectionType -> Parser (Node Section)
-sectionP (SectionType kw headingT fmt childrenT) = do
+sectionP :: SectionType -> Parser () -> Parser (Node Section)
+sectionP (SectionType kw headingT fmt childrenT) succStartP = do
     (mLabel, heading) <- nonIndented $ headingP kw headingT
     Node mLabel . Section fmt heading
         <$> nonIndented (bitraverse parsP secsP childrenT)
   where
     parsP :: ParagraphType -> Parser [Node Paragraph]
-    parsP t = many $ nLexeme $ paragraphP t
+    parsP t = many $ nLexeme $ paragraphP t succStartP
 
     secsP :: SimpleRegex SectionType -> Parser [Node Section]
-    secsP = simpleRegexP sectionP
+    secsP = simpleRegexP sectionP'
+      where
+        sectionP' t succs = sectionP t (f succs)
+          where
+            f (Heads nullableSuccs rSuccs) =
+                choice (map toStartP rSuccs)
+                    <|> whenAlt nullableSuccs succStartP
+
+toStartP :: SectionType -> Parser ()
+toStartP (SectionType kw _ _ _) = void $ keywordP kw
 
 headingP :: Keyword -> HeadingType -> Parser (Maybe Label, Heading)
 headingP kw (HeadingType fmt tt) =


### PR DESCRIPTION
The paragraph parser previously would also consume what should actually be subsequent sections.

It now gets passed a parser to check for the start of a new section.

This necessitated quite some work on the SimpleRegex (we need to know all possible successor section types).  We are now actually approximately halfway to a full (simple, DFA-style) regex parser.  Thus, we might reconsider limiting the regexes to "simple regexes".

fixes: #222