### PR TITLE
Backend Docs API: Embed User Info in Revision Headers

### DIFF
--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -23,7 +23,6 @@ import Data.Scientific (toBoundedInteger)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (UTCTime)
-import Data.UUID (UUID)
 
 import Text.Read (readMaybe)
 
@@ -62,6 +61,7 @@ import Docs.TextElement
     , TextElementRef (..)
     , prettyPrintTextElementRef
     )
+import Docs.UserRef (UserRef)
 
 data TextRevisionRef
     = TextRevisionRef
@@ -170,7 +170,7 @@ specificTextRevision (Specific id_) = Just id_
 data TextRevisionHeader = TextRevisionHeader
     { identifier :: TextRevisionID
     , timestamp :: UTCTime
-    , author :: UUID
+    , author :: UserRef
     }
     deriving (Show, Generic)
 

--- a/backend/src/Docs/TreeRevision.hs
+++ b/backend/src/Docs/TreeRevision.hs
@@ -25,7 +25,6 @@ import Data.Scientific (toBoundedInteger)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (UTCTime)
-import Data.UUID (UUID)
 
 import Text.Read (readMaybe)
 
@@ -60,6 +59,7 @@ import Docs.TextElement (TextElement, TextElementID)
 import Docs.TextRevision (TextElementRevision, TextRevision)
 import Docs.Tree (Node)
 import qualified Docs.Tree as Tree
+import Docs.UserRef (UserRef)
 
 data TreeRevisionRef
     = TreeRevisionRef
@@ -160,7 +160,7 @@ instance FromHttpApiData TreeRevisionID where
 data TreeRevisionHeader = TreeRevisionHeader
     { identifier :: TreeRevisionID
     , timestamp :: UTCTime
-    , author :: UUID
+    , author :: UserRef
     }
     deriving (Generic)
 


### PR DESCRIPTION
This PR adds embedding of user info (currently just the users name) in the revision headers. Thus, the frontend can easily display the author without having to manually fetch their name first. This is especially helpful when displaying a list of revisions.