### PR TITLE
Backend Docs: API History Limit QueryParam

### DIFF
--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -42,6 +42,7 @@ import Docs.TextRevision
     )
 import Docs.Tree (Node)
 import Docs.TreeRevision (TreeRevision, TreeRevisionHistory, TreeRevisionRef)
+import GHC.Int (Int32)
 
 class (Monad m) => HasCheckPermission m where
     checkDocumentPermission :: UserID -> DocumentID -> Permission -> m Bool
@@ -79,13 +80,14 @@ class
     getTextElementRevision :: TextRevisionRef -> m (Maybe TextElementRevision)
 
 class (HasCheckPermission m, HasExistsTextElement m) => HasGetTextHistory m where
-    getTextHistory :: TextElementRef -> Maybe UTCTime -> m TextRevisionHistory
+    getTextHistory
+        :: TextElementRef -> Maybe UTCTime -> Int32 -> m TextRevisionHistory
 
 class (HasCheckPermission m, HasExistsDocument m) => HasGetTreeHistory m where
-    getTreeHistory :: DocumentID -> Maybe UTCTime -> m TreeRevisionHistory
+    getTreeHistory :: DocumentID -> Maybe UTCTime -> Int32 -> m TreeRevisionHistory
 
 class (HasCheckPermission m, HasExistsDocument m) => HasGetDocumentHistory m where
-    getDocumentHistory :: DocumentID -> Maybe UTCTime -> m DocumentHistory
+    getDocumentHistory :: DocumentID -> Maybe UTCTime -> Int32 -> m DocumentHistory
 
 -- create
 

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -66,13 +66,13 @@ instance HasGetTextElementRevision HasqlSession where
     getTextElementRevision = HasqlSession . Sessions.getTextElementRevision
 
 instance HasGetTextHistory HasqlSession where
-    getTextHistory = (HasqlSession .) . Sessions.getTextRevisionHistory
+    getTextHistory = ((HasqlSession .) .) . Sessions.getTextRevisionHistory
 
 instance HasGetTreeHistory HasqlSession where
-    getTreeHistory = (HasqlSession .) . Sessions.getTreeRevisionHistory
+    getTreeHistory = ((HasqlSession .) .) . Sessions.getTreeRevisionHistory
 
 instance HasGetDocumentHistory HasqlSession where
-    getDocumentHistory = (HasqlSession .) . Sessions.getDocumentRevisionHistory
+    getDocumentHistory = ((HasqlSession .) .) . Sessions.getDocumentRevisionHistory
 
 -- create
 

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -61,6 +61,7 @@ import Docs.TreeRevision
     , TreeRevisionRef (..)
     )
 import DocumentManagement.Hash (Hash)
+import GHC.Int (Int32)
 
 existsDocument :: DocumentID -> Session Bool
 existsDocument = flip statement Statements.existsDocument
@@ -137,21 +138,21 @@ getTree rootHash = do
             (TreeEdgeToNode hash header) -> fromHeader hash header <&> Tree.Tree
 
 getTextRevisionHistory
-    :: TextElementRef -> Maybe UTCTime -> Session TextRevisionHistory
-getTextRevisionHistory ref before =
-    statement (ref, before) Statements.getTextRevisionHistory
+    :: TextElementRef -> Maybe UTCTime -> Int32 -> Session TextRevisionHistory
+getTextRevisionHistory ref before limit =
+    statement (ref, before, limit) Statements.getTextRevisionHistory
         <&> TextRevisionHistory ref . Vector.toList
 
 getTreeRevisionHistory
-    :: DocumentID -> Maybe UTCTime -> Session TreeRevisionHistory
-getTreeRevisionHistory id_ before =
-    statement (id_, before) Statements.getTreeRevisionHistory
+    :: DocumentID -> Maybe UTCTime -> Int32 -> Session TreeRevisionHistory
+getTreeRevisionHistory id_ before limit =
+    statement (id_, before, limit) Statements.getTreeRevisionHistory
         <&> TreeRevisionHistory id_ . Vector.toList
 
 getDocumentRevisionHistory
