### PR TITLE
Extend admin panel

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -48,7 +48,6 @@ WORKDIR /home
 COPY index.html index.html
 COPY --from=build /build/index.js index.js
 
-# TODO: resources folder
 COPY static static
 COPY favicon.png favicon.png
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
     />
     <link rel="stylesheet" href="static/highlighting.css">
     <link rel="stylesheet" href="static/tooltip.css">
+    <link rel="stylesheet" href="static/responsive.css">
   </head>
   <body>
     <script

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="static/highlighting.css">
+    <link rel="stylesheet" href="static/tooltip.css">
   </head>
   <body>
     <script

--- a/frontend/src/FPO/Components/Modals/DeleteModal.purs
+++ b/frontend/src/FPO/Components/Modals/DeleteModal.purs
@@ -5,8 +5,8 @@ module FPO.Components.Modals.DeleteModal
 import Prelude
 
 import Data.Array (singleton)
-import FPO.Page.HTML (addModal)
 import FPO.Translations.Labels (Labels)
+import FPO.UI.HTML (addModal)
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -115,7 +115,7 @@ navbar = connect (selectEq identity) $ H.mkComponent
                                 ( translate (label :: _ "navbar_documents")
                                     state.translator
                                 )
-                                (ViewGroupDocuments 1)
+                                (ViewGroupDocuments { groupID: 1 })
                             ]
                         ]
                       else []

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -17,13 +17,13 @@ import FPO.Data.Route (Route(..))
 import FPO.Data.Store (saveLanguage)
 import FPO.Data.Store as Store
 import FPO.Dto.UserDto (User)
-import FPO.Page.HTML (addClass)
 import FPO.Translations.Translator
   ( FPOTranslator(..)
   , fromFpoTranslator
   , getTranslatorForLanguage
   )
 import FPO.Translations.Util (FPOState)
+import FPO.UI.HTML (addClass)
 import Halogen (AttrName(..), ClassName(..))
 import Halogen as H
 import Halogen.HTML as HH

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -24,6 +24,7 @@ import Effect.Aff as Exn
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
+import FPO.Dto.CreateDocumentDto (DocumentCreateDto(..))
 import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID)
 import FPO.Dto.GroupDto (GroupCreate, GroupOverview)
 import FPO.Dto.UserDto (User, decodeUser)
@@ -99,6 +100,11 @@ getGroups = getFromJSONEndpoint (decodeArray decodeJson) "/groups"
 -- | Fetches the document header for a given document ID.
 getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
 getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)
+
+-- | Creates a new document for the specified group.
+-- | TODO: This is according to the old API, might change in the future.
+createDocument :: DocumentCreateDto -> Aff (Either Error (Response Json))
+createDocument dto = postJson "/documents" (encodeJson dto)
 
 getDocumentsFromURL :: String -> Aff (Maybe (Array DocumentHeader))
 getDocumentsFromURL url = getFromJSONEndpoint (decodeArray decodeJson) url

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -24,7 +24,7 @@ import Effect.Aff as Exn
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
-import FPO.Dto.CreateDocumentDto (DocumentCreateDto(..))
+import FPO.Dto.CreateDocumentDto (DocumentCreateDto)
 import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID)
 import FPO.Dto.GroupDto (GroupCreate, GroupOverview)
 import FPO.Dto.UserDto (User, decodeUser)

--- a/frontend/src/FPO/Data/Route.purs
+++ b/frontend/src/FPO/Data/Route.purs
@@ -7,7 +7,8 @@ import Prelude hiding ((/))
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(Nothing), fromMaybe)
 import FPO.Dto.DocumentDto (DocumentID)
