### PR TITLE
Load correct project when navigating from Home

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -42,6 +42,7 @@
             "simple-i18n",
             "strings",
             "tailrec",
+            "transformers",
             "tuples",
             "unsafe-coerce",
             "web-dom",

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -38,6 +38,7 @@ package:
     - simple-i18n
     - strings
     - tailrec
+    - transformers
     - tuples
     - unsafe-coerce
     - web-dom

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -89,8 +89,10 @@ navbar = connect (selectEq identity) $ H.mkComponent
                           (translate (label :: _ "common_home") state.translator)
                           Home
                       ]
+                  -- TODO: This doesn't make sense anymore and should be removed.
+                  --       We keep this for convenience for now.
                   , HH.li [ HP.classes [ HB.navItem ] ]
-                      [ navButton "Editor" Editor ]
+                      [ navButton "Editor" (Editor { docID: 1 }) ]
                   ]
                     <>
                       if (maybe false _.isAdmin state.user) then

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -186,14 +186,16 @@ splitview docID = H.mkComponent
       , toolbarButton "Save" SaveSection
       , toolbarButton "Query Editor" QueryEditor
       , toolbarButton "Load PDF" ClickLoadPdf
-      , toolbarButton ((if state.pdfWarningIsShown then "Hide" else "Show") <> " Warning") ShowWarning
+      , toolbarButton
+          ((if state.pdfWarningIsShown then "Hide" else "Show") <> " Warning")
+          ShowWarning
       ]
     where
-      toolbarButton label act = HH.button
-        [ HP.classes [ HB.btn, HB.btnSuccess, HB.btnSm ]
-        , HE.onClick $ const act
-        ]
-        [ HH.text label ]
+    toolbarButton label act = HH.button
+      [ HP.classes [ HB.btn, HB.btnSuccess, HB.btnSm ]
+      , HE.onClick $ const act
+      ]
+      [ HH.text label ]
 
   renderSplit :: State -> H.ComponentHTML Action Slots m
   renderSplit state =
@@ -470,6 +472,8 @@ splitview docID = H.mkComponent
         st { tocEntries = Empty, mTimeFormatter = timeFormatter }
       H.tell _comment unit (Comment.ReceiveTimeFormatter timeFormatter)
       H.tell _toc unit (TOC.ReceiveTOCs Empty)
+      -- Load the initial TOC entries into the editor
+      handleAction GET
 
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -24,11 +24,7 @@ import Effect.Aff as Exn
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
-{- import FPO.Data.JSON
-( decodeDocument
-, decodeDocumentWithPermission
-) -}
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission)
+import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID)
 import FPO.Dto.GroupDto (GroupCreate, GroupOverview)
 import FPO.Dto.UserDto (User, decodeUser)
 import Foreign (renderForeignError)
@@ -99,6 +95,10 @@ getUser = getFromJSONEndpoint decodeUser "/me"
 -- | Fetches the groups of the current user from the server.
 getGroups :: Aff (Maybe (Array GroupOverview))
 getGroups = getFromJSONEndpoint (decodeArray decodeJson) "/groups"
+
+-- | Fetches the document header for a given document ID.
+getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
+getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)
 
 getDocumentsFromURL :: String -> Aff (Maybe (Array DocumentHeader))
 getDocumentsFromURL url = getFromJSONEndpoint (decodeArray decodeJson) url