-    :: DocumentID -> Maybe UTCTime -> Session DocumentHistory
-getDocumentRevisionHistory id_ before =
-    statement (id_, before) Statements.getDocumentRevisionHistory
+    :: DocumentID -> Maybe UTCTime -> Int32 -> Session DocumentHistory
+getDocumentRevisionHistory id_ before limit =
+    statement (id_, before, limit) Statements.getDocumentRevisionHistory
         <&> DocumentHistory id_ . Vector.toList
 
 hasPermission :: UserID -> DocumentID -> Permission -> Session Bool

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -167,6 +167,7 @@ type GetTextHistory =
         :> Capture "textElementID" TextElementID
         :> "history"
         :> QueryParam "before" UTCTime
+        :> QueryParam "limit" Docs.Limit
         :> Get '[JSON] TextRevisionHistory
 
 type GetTreeHistory =
@@ -175,6 +176,7 @@ type GetTreeHistory =
         :> "tree"
         :> "history"
         :> QueryParam "before" UTCTime
+        :> QueryParam "limit" Docs.Limit
         :> Get '[JSON] TreeRevisionHistory
 
 type GetDocumentHistory =
@@ -182,6 +184,7 @@ type GetDocumentHistory =
         :> Capture "documentID" DocumentID
         :> "history"
         :> QueryParam "before" UTCTime
+        :> QueryParam "limit" Docs.Limit
         :> Get '[JSON] DocumentHistory
 
 docsServer :: Server DocsAPI
@@ -309,8 +312,9 @@ getTextHistoryHandler
     -> DocumentID
     -> TextElementID
     -> Maybe UTCTime
+    -> Maybe Docs.Limit
     -> Handler TextRevisionHistory
-getTextHistoryHandler auth docID textID before = do
+getTextHistoryHandler auth docID textID before limit = do
     userID <- getUser auth
     withDB $
         run $
@@ -318,24 +322,27 @@ getTextHistoryHandler auth docID textID before = do
                 userID
                 (TextElementRef docID textID)
                 before
+                limit
 
 getTreeHistoryHandler
     :: AuthResult Auth.Token
     -> DocumentID
     -> Maybe UTCTime
+    -> Maybe Docs.Limit
     -> Handler TreeRevisionHistory
-getTreeHistoryHandler auth docID before = do
+getTreeHistoryHandler auth docID before limit = do
     userID <- getUser auth
-    withDB $ run $ Docs.getTreeHistory userID docID before
+    withDB $ run $ Docs.getTreeHistory userID docID before limit
 
 getDocumentHistoryHandler
     :: AuthResult Auth.Token
     -> DocumentID
     -> Maybe UTCTime
+    -> Maybe Docs.Limit
     -> Handler DocumentHistory
-getDocumentHistoryHandler auth docID before = do
+getDocumentHistoryHandler auth docID before limit = do
     userID <- getUser auth
-    withDB $ run $ Docs.getDocumentHistory userID docID before
+    withDB $ run $ Docs.getDocumentHistory userID docID before limit
 
 -- utililty
 

--- a/scripts/test_api.py
+++ b/scripts/test_api.py
@@ -37,8 +37,10 @@ class Client:
     def document_tree_full(self, doc_id: int, revision: Literal["latest"] | int) -> str:
         return self.get_json(f"v2/docs/{doc_id}/tree/{revision}/full")
 
-    def document_history(self, doc_id: int) -> str:
-        return self.get_json(f"v2/docs/{doc_id}/history")
+    def document_history(self, doc_id: int, before: str|None=None, limit: int|None=None) -> str:
+        query = "&".join([f"{name}={value}" for (name, value) in [("before", before), ("limit", limit)] if value])
+        query = f"?{query}" if query else ""
+        return self.get_json(f"v2/docs/{doc_id}/history{query}")
 
     def post(self, endpoint: str, payload: object) -> Response:
         return self.__session.post(
@@ -80,4 +82,4 @@ if __name__ == "__main__":
     )
     print(client.document(1))
     print(client.document_tree_full(1, "latest"))
-    print(client.document_history(1))
+    print(client.document_history(1, limit=5))


### PR DESCRIPTION
This PR adds `limit` query parameters to all `/history` endpoints.

Closes #277 