-import Routing.Duplex (RouteDuplex', boolean, int, optional, root, segment)
+import FPO.Dto.GroupDto (GroupID)
+import Routing.Duplex (RouteDuplex', boolean, int, optional, root)
 import Routing.Duplex.Generic (noArgs, sum)
 import Routing.Duplex.Generic.Syntax ((/), (?))
 
@@ -19,7 +20,7 @@ data Route
   | PasswordReset
   | AdminViewUsers
   | AdminViewGroups
-  | ViewGroupDocuments Int
+  | ViewGroupDocuments { groupID :: GroupID }
   | Page404
   | Profile { loginSuccessful :: Maybe Boolean }
 
@@ -36,7 +37,7 @@ routeCodec = root $ sum
   , "PasswordReset": "password-reset" / noArgs
   , "AdminViewUsers": "admin-users" / noArgs
   , "AdminViewGroups": "admin-groups" / noArgs
-  , "ViewGroupDocuments": "view-group-documents" / int segment
+  , "ViewGroupDocuments": "view-group-documents" ? { groupID: int }
   , "Page404": "404" / noArgs
   , "Profile": "profile" ? { loginSuccessful: optional <<< boolean }
   }

--- a/frontend/src/FPO/Dto/CreateDocumentDto.purs
+++ b/frontend/src/FPO/Dto/CreateDocumentDto.purs
@@ -1,0 +1,15 @@
+module FPO.Dto.CreateDocumentDto where
+
+import Data.Argonaut (class DecodeJson, class EncodeJson)
+import Data.Newtype (class Newtype)
+
+-- | According to `POST /documents` API endpoint.
+newtype DocumentCreateDto = DocumentCreateDto
+  { documentCreateGroupId :: Int
+  , documentCreateName :: String
+  }
+
+derive instance newtypeDocumentCreateDto :: Newtype DocumentCreateDto _
+
+derive newtype instance encodeJsonDocumentCreateDto :: EncodeJson DocumentCreateDto
+derive newtype instance decodeJsonDocumentCreateDto :: DecodeJson DocumentCreateDto

--- a/frontend/src/FPO/Dto/GroupDto.purs
+++ b/frontend/src/FPO/Dto/GroupDto.purs
@@ -4,9 +4,11 @@ module FPO.Dto.GroupDto where
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Newtype (class Newtype)
 
+type GroupID = Int
+
 -- | Represents a group overview entity, as returned by the `GET /groups` endpoint.
 newtype GroupOverview = GroupOverview
-  { groupOverviewName :: String, groupOverviewID :: Int }
+  { groupOverviewName :: String, groupOverviewID :: GroupID }
 
 getGroupOverviewID :: GroupOverview -> Int
 getGroupOverviewID (GroupOverview g) = g.groupOverviewID

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -22,7 +22,7 @@ import FPO.Data.Route (Route(..), routeCodec, routeToString)
 import FPO.Data.Store (loadLanguage)
 import FPO.Data.Store as Store
 import FPO.Dto.UserDto (User)
-import FPO.Page.Admin.DocOverview as ViewGroupDocuments
+import FPO.Page.Admin.Group.DocOverview as ViewGroupDocuments
 import FPO.Page.Admin.Groups as AdminViewGroups
 import FPO.Page.Admin.Users as AdminViewUsers
 import FPO.Page.EditorPage as EditorPage
@@ -31,11 +31,7 @@ import FPO.Page.Login as Login
 import FPO.Page.Page404 as Page404
 import FPO.Page.Profile as Profile
 import FPO.Page.ResetPassword as PasswordReset
-import FPO.Translations.Translator
-  ( FPOTranslator(..)
-  , detectBrowserLanguage
-  , getTranslatorForLanguage
-  )
+import FPO.Translations.Translator (FPOTranslator(..), detectBrowserLanguage, getTranslatorForLanguage)
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -44,23 +40,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Halogen.VDom.Driver (runUI)
-import Prelude
-  ( Unit
-  , Void
-  , bind
-  , const
-  , discard
-  , pure
-  , unit
-  , void
-  , when
-  , ($)
-  , (/=)
-  , (<$>)
-  , (<<<)
-  , (<>)
-  , (==)
-  )
+import Prelude (Unit, Void, bind, const, discard, pure, unit, void, when, ($), (/=), (<$>), (<<<), (<>), (==))
 import Routing.Duplex as RD
 import Routing.Hash (getHash, matchesWith)
 import Type.Proxy (Proxy(..))
@@ -136,7 +116,7 @@ component =
           PasswordReset -> HH.slot_ _resetPassword unit PasswordReset.component unit
           AdminViewUsers -> HH.slot_ _adminUsers unit AdminViewUsers.component unit
           AdminViewGroups -> HH.slot_ _adminGroups unit AdminViewGroups.component unit
-          ViewGroupDocuments groupID -> HH.slot_ _viewGroupDocuments unit
+          ViewGroupDocuments { groupID } -> HH.slot_ _viewGroupDocuments unit
             ViewGroupDocuments.component
             groupID
           Page404 -> HH.slot_ _page404 unit Page404.component unit

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -31,7 +31,11 @@ import FPO.Page.Login as Login
 import FPO.Page.Page404 as Page404
 import FPO.Page.Profile as Profile
 import FPO.Page.ResetPassword as PasswordReset
-import FPO.Translations.Translator (FPOTranslator(..), detectBrowserLanguage, getTranslatorForLanguage)
+import FPO.Translations.Translator
+  ( FPOTranslator(..)
+  , detectBrowserLanguage
+  , getTranslatorForLanguage
+  )
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -40,7 +44,23 @@ import Halogen.HTML.Properties as HP
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Halogen.VDom.Driver (runUI)
-import Prelude (Unit, Void, bind, const, discard, pure, unit, void, when, ($), (/=), (<$>), (<<<), (<>), (==))
+import Prelude
+  ( Unit
+  , Void
+  , bind
+  , const
+  , discard
+  , pure
+  , unit
+  , void
+  , when
+  , ($)
+  , (/=)
+  , (<$>)
+  , (<<<)
+  , (<>)
+  , (==)
+  )
 import Routing.Duplex as RD
 import Routing.Hash (getHash, matchesWith)
 import Type.Proxy (Proxy(..))

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -38,6 +38,7 @@ import FPO.Page.Home (formatRelativeTime)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
 import FPO.UI.HTML (addCard, addColumn)
+import FPO.UI.Style as Style
 import Halogen (liftAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -137,7 +138,7 @@ component =
   render :: State -> H.ComponentHTML Action Slots m
   render state =
     HH.div
-      [ HP.classes [ HB.row, HB.justifyContentCenter, HB.my5 ] ]
+      [ HP.classes [ HB.container, HB.my5 ] ]
       $
         ( case state.requestDelete of
             Just documentID ->
@@ -161,19 +162,17 @@ component =
 
   renderDocumentManagement :: State -> H.ComponentHTML Action Slots m
   renderDocumentManagement state =
-    HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
-      [ HH.div [ HP.classes [ HB.colSm12, HB.colMd10, HB.colLg9 ] ]
-          [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
-              [ HH.text $ translate (label :: _ "gp_projectManagement")
-                  state.translator
-              ]
-          , renderDocumentListView state
+    HH.div_
+      [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
+          [ HH.text $ translate (label :: _ "gp_projectManagement")
+              state.translator
           ]
+      , renderDocumentListView state
       ]
 
   renderDocumentListView :: State -> H.ComponentHTML Action Slots m
   renderDocumentListView state =
-    HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
+    HH.div [ HP.classes [ HB.row ] ]
       [ renderSideButtons state
       , renderDocumentsOverview state
       ]
@@ -181,10 +180,10 @@ component =
   -- Renders the overview of projects for the user.
   renderDocumentsOverview :: State -> H.ComponentHTML Action Slots m
   renderDocumentsOverview state =
-    HH.div [ HP.classes [ HB.col9, HB.justifyContentCenter ] ]
+    HH.div [ HP.classes [ HB.col12, HB.colMd9, HB.colLg8 ] ]
       [ addCard
           (translate (label :: _ "gp_groupProjects") state.translator)
-          [ HP.classes [ HB.colSm11, HB.colMd10, HB.colLg9 ] ]
+          []
           (renderDocumentOverview state)
       ]
 
@@ -294,31 +293,45 @@ component =
 
   renderSideButtons :: forall w. State -> HH.HTML w Action
   renderSideButtons state =
-    HH.div [ HP.classes [ HB.col, HB.justifyContentCenter ] ]
-      [ renderToMemberButton state
-      , renderCreateDocButton state
+    HH.div [ HP.classes [ HB.colMd3, HB.colLg2, HB.col12, HB.mb3 ] ]
+      [ -- The grid layout allows for vertical button stacking on bigger screens
+        -- and horizontal alignment on smaller screens, just above the document list.
+        HH.div
+          [ HP.classes [ HB.dFlex, HB.dMdGrid, HB.justifyContentCenter, HB.gap2 ] ]
+          [ renderToMemberButton state
+          , renderCreateDocButton state
+          ]
       ]
 
   renderToMemberButton :: forall w. State -> HH.HTML w Action
   renderToMemberButton state =
-    HH.div [ HP.classes [ HB.inputGroup ] ]
-      [ HH.button
-          [ HP.classes [ HB.btn, HB.btnOutlineInfo, HB.btnLg, HB.p4, HB.textDark ]
-          , HE.onClick (const $ DoNothing)
+    HH.button
+      [ HP.classes
+          [ HB.btn
+          , HB.btnOutlineInfo
+          , HB.btnLg
+          , HB.p3
+          , HB.textDark
+          , Style.responsiveButton
           ]
-          [ HH.text $ translate (label :: _ "common_members") state.translator ]
+      , HE.onClick (const $ DoNothing)
       ]
+      [ HH.text $ translate (label :: _ "common_members") state.translator ]
 
   renderCreateDocButton :: forall w. State -> HH.HTML w Action
   renderCreateDocButton state =
-    HH.div [ HP.classes [ HB.inputGroup ] ]
-      [ HH.button
-          [ HP.classes
-              [ HB.btn, HB.btnOutlineInfo, HB.btnLg, HB.p4, HB.mt5, HB.textDark ]
-          , HE.onClick (const $ DoNothing)
+    HH.button
+      [ HP.classes
+          [ HB.btn
+          , HB.btnOutlineInfo
+          , HB.btnLg
+          , HB.p3
+          , HB.textDark
+          , Style.responsiveButton
           ]
-          [ HH.text $ translate (label :: _ "gp_newProject") state.translator ]
+      , HE.onClick (const $ DoNothing)
       ]
+      [ HH.text $ translate (label :: _ "gp_newProject") state.translator ]
 
   buttonDeleteDocument :: forall w. Int -> HH.HTML w Action
   buttonDeleteDocument documentID =

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -2,8 +2,8 @@
 
 -- Things to change in this file:
 --   [x] always loading for group 1 (see initialize and ConfirmDeleteDocument)
---   [ ] No connection to Backend yet
---   [ ] both buttons not funtional yet
+--   [x] No connection to Backend yet
+--   [ ] button for member overview not functional yet
 --   [ ] many things same as in Home.purs or PageGroups.purs. Need to relocate reusable code fragments.
 --   [ ] archive column should have checkboxes
 --   [ ] move the creation modal to a separate file / component, and perhaps even to a separate page.

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -34,10 +34,10 @@ import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto (DocumentHeader, DocumentID, getDHID, getDHName)
 import FPO.Dto.GroupDto (GroupID)
-import FPO.Page.HTML (addCard, addColumn)
 import FPO.Page.Home (formatRelativeTime)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addCard, addColumn)
 import Halogen (liftAff)
 import Halogen as H
 import Halogen.HTML as HH

--- a/frontend/src/FPO/Page/Admin/Groups.purs
+++ b/frontend/src/FPO/Page/Admin/Groups.purs
@@ -38,16 +38,10 @@ import FPO.Dto.GroupDto
   , getGroupOverviewID
   , getGroupOverviewName
   )
-import FPO.Page.HTML
-  ( addButton
-  , addCard
-  , addColumn
-  , addError
-  , addModal
-  , emptyEntryGen
-  )
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addButton, addCard, addColumn, addError, addModal, emptyEntryGen)
+import FPO.UI.Style as Style
 import Halogen (liftAff, liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
@@ -429,9 +423,8 @@ component =
           , HB.justifyContentBetween
           , HB.alignItemsCenter
           ]
-      , HP.style "cursor: pointer;"
       , HE.onClick (const $ NavigateToGroupDocuments g.groupOverviewID)
-      , HP.title $ translate
+      , Style.popover $ translate
           (label :: _ "admin_groups_viewDocumentsPage")
           state.translator
       ]

--- a/frontend/src/FPO/Page/Admin/Groups.purs
+++ b/frontend/src/FPO/Page/Admin/Groups.purs
@@ -33,6 +33,7 @@ import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.GroupDto
   ( GroupCreate(..)
+  , GroupID
   , GroupOverview(..)
   , getGroupOverviewID
   , getGroupOverviewName
@@ -81,6 +82,14 @@ data Action
   | ConfirmDeleteGroup String
   | CancelDeleteGroup
   | Filter
+  -- | Navigates to the documents of a specific group.
+  -- | TODO: Because we have no group member page yet,
+  -- |       we simply navigate to the group documents page.
+  -- |       After the group member page is implemented, we
+  -- |       could consider changing this action to instead
+  -- |       navigate to the group member page. Might be more
+  -- |       intuitive for the user.
+  | NavigateToGroupDocuments GroupID
 
 type State = FPOState
   ( error :: Maybe String
@@ -318,6 +327,8 @@ component =
             { error = Just
                 (translate (label :: _ "admin_groups_stillLoading") s.translator)
             }
+    NavigateToGroupDocuments gID -> do
+      navigate $ ViewGroupDocuments { groupID: gID }
 
   -- | Specifies the waiting state.
   setWaiting :: Boolean -> H.HalogenM State Action Slots output m Unit
@@ -418,6 +429,11 @@ component =
           , HB.justifyContentBetween
           , HB.alignItemsCenter
           ]
+      , HP.style "cursor: pointer;"
+      , HE.onClick (const $ NavigateToGroupDocuments g.groupOverviewID)
+      , HP.title $ translate
+          (label :: _ "admin_groups_viewDocumentsPage")
+          state.translator
       ]
       [ HH.text g.groupOverviewName
       , buttonDeleteGroup state g.groupOverviewName

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -24,14 +24,35 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Data.Email as Email
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request (LoadState(..), deleteIgnore, getFromJSONEndpoint, getUser, postJson)
+import FPO.Data.Request
+  ( LoadState(..)
+  , deleteIgnore
+  , getFromJSONEndpoint
+  , getUser
+  , postJson
+  )
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
-import FPO.Dto.CreateUserDto (CreateUserDto, getEmail, getName, getPassword, withEmail, withName, withPassword)
+import FPO.Dto.CreateUserDto
+  ( CreateUserDto
+  , getEmail
+  , getName
+  , getPassword
+  , withEmail
+  , withName
+  , withPassword
+  )
 import FPO.Dto.CreateUserDto as CreateUserDto
 import FPO.Dto.UserOverviewDto (UserOverviewDto)
 import FPO.Dto.UserOverviewDto as UserOverviewDto
-import FPO.Page.HTML (addButton, addCard, addColumn, addError, deleteButton, emptyEntryText)
+import FPO.Page.HTML
+  ( addButton
+  , addCard
+  , addColumn
+  , addError
+  , deleteButton
+  , emptyEntryText
+  )
 import FPO.Translations.Labels (Labels)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -24,35 +24,14 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Data.Email as Email
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request
-  ( LoadState(..)
-  , deleteIgnore
-  , getFromJSONEndpoint
-  , getUser
-  , postJson
-  )
+import FPO.Data.Request (LoadState(..), deleteIgnore, getFromJSONEndpoint, getUser, postJson)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
-import FPO.Dto.CreateUserDto
-  ( CreateUserDto
-  , getEmail
-  , getName
-  , getPassword
-  , withEmail
-  , withName
-  , withPassword
-  )
+import FPO.Dto.CreateUserDto (CreateUserDto, getEmail, getName, getPassword, withEmail, withName, withPassword)
 import FPO.Dto.CreateUserDto as CreateUserDto
 import FPO.Dto.UserOverviewDto (UserOverviewDto)
 import FPO.Dto.UserOverviewDto as UserOverviewDto
-import FPO.Page.HTML
-  ( addButton
-  , addCard
-  , addColumn
-  , addError
-  , deleteButton
-  , emptyEntryText
-  )
+import FPO.Page.HTML (addButton, addCard, addColumn, addError, deleteButton, emptyEntryText)
 import FPO.Translations.Labels (Labels)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
@@ -144,7 +123,7 @@ component =
   render :: State -> H.ComponentHTML Action Slots m
   render state =
     HH.div
-      [ HP.classes [ HB.container, HB.dFlex, HB.justifyContentCenter, HB.my5 ]
+      [ HP.classes [ HB.container, HB.my5 ]
       ]
       [ renderDeleteModal state
       , renderUserManagement state
@@ -241,7 +220,7 @@ component =
 
   renderUserManagement :: State -> H.ComponentHTML Action Slots m
   renderUserManagement state =
-    HH.div [ HP.classes [ HB.w100, HB.col12 ] ]
+    HH.div_
       [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
           [ HH.text $ translate (label :: _ "au_userManagement") state.translator
           ]
@@ -263,7 +242,7 @@ component =
   renderFilterBy :: State -> H.ComponentHTML Action Slots m
   renderFilterBy state =
     addCard (translate (label :: _ "common_filterBy") state.translator)
-      [ HP.classes [ HB.col3 ] ] $ HH.div
+      [ HP.classes [ HB.col12, HB.colMd3, HB.colLg3, HB.mb3 ] ] $ HH.div
       [ HP.classes [ HB.row ] ]
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
@@ -296,7 +275,7 @@ component =
   renderUserList :: State -> H.ComponentHTML Action Slots m
   renderUserList state =
     addCard (translate (label :: _ "admin_users_listOfUsers") state.translator)
-      [ HP.classes [ HB.col6 ] ] $ HH.div_
+      [ HP.classes [ HB.col12, HB.colMd6, HB.colLg6, HB.mb3 ] ] $ HH.div_
       [ HH.ul [ HP.classes [ HB.listGroup ] ]
           $ map (createUserEntry state.translator) usrs
               <> replicate (10 - length usrs)
@@ -318,7 +297,7 @@ component =
   renderNewUserForm :: forall w. State -> HH.HTML w Action
   renderNewUserForm state =
     addCard (translate (label :: _ "admin_users_createNewUser") state.translator)
-      [ HP.classes [ HB.col3 ] ] $ HH.div_
+      [ HP.classes [ HB.col12, HB.colMd3, HB.colLg3 ] ] $ HH.div_
       [ HH.div [ HP.classes [ HB.col ] ]
           [ addColumn
               (getName state.createUserDto)

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -45,7 +45,10 @@ import FPO.Dto.CreateUserDto
 import FPO.Dto.CreateUserDto as CreateUserDto
 import FPO.Dto.UserOverviewDto (UserOverviewDto)
 import FPO.Dto.UserOverviewDto as UserOverviewDto
-import FPO.Page.HTML
+import FPO.Translations.Labels (Labels)
+import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
+import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML
   ( addButton
   , addCard
   , addColumn
@@ -53,9 +56,6 @@ import FPO.Page.HTML
   , deleteButton
   , emptyEntryText
   )
-import FPO.Translations.Labels (Labels)
-import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
-import FPO.Translations.Util (FPOState, selectTranslator)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE

--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -36,9 +36,9 @@ import FPO.Dto.DocumentDto
   , getDHPPName
   )
 import FPO.Dto.UserDto (User)
-import FPO.Page.HTML (addCard, addColumn)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addCard, addColumn)
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH

--- a/frontend/src/FPO/Page/Login.purs
+++ b/frontend/src/FPO/Page/Login.purs
@@ -21,9 +21,9 @@ import FPO.Data.Request (postString) as Request
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.Login (LoginDto)
-import FPO.Page.HTML (addColumn)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addColumn)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events (onClick, onSubmit) as HE

--- a/frontend/src/FPO/Page/ResetPassword.purs
+++ b/frontend/src/FPO/Page/ResetPassword.purs
@@ -14,9 +14,9 @@ import Data.String.Regex (regex, test)
 import Data.String.Regex.Flags (noFlags)
 import Effect.Aff.Class (class MonadAff)
 import FPO.Data.Store as Store
-import FPO.Page.HTML (addColumn)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addColumn)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events (onClick, onSubmit, onValueInput) as HE

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -118,6 +118,7 @@ type Labels =
       ::: "admin_groups_notEmpty"
       ::: "admin_groups_searchForGroups"
       ::: "admin_groups_stillLoading"
+      ::: "admin_groups_viewDocumentsPage"
 
       -- | Admin Users Page
       ::: "admin_users_create"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -165,7 +165,9 @@ type Labels =
       ::: "editor_undo"
 
       -- | Group Projects Page
-
+      ::: "gp_createNewProject"
+      ::: "gp_documentName"
+      ::: "gp_enterDocumentName"
       ::: "gp_groupProjects"
       ::: "gp_newProject"
       ::: "gp_projectManagement"

--- a/frontend/src/FPO/Translations/Page/Admin/GroupProjects.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/GroupProjects.purs
@@ -4,7 +4,10 @@ import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord)
 
 type GroupProjectsPageLabels =
-  ( "gp_groupProjects"
+  ( "gp_createNewProject"
+      ::: "gp_documentName"
+      ::: "gp_enterDocumentName"
+      ::: "gp_groupProjects"
       ::: "gp_newProject"
       ::: "gp_projectManagement"
       ::: "gp_searchProjects"
@@ -13,7 +16,10 @@ type GroupProjectsPageLabels =
 
 enGroupProjectsPage :: Translation GroupProjectsPageLabels
 enGroupProjectsPage = fromRecord
-  { gp_groupProjects: "Projects of Group"
+  { gp_createNewProject: "Create New Project"
+  , gp_documentName: "Document Name"
+  , gp_enterDocumentName: "Enter Document Name"
+  , gp_groupProjects: "Projects of Group"
   , gp_newProject: "Create Project"
   , gp_projectManagement: "Project Management"
   , gp_searchProjects: "Search for Projects"
@@ -21,7 +27,10 @@ enGroupProjectsPage = fromRecord
 
 deGroupProjectsPage :: Translation GroupProjectsPageLabels
 deGroupProjectsPage = fromRecord
-  { gp_groupProjects: "Projekte der Gruppe"
+  { gp_createNewProject: "Neues Projekt erstellen"
+  , gp_documentName: "Dokumentname"
+  , gp_enterDocumentName: "Dokumentname eingeben"
+  , gp_groupProjects: "Projekte der Gruppe"
   , gp_newProject: "Neues Projekt"
   , gp_projectManagement: "Projektverwaltung"
   , gp_searchProjects: "Suche nach Projekten"

--- a/frontend/src/FPO/Translations/Page/Admin/PageGroups.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/PageGroups.purs
@@ -19,6 +19,7 @@ type AdminGroupPageLabels =
       ::: "admin_groups_notEmpty"
       ::: "admin_groups_searchForGroups"
       ::: "admin_groups_stillLoading"
+      ::: "admin_groups_viewDocumentsPage"
       ::: SNil
   )
 
@@ -39,6 +40,7 @@ enAdminGroupPage = fromRecord
   , admin_groups_notEmpty: "Group name cannot be empty."
   , admin_groups_searchForGroups: "Search for Groups"
   , admin_groups_stillLoading: "Groups are still loading."
+  , admin_groups_viewDocumentsPage: "View Documents Page of Group"
   }
 
 deAdminGroupPage :: Translation AdminGroupPageLabels
@@ -58,5 +60,6 @@ deAdminGroupPage = fromRecord
   , admin_groups_notEmpty: "Der Gruppenname darf nicht leer sein."
   , admin_groups_searchForGroups: "Nach Gruppen suchen"
   , admin_groups_stillLoading: "Gruppen werden noch geladen."
+  , admin_groups_viewDocumentsPage: "Dokumente der Gruppe anzeigen"
   }
 

--- a/frontend/src/FPO/UI/HTML.purs
+++ b/frontend/src/FPO/UI/HTML.purs
@@ -7,6 +7,7 @@ import Prelude
 
 import DOM.HTML.Indexed as I
 import DOM.HTML.Indexed.InputType (InputType)
+import Data.Array as Array
 import Data.Maybe (Maybe(..))
 import Data.String (null)
 import Halogen.HTML as H
@@ -112,13 +113,16 @@ addCard
   -> HH.HTML w i -- ^ content of the card
   -> HH.HTML w i
 addCard title e content =
-  HH.div e
-    [ HH.div ([ HP.classes [ HB.card ] ])
-        [ HH.h5 [ HP.classes [ HB.cardHeader ] ]
-            [ HH.text title ]
-        , content `addClass` HB.cardBody
-        ]
-    ]
+  if Array.null e then cardContent
+  else HH.div e [ cardContent ]
+  where
+  cardContent =
+    HH.div
+      [ HP.classes [ HB.card ] ]
+      [ HH.h5 [ HP.classes [ HB.cardHeader ] ]
+          [ HH.text title ]
+      , content `addClass` HB.cardBody
+      ]
 
 addModal
   :: forall w i

--- a/frontend/src/FPO/UI/HTML.purs
+++ b/frontend/src/FPO/UI/HTML.purs
@@ -1,7 +1,7 @@
 -- | This module contains some HTML helpers and goodies for the FPO app,
 -- | useful for creating and reusing HTML components and pages.
 
-module FPO.Page.HTML where
+module FPO.UI.HTML where
 
 import Prelude
 

--- a/frontend/src/FPO/UI/Style.purs
+++ b/frontend/src/FPO/UI/Style.purs
@@ -1,0 +1,14 @@
+-- | This module contains some additional styling helpers and goodies for the FPO app,
+-- | useful for creating and reusing CSS styles across components and pages.
+
+module FPO.UI.Style where
+
+import Halogen.HTML as HH
+
+-- | Popover attribute for tooltips. Can be used just like any other HTML attribute, and
+-- | adds a tooltip to the element when hovered.
+-- |
+-- | Example usage:
+-- |    `HH.div [ popover "Tooltip text" ] [ HH.text "Hover me!" ]`
+popover :: forall r i. String -> HH.IProp r i
+popover = HH.attr (HH.AttrName "data-tooltip")

--- a/frontend/src/FPO/UI/Style.purs
+++ b/frontend/src/FPO/UI/Style.purs
@@ -5,6 +5,8 @@
 module FPO.UI.Style where
 
 import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Halogen.Themes.Bootstrap5 as HB
 
 -- | Popover attribute for tooltips. Can be used just like any other HTML
 -- | attribute, and adds a tooltip to the element when hovered.
@@ -19,3 +21,15 @@ popover = HH.attr (HH.AttrName "data-tooltip")
 -- | and desktop views.
 responsiveButton :: HH.ClassName
 responsiveButton = HH.ClassName "responsive-btn"
+
+-- | A cyan style button, predominantly used as main-feature buttons
+-- | of some admin pages.
+cyanStyle :: forall r i. HH.IProp (class :: String | r) i
+cyanStyle = HP.classes
+  [ HB.btn
+  , HB.btnOutlineInfo
+  , HB.btnLg
+  , HB.p3
+  , HB.textDark
+  , responsiveButton
+  ]

--- a/frontend/src/FPO/UI/Style.purs
+++ b/frontend/src/FPO/UI/Style.purs
@@ -1,14 +1,21 @@
--- | This module contains some additional styling helpers and goodies for the FPO app,
--- | useful for creating and reusing CSS styles across components and pages.
+-- | This module contains some additional styling helpers and goodies
+-- | for the FPO app, useful for creating and reusing CSS styles across
+-- | components and pages.
 
 module FPO.UI.Style where
 
 import Halogen.HTML as HH
 
--- | Popover attribute for tooltips. Can be used just like any other HTML attribute, and
--- | adds a tooltip to the element when hovered.
+-- | Popover attribute for tooltips. Can be used just like any other HTML
+-- | attribute, and adds a tooltip to the element when hovered.
 -- |
 -- | Example usage:
 -- |    `HH.div [ popover "Tooltip text" ] [ HH.text "Hover me!" ]`
 popover :: forall r i. String -> HH.IProp r i
 popover = HH.attr (HH.AttrName "data-tooltip")
+
+-- | Class for responsive buttons that adapt to different screen sizes.
+-- | This class can be used to ensure buttons look good on both mobile
+-- | and desktop views.
+responsiveButton :: HH.ClassName
+responsiveButton = HH.ClassName "responsive-btn"

--- a/frontend/static/responsive.css
+++ b/frontend/static/responsive.css
@@ -1,0 +1,11 @@
+/* This file is a collection of specifications regarding responsive styling */
+
+/* `responsive-btn` class makes buttons appear smaller on smaller screens,
+   very useful for the responsive button layout of the cyan buttons in the
+   group documents overview and group member overview pages. */
+@media (max-width: 767.98px) {
+  .responsive-btn {
+    font-size: 0.875rem;
+    font-weight: 400;
+  }
+}

--- a/frontend/static/tooltip.css
+++ b/frontend/static/tooltip.css
@@ -1,0 +1,47 @@
+/* CSS-only tooltip. We could also use bootstrap tooltips ("popovers"), but handling
+   the DOM using javascript hooks and whatnot is not worth the hassle. */
+[data-tooltip] {
+  position: relative;
+  cursor: pointer;
+}
+
+[data-tooltip]::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  white-space: nowrap;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+[data-tooltip]:hover::before {
+  opacity: 1;
+  transition-delay: 0.8s;
+}
+
+[data-tooltip]::after {
+  content: '';
+  position: absolute;
+  bottom: calc(100%);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top: 5px solid #333;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+  transition-delay: 0.8s;
+}


### PR DESCRIPTION
This pull request is part of a larger extension to the UI regarding a lot of administrative features, including 

- [x] a full-fledged project/document creation page
- [ ] role assignment page per document/project
- [ ] member assignment page per group (see issue #139)

Some other smaller features, including QoT improvements, are also included here;

- much more responsive UI
- navigation between group overview page and group page

See issue #212 