### PR TITLE
Strato zieht gerade unseren Server um...

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
 
   test-backend:
     name: Run backend tests
-    runs-on: postgres
+    runs-on: self-hostet #postgres
     needs:
       - job-spec
       - check-backend


### PR DESCRIPTION
Darum ist der gerade nicht erreichbar.
Da wir gerade sowieso keine integration tests haben, lasse ich die temporär einfach auf allen runnern laufen.