### PR TITLE
backend/ltml: Insert Enumeration node

### DIFF
--- a/backend/src/Language/Ltml/AST/Text.hs
+++ b/backend/src/Language/Ltml/AST/Text.hs
@@ -8,6 +8,7 @@ module Language.Ltml.AST.Text
     , RichTextTree
     , ParagraphTextTree
     , FontStyle (..)
+    , Enumeration (..)
     , EnumItem (..)
     , SentenceStart (..)
     )
@@ -18,13 +19,13 @@ import Data.Text.FromWhitespace (FromWhitespace, fromWhitespace)
 import Data.Void (Void)
 import Language.Ltml.AST.Label (Label)
 
-data TextTree style enumItem special
+data TextTree style enum special
     = Word Text
     | Space
     | Special special
     | Reference Label
-    | Styled style [TextTree style enumItem special]
-    | EnumChild enumItem
+    | Styled style [TextTree style enum special]
+    | Enum enum
     | Footnote [FootnoteTextTree]
     deriving (Show)
 
@@ -36,14 +37,17 @@ type PlainTextTree = TextTree Void Void Void
 
 type FootnoteTextTree = TextTree FontStyle Void Void
 
-type RichTextTree = TextTree FontStyle EnumItem Void
+type RichTextTree = TextTree FontStyle Enumeration Void
 
-type ParagraphTextTree = TextTree FontStyle EnumItem SentenceStart
+type ParagraphTextTree = TextTree FontStyle Enumeration SentenceStart
 
 data FontStyle
     = Bold
     | Italics
     | Underlined
+    deriving (Show)
+
+newtype Enumeration = Enumeration [EnumItem]
     deriving (Show)
 
 newtype EnumItem = EnumItem [RichTextTree]

--- a/backend/src/Language/Ltml/Parser.hs
+++ b/backend/src/Language/Ltml/Parser.hs
@@ -11,6 +11,7 @@ module Language.Ltml.Parser
     , nli
     , nextIndentLevel
     , nonIndented
+    , someIndented
     , checkIndent
     , eoi
     )
@@ -27,6 +28,7 @@ import Text.Megaparsec
     , Pos
     , eof
     , mkPos
+    , sepBy1
     , takeWhile1P
     , takeWhileP
     , (<?>)
@@ -72,6 +74,13 @@ nli =
 --   similar.
 nonIndented :: (MonadParser m) => m a -> m a
 nonIndented p = sp *> (eof <|> checkIndent pos1) *> p
+
+-- | Parse some (>= 1) indented items, all with the same indentation level.
+--   Unlike 'nonIndented', this assumes that no indentation remains to parse
+--   at the start, and that its argument parser consumes any trailing
+--   indentation.
+someIndented :: (MonadParser m) => m a -> m [a]
+someIndented p = L.indentLevel >>= (\lvl -> p `sepBy1` checkIndent lvl)
 
 -- | Check whether the current actual indentation matches the current required
 --   indentation level.


### PR DESCRIPTION
Previously, there were just enumeration items, as part of text.  Now, text may contain enumerations, which in turn contain enumeration items.

Note that this breaks the desired requirement that a sentence does not contain more than one enumeration.
I.e., we can build ASTs that are illegal w.r.t. this requirement. This requirement was previously enforced implicitly---by the interpretation of the AST.
(Other illegal AST constructions existed previously and remain.)

If this requirement is to remain, we probably want to generate an error (or maybe rather a warning) by/upon walking the AST.

See also: #156