--- a/frontend/src/FPO/Data/Route.purs
+++ b/frontend/src/FPO/Data/Route.purs
@@ -6,6 +6,7 @@ import Prelude hiding ((/))
 
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(Nothing), fromMaybe)
+import FPO.Dto.DocumentDto (DocumentID)
 import Routing.Duplex (RouteDuplex', boolean, int, optional, root, segment)
 import Routing.Duplex.Generic (noArgs, sum)
 import Routing.Duplex.Generic.Syntax ((/), (?))
@@ -13,7 +14,7 @@ import Routing.Duplex.Generic.Syntax ((/), (?))
 -- | Represents all available routes in the application.
 data Route
   = Home
-  | Editor
+  | Editor { docID :: DocumentID }
   | Login
   | PasswordReset
   | AdminViewUsers
@@ -30,7 +31,7 @@ derive instance ordRoute :: Ord Route
 routeCodec :: RouteDuplex' Route
 routeCodec = root $ sum
   { "Home": noArgs
-  , "Editor": "editor" / noArgs
+  , "Editor": "editor" ? { docID: int }
   , "Login": "login" / noArgs
   , "PasswordReset": "password-reset" / noArgs
   , "AdminViewUsers": "admin-users" / noArgs
@@ -45,7 +46,7 @@ routeCodec = root $ sum
 routeToString :: Route -> String
 routeToString = case _ of
   Home -> "Home"
-  Editor -> "Editor"
+  Editor docID -> "Editor:" <> show docID
   Login -> "Login"
   PasswordReset -> "PasswordReset"
   AdminViewUsers -> "AdminViewUsers"

--- a/frontend/src/FPO/Dto/DocumentDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto.purs
@@ -18,8 +18,11 @@ newtype NodeWithRef = NodeWithRef
 
 type DocumentTree = Tree NodeWithRef
 
+type DocumentID = Int
+type CommitID = Int
+
 newtype DocumentHeader = DH
-  { group :: Int, headCommit :: Maybe Int, id :: Int, name :: String }
+  { group :: Int, headCommit :: Maybe CommitID, id :: DocumentID, name :: String }
 
 newtype DocumentHeaderPlusPermission = DHPP
   { document :: DocumentHeader, documentPermission :: String }
@@ -52,8 +55,14 @@ getDHName (DH dh) = dh.name
 getDHID :: DocumentHeader -> Int
 getDHID (DH dh) = dh.id
 
+getDHHeadCommit :: DocumentHeader -> Maybe CommitID
+getDHHeadCommit (DH dh) = dh.headCommit
+
 getDHPPName :: DocumentHeaderPlusPermission -> String
 getDHPPName (DHPP dhpp) = getDHName dhpp.document
+
+getDHPPID :: DocumentHeaderPlusPermission -> Int
+getDHPPID (DHPP dhpp) = getDHID dhpp.document
 
 instance decodeJsonNodeWithRef :: DecodeJson NodeWithRef where
   decodeJson json = do

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -131,7 +131,7 @@ component =
         Nothing -> HH.slot_ _page404 unit Page404.component unit
         Just p -> case p of
           Home -> HH.slot_ _home unit Home.component unit
-          Editor -> HH.slot_ _editor unit EditorPage.component unit
+          Editor { docID } -> HH.slot_ _editor unit (EditorPage.component docID) unit
           Login -> HH.slot_ _login unit Login.component unit
           PasswordReset -> HH.slot_ _resetPassword unit PasswordReset.component unit
           AdminViewUsers -> HH.slot_ _adminUsers unit AdminViewUsers.component unit

--- a/frontend/src/FPO/Page/Admin/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/DocOverview.purs
@@ -3,7 +3,6 @@
 -- Things to change in this file:
 -- always loading for group 1 (see initialize and ConfirmDeleteDocument)
 -- No connection to Backend yet
--- different Docs lead to same editor
 -- both buttons not funtional yet
 -- many things same as in Home.purs or PageGroups.purs. Need to relocate reusable code fragments.
 -- archive column should have checkboxes
@@ -401,7 +400,7 @@ component =
       case s.requestDelete of
         Nothing -> do
           log ("Routing to editor for project " <> ((docNameFromID s) documentID))
-          navigate Editor
+          navigate (Editor { docID: documentID })
         _ ->
           pure unit
     ChangeSorting (TH.Clicked title order) -> do

--- a/frontend/src/FPO/Page/EditorPage.purs
+++ b/frontend/src/FPO/Page/EditorPage.purs
@@ -10,6 +10,7 @@ import Prelude
 import Effect.Aff.Class (class MonadAff)
 import FPO.Component.Splitview as Splitview
 import FPO.Data.Store as Store
+import FPO.Dto.DocumentDto (DocumentID)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
@@ -31,8 +32,9 @@ component
   :: forall query input output m
    . MonadAff m
   => MonadStore Store.Action Store.Store m
-  => H.Component query input output m
-component =
+  => DocumentID
+  -> H.Component query input output m
+component docID =
   H.mkComponent
     { initialState: const {}
     , render
@@ -42,7 +44,7 @@ component =
   render :: State -> H.ComponentHTML Action Slots m
   render _ =
     HH.div [ HP.classes [ HB.flexGrow1, HB.p0, HB.overflowHidden ] ]
-      [ HH.slot _splitview unit Splitview.splitview unit HandleSplitview
+      [ HH.slot _splitview unit (Splitview.splitview docID) unit HandleSplitview
       ]
 
   handleAction :: MonadAff m => Action -> H.HalogenM State Action Slots output m Unit

--- a/frontend/src/FPO/Translations/Common.purs
+++ b/frontend/src/FPO/Translations/Common.purs
@@ -54,7 +54,7 @@ deCommon = fromRecord
   , common_deletePhraseA: "Sind Sie sicher, dass Sie "
   , common_deletePhraseB: " löschen möchten?"
   , common_email: "E-Mail"
-  , common_emailAddress: "E-Mail Addresse"
+  , common_emailAddress: "E-Mail-Addresse"
   , common_filterBy: "Filtern nach"
   , common_group: "Gruppe"
   , common_home: "Start"


### PR DESCRIPTION
This PR adds a project ID to the editor route. This allows the user to select any project on the home page, and actually get the editor page for this project. Furthermore, this PR links a test commit to a test document in the backend/database. 

Notice that the _Editor_ tab in the navbar doesn't really make sense anymore, but because we might want to access the editor without having to log in first and selecting a project in the home view, the button still exists and forwards the user to the editor with `projectID=1` (which may or may not exist). 

See #252