### PR TITLE
Improve html structure of groups page

### DIFF
--- a/frontend/src/FPO/Components/Modals/DeleteModal.purs
+++ b/frontend/src/FPO/Components/Modals/DeleteModal.purs
@@ -4,6 +4,7 @@ module FPO.Components.Modals.DeleteModal
 
 import Prelude
 
+import Data.Array (singleton)
 import FPO.Page.HTML (addModal)
 import FPO.Translations.Labels (Labels)
 import Halogen.HTML as HH
@@ -47,13 +48,14 @@ deleteConfirmationModal
   addModal "Confirm Delete" (const cancelAction) $
     [ HH.div
         [ HP.classes [ HB.modalBody ] ]
-        [ HH.text
-            ( translate (label :: _ "common_deletePhraseA") translator
-                <> objectTypeName
-                <> " "
-                <> toObjectName objectIdentifier
-                <> translate (label :: _ "common_deletePhraseB") translator
-            )
+        [ HH.text $
+            translate (label :: _ "common_deletePhraseA") translator
+              <> objectTypeName
+              <> " "
+        , HH.i_ $ singleton $ HH.text $
+            toObjectName objectIdentifier
+        , HH.text $
+            translate (label :: _ "common_deletePhraseB") translator
         ]
     , HH.div
         [ HP.classes [ HB.modalFooter ] ]

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -46,7 +46,14 @@ import FPO.Dto.CreateUserDto
 import FPO.Dto.CreateUserDto as CreateUserDto
 import FPO.Dto.UserOverviewDto (UserOverviewDto)
 import FPO.Dto.UserOverviewDto as UserOverviewDto
-import FPO.Page.HTML (addButton, addCard, addColumn, deleteButton, emptyEntryText)
+import FPO.Page.HTML
+  ( addButton
+  , addCard
+  , addColumn
+  , addError
+  , deleteButton
+  , emptyEntryText
+  )
 import FPO.Translations.Labels (Labels)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
@@ -142,20 +149,12 @@ component =
       ]
       [ renderDeleteModal state
       , renderUserManagement state
-      , case state.error of
-          Just err -> HH.div
-            [ HP.classes [ HB.alert, HB.alertDanger, HB.textCenter, HB.mt5 ] ]
-            [ HH.text err ]
-          Nothing -> HH.text ""
+      , addError state.error
       ]
 
   handleAction :: Action -> H.HalogenM State Action Slots output m Unit
   handleAction = case _ of
     Initialize -> do
-      -- TODO: Usually, we would fetch some data here (and handle
-      --       the error of missing credentials), but for now,
-      --       we just check if the user is an admin and redirect
-      --       to a 404 page if not.
       u <- H.liftAff $ getUser
       when (fromMaybe true (not <$> _.isAdmin <$> u)) $ navigate Page404
       fetchAndLoadUsers

--- a/frontend/src/FPO/Page/HTML.purs
+++ b/frontend/src/FPO/Page/HTML.purs
@@ -1,5 +1,5 @@
 -- | This module contains some HTML helpers and goodies for the FPO app,
--- | useful for creating and reusing HTML components.
+-- | useful for creating and reusing HTML components and pages.
 
 module FPO.Page.HTML where
 
@@ -113,7 +113,7 @@ addCard
   -> HH.HTML w i
 addCard title e content =
   HH.div e
-    [ HH.div [ HP.classes [ HB.card ] ]
+    [ HH.div ([ HP.classes [ HB.card ] ])
         [ HH.h5 [ HP.classes [ HB.cardHeader ] ]
             [ HH.text title ]
         , content `addClass` HB.cardBody
@@ -135,7 +135,6 @@ addModal title cancelAction content =
         , HP.attr (HH.AttrName "data-bs-backdrop") "static"
         , HP.attr (HH.AttrName "data-bs-keyboard") "false"
         , HP.attr (HH.AttrName "tabindex") "-1"
-        -- , HP.attr (HH.AttrName "aria-labelledby") "deleteModalLabel"
         , HP.attr (HH.AttrName "aria-hidden") "false"
         , HP.style "display: block;"
         ]
@@ -148,7 +147,6 @@ addModal title cancelAction content =
                       [ HH.h1
                           [ HP.classes
                               [ HH.ClassName "modal-title", HH.ClassName "fs-5" ]
-                          -- , HP.id "deleteModalLabel"
                           ]
                           [ HH.text title ]
                       , HH.button
@@ -173,6 +171,7 @@ addModal title cancelAction content =
         []
     ]
 
+-- | Creates a delete button with an icon.
 deleteButton :: forall w a. (MouseEvent -> a) -> HH.HTML w a
 deleteButton action =
   HH.button
@@ -196,4 +195,18 @@ emptyEntryGen content =
   HH.li [ HP.classes [ HB.listGroupItem ] ]
     [ HH.div [ HP.classes [ HB.textCenter, HB.invisible ] ]
         content
+    ]
+
+-- | Adds an error message to the page.
+addError
+  :: forall w i
+   . Maybe String -- ^ error message
+  -> HH.HTML w i
+addError msg =
+  HH.div [ HP.classes [ HB.textCenter ] ]
+    [ case msg of
+        Just err -> HH.div
+          [ HP.classes [ HB.alert, HB.alertDanger, HB.mt5 ] ]
+          [ HH.text err ]
+        Nothing -> HH.text ""
     ]


### PR DESCRIPTION
The groups page should now respond much better to horizontal screen resizing. For example, if the screen is too narrow, the cards are aligned vertically, and the cards should not grow indefinitely when widening the screen.

Also, names in deletion modals are now _italic_.

See also #139 