### PR TITLE
Backend Document: Properly Sort Tree Children

### DIFF
--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -588,6 +588,8 @@ getTreeEdgesByParent =
                     left join doc_text_elements t on e.child_text_element = t.id
                 where
                     e.parent = $1 :: bytea
+                order by
+                    e.position ASC
             |]
 
 uncurryTreeRevisionHeader :: (Int32, UTCTime, UserID) -> TreeRevisionHeader


### PR DESCRIPTION
Sort tree children in ascending order at SQL level.