### PR TITLE
Add member management to group page

### DIFF
--- a/frontend/src/FPO/Components/Modals/DeleteModal.purs
+++ b/frontend/src/FPO/Components/Modals/DeleteModal.purs
@@ -45,7 +45,8 @@ deleteConfirmationModal
   cancelAction
   confirmAction
   objectTypeName =
-  addModal "Confirm Delete" (const cancelAction) $
+  addModal (translate (label :: _ "common_confirmDelete") translator)
+    (const cancelAction) $
     [ HH.div
         [ HP.classes [ HB.modalBody ] ]
         [ HH.text $

--- a/frontend/src/FPO/Data/Route.purs
+++ b/frontend/src/FPO/Data/Route.purs
@@ -21,6 +21,7 @@ data Route
   | AdminViewUsers
   | AdminViewGroups
   | ViewGroupDocuments { groupID :: GroupID }
+  | ViewGroupMembers { groupID :: GroupID }
   | Page404
   | Profile { loginSuccessful :: Maybe Boolean }
 
@@ -38,6 +39,7 @@ routeCodec = root $ sum
   , "AdminViewUsers": "admin-users" / noArgs
   , "AdminViewGroups": "admin-groups" / noArgs
   , "ViewGroupDocuments": "view-group-documents" ? { groupID: int }
+  , "ViewGroupMembers": "view-group-members" ? { groupID: int }
   , "Page404": "404" / noArgs
   , "Profile": "profile" ? { loginSuccessful: optional <<< boolean }
   }
@@ -53,6 +55,7 @@ routeToString = case _ of
   AdminViewUsers -> "AdminViewUsers"
   AdminViewGroups -> "AdminViewGroups"
   ViewGroupDocuments groupID -> "ViewGroupDocuments:" <> show groupID
+  ViewGroupMembers groupID -> "ViewGroupMembers:" <> show groupID
   Page404 -> "Page404"
   Profile { loginSuccessful } -> "Profile" <>
     ( if loginSuccessful == Nothing then ""

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -23,6 +23,7 @@ import FPO.Data.Store (loadLanguage)
 import FPO.Data.Store as Store
 import FPO.Dto.UserDto (User)
 import FPO.Page.Admin.Group.DocOverview as ViewGroupDocuments
+import FPO.Page.Admin.Group.MemberOverview as ViewGroupMembers
 import FPO.Page.Admin.Groups as AdminViewGroups
 import FPO.Page.Admin.Users as AdminViewUsers
 import FPO.Page.EditorPage as EditorPage
@@ -82,6 +83,7 @@ _resetPassword = Proxy :: Proxy "resetPassword"
 _adminUsers = Proxy :: Proxy "adminPanelUsers"
 _adminGroups = Proxy :: Proxy "adminPanelGroups"
 _viewGroupDocuments = Proxy :: Proxy "viewGroupDocuments"
+_viewGroupMembers = Proxy :: Proxy "viewGroupMembers"
 _page404 = Proxy :: Proxy "page404"
 _profile = Proxy :: Proxy "profile"
 
@@ -94,6 +96,7 @@ type Slots =
   , adminPanelUsers :: forall q. H.Slot q Void Unit
   , adminPanelGroups :: forall q. H.Slot q Void Unit
   , viewGroupDocuments :: forall q. H.Slot q Void Unit
+  , viewGroupMembers :: forall q. H.Slot q Void Unit
   , page404 :: forall q. H.Slot q Void Unit
   , profile :: forall q. H.Slot q Void Unit
   )
@@ -138,6 +141,9 @@ component =
           AdminViewGroups -> HH.slot_ _adminGroups unit AdminViewGroups.component unit
           ViewGroupDocuments { groupID } -> HH.slot_ _viewGroupDocuments unit
             ViewGroupDocuments.component
+            groupID
+          ViewGroupMembers { groupID } -> HH.slot_ _viewGroupMembers unit
+            ViewGroupMembers.component
             groupID
           Page404 -> HH.slot_ _page404 unit Page404.component unit
           Profile { loginSuccessful } -> HH.slot_ _profile unit Profile.component

--- a/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
@@ -1,0 +1,450 @@
+-- | Overview of Members belonging to a Group.
+
+module FPO.Page.Admin.Group.MemberOverview (component) where
+
+import Prelude
+
+import Affjax (printError)
+import Data.Array (filter, length, null, replicate, slice)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String (contains)
+import Data.String.Pattern (Pattern(..))
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console (log)
+import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
+import FPO.Components.Pagination as P
+import FPO.Components.Table.Head as TH
+import FPO.Data.Navigate (class Navigate, navigate)
+import FPO.Data.Request (changeRole, deleteIgnore, getGroup, getStatusCode, getUser)
+import FPO.Data.Route (Route(..))
+import FPO.Data.Store as Store
+import FPO.Dto.GroupDto
+  ( GroupDto
+  , GroupID
+  , GroupMemberDto
+  , Role(..)
+  , UserID
+  , getGroupMembers
+  , getUserInfoID
+  , getUserInfoName
+  , getUserInfoRole
+  , lookupUser
+  )
+import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
+import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addCard, addColumn)
+import FPO.UI.Style as Style
+import Halogen (liftAff)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Halogen.Store.Connect (Connected, connect)
+import Halogen.Store.Monad (class MonadStore)
+import Halogen.Themes.Bootstrap5 as HB
+import Halogen.Themes.Bootstrap5 as Hb
+import Simple.I18n.Translator (label, translate)
+import Type.Proxy (Proxy(..))
+
+_tablehead = Proxy :: Proxy "tablehead"
+_pagination = Proxy :: Proxy "pagination"
+
+type Slots =
+  ( tablehead :: forall q. H.Slot q TH.Output Unit
+  , pagination :: H.Slot P.Query P.Output Unit
+  )
+
+type Input = GroupID
+
+data Action
+  = Initialize
+  | Receive (Connected FPOTranslator Input)
+  | SetPage P.Output
+  | FilterForMember String
+  | ChangeSorting TH.Output
+  -- | Actions regarding deletion of members.
+  | RequestRemoveMember UserID
+  | ConfirmRemoveMember UserID
+  | CancelModal
+  | ReloadGroupMembers
+  | NavigateToDocuments
+  | SetUserRole GroupMemberDto Role
+
+-- | Simple "state machine" for the modal system.
+data ModalState
+  = NoModal
+  | RemoveMemberModal UserID
+
+type State = FPOState
+  ( error :: Maybe String
+  , page :: Int
+  , groupID :: GroupID
+  , group :: Maybe GroupDto
+  , filteredMembers :: Array GroupMemberDto
+  , modalState :: ModalState
+  , isAdmin :: Boolean
+  , memberNameFilter :: String
+  )
+
+component
+  :: forall query output m
+   . MonadStore Store.Action Store.Store m
+  => MonadAff m
+  => Navigate m
+  => H.Component query Input output m
+component =
+  connect selectTranslator $ H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval H.defaultEval
+        { handleAction = handleAction
+        , initialize = Just Initialize
+        , receive = Just <<< Receive
+        }
+    }
+  where
+  initialState :: Connected FPOTranslator Input -> State
+  initialState { context, input } =
+    { translator: fromFpoTranslator context
+    , page: 0
+    , groupID: input
+    , filteredMembers: []
+    , modalState: NoModal
+    , error: Nothing
+    , group: Nothing
+    , isAdmin: false
+    , memberNameFilter: ""
+    }
+
+  render :: State -> H.ComponentHTML Action Slots m
+  render state =
+    HH.div
+      [ HP.classes [ HB.container, HB.my5 ] ]
+      $
+        ( case state.modalState of
+            RemoveMemberModal userID ->
+              fromMaybe [] do
+                group <- state.group
+                member <- lookupUser group userID
+                pure
+                  [ deleteConfirmationModal state.translator userID
+                      (const $ getUserInfoName member)
+                      CancelModal
+                      ConfirmRemoveMember
+                      (translate (label :: _ "common_member") state.translator)
+                  ]
+            _ -> []
+        ) <>
+          [ renderMemberManagement state
+          , HH.div [ HP.classes [ HB.textCenter ] ]
+              [ case state.error of
+                  Just err -> HH.div
+                    [ HP.classes [ HB.alert, HB.alertDanger, HB.mt5 ] ]
+                    [ HH.text err ]
+                  Nothing -> HH.text ""
+              ]
+          ]
+
+  renderMemberManagement :: State -> H.ComponentHTML Action Slots m
+  renderMemberManagement state =
+    HH.div_
+      [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
+          [ HH.text $ translate (label :: _ "gm_memberManagement")
+              state.translator
+          ]
+      , renderMemberListView state
+      ]
+
+  renderMemberListView :: State -> H.ComponentHTML Action Slots m
+  renderMemberListView state =
+    case state.group of
+      Nothing -> HH.div [ HP.classes [ HB.my3, HB.textCenter ] ]
+        [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
+      Just _ -> HH.div [ HP.classes [ HB.row ] ]
+        [ renderSideButtons state
+        , renderMembersOverview state
+        ]
+
+  -- Renders the overview of members of this group.
+  renderMembersOverview :: State -> H.ComponentHTML Action Slots m
+  renderMembersOverview state =
+    HH.div [ HP.classes [ HB.col12, HB.colMd9, HB.colLg8 ] ]
+      [ addCard
+          ( translate (label :: _ "gm_membersOfGroup") state.translator
+          )
+          []
+          (renderMemberOverview state)
+      ]
+
+  -- Search bar and list of members.
+  renderMemberOverview :: State -> H.ComponentHTML Action Slots m
+  renderMemberOverview state =
+    HH.div [ HP.classes [ HB.container ] ]
+      [ HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
+          [ HH.div [ HP.classes [ HB.col6 ] ]
+              [ addColumn
+                  state.memberNameFilter
+                  ""
+                  (translate (label :: _ "gm_searchMembers") state.translator)
+                  "bi-search"
+                  HP.InputText
+                  FilterForMember
+              ]
+          , HH.div [ HP.classes [ HB.col12 ] ]
+              [ renderMemberList docs state ]
+          , HH.slot _pagination unit P.component ps SetPage
+          ]
+      ]
+    where
+    docs = slice (state.page * 10) ((state.page + 1) * 10) state.filteredMembers
+    ps =
+      { pages: P.calculatePageCount (length state.filteredMembers) 10
+      , style: P.Compact 1
+      , reaction: P.PreservePage
+      }
+
+  -- Renders the list of projects.
+  renderMemberList :: Array GroupMemberDto -> State -> H.ComponentHTML Action Slots m
+  renderMemberList docs state =
+    HH.table
+      [ HP.classes [ HB.table, HB.tableHover, HB.tableBordered ] ]
+      [ HH.colgroup_
+          [ HH.col [ HP.style "width: 55%;" ]
+          , HH.col [ HP.style "width: 35%;" ]
+          , HH.col [ HP.style "width: 10%;" ]
+          ]
+      , HH.slot _tablehead unit TH.component
+          { columns: tableCols
+          , sortedBy: translate (label :: _ "common_userName") state.translator
+          }
+          ChangeSorting
+      , HH.tbody_ $
+          if null docs then
+            [ HH.tr []
+                [ HH.td
+                    [ HP.colSpan 3
+                    , HP.classes [ HB.textCenter ]
+                    ]
+                    [ HH.i_ [ HH.text "No members found" ] ]
+                ]
+            ]
+          else
+            ( map (renderMemberEntry state) docs
+                <> replicate (10 - length docs) (emptyMemberEntry state)
+            )
+      ]
+    where
+    tableCols = TH.createTableColumns
+      [ { title: translate (label :: _ "common_userName") state.translator
+        , style: Nothing
+        }
+      , { title: translate (label :: _ "gm_role") state.translator
+        , style: Nothing
+        }
+      , { title: ""
+        , style: Nothing
+        }
+      ]
+
+  -- Renders a single project row in the table.
+  renderMemberEntry :: forall w. State -> GroupMemberDto -> HH.HTML w Action
+  renderMemberEntry state member =
+    HH.tr
+      []
+      [ HH.td [ HP.classes [ HB.textCenter ] ]
+          [ HH.text $ getUserInfoName member ]
+      , HH.td [ HP.classes [ HB.textCenter ] ]
+          [ memberRole ]
+      , HH.td [ HP.classes [ HB.textCenter ] ]
+          [ buttonRemoveMember state $ getUserInfoID member ]
+      ]
+    where
+    -- Admins have a dropdown to change the role of the member.
+    memberRole
+      | state.isAdmin =
+          HH.select
+            [ HE.onValueChange setRole
+            , HP.classes [ HB.formSelect, Hb.formSelectSm ]
+            ]
+            [ HH.option
+                [ HP.value adminStr
+                , HP.selected (getUserInfoRole member == Admin)
+                ]
+                [ HH.text adminStr ]
+            , HH.option
+                [ HP.value memberStr
+                , HP.selected (getUserInfoRole member == Member)
+                ]
+                [ HH.text memberStr ]
+            ]
+      | otherwise = HH.text userRoleString
+
+    userRoleString = case getUserInfoRole member of
+      Admin -> adminStr
+      Member -> memberStr
+
+    adminStr :: String
+    adminStr = "Admin"
+
+    memberStr :: String
+    memberStr = translate (label :: _ "common_member") state.translator
+
+    setRole :: String -> Action
+    setRole roleStr =
+      if roleStr == adminStr then
+        SetUserRole member Admin
+      else
+        SetUserRole member Member
+
+  -- Renders an empty project row for padding.
+  emptyMemberEntry :: forall w. State -> HH.HTML w Action
+  emptyMemberEntry state =
+    HH.tr []
+      [ HH.td
+          [ HP.colSpan 3
+          , HP.classes [ HB.textCenter, HB.invisible ]
+          ]
+          [ HH.text $ "Empty Row", buttonRemoveMember state "" ]
+      ]
+
+  renderSideButtons :: forall w. State -> HH.HTML w Action
+  renderSideButtons state =
+    HH.div [ HP.classes [ HB.colMd3, HB.colLg2, HB.col12, HB.mb3 ] ]
+      [ HH.div
+          [ HP.classes [ HB.dFlex, HB.dMdGrid, HB.justifyContentCenter, HB.gap2 ] ]
+          [ renderToDocumentsButton state
+          , renderAddMemberButton state
+          ]
+      ]
+
+  renderToDocumentsButton :: forall w. State -> HH.HTML w Action
+  renderToDocumentsButton state =
+    HH.button
+      [ Style.cyanStyle
+      , HE.onClick (const NavigateToDocuments)
+      ]
+      [ HH.text $ translate (label :: _ "common_projects") state.translator ]
+
+  renderAddMemberButton :: forall w. State -> HH.HTML w Action
+  renderAddMemberButton state =
+    HH.button
+      [ Style.cyanStyle
+      -- , HE.onClick (const $ DoNothing) -- TODO: Actually implement
+      ]
+      [ HH.text $ translate (label :: _ "gm_addMember") state.translator ]
+
+  buttonRemoveMember :: forall w. State -> String -> HH.HTML w Action
+  buttonRemoveMember state memberID =
+    HH.button
+      [ HP.classes [ HB.btn, HB.btnOutlineDanger, HB.btnSm ]
+      , HE.onClick (const $ RequestRemoveMember memberID)
+      , Style.popover
+          ( translate (label :: _ "gm_removeMember") state.translator
+          )
+      ]
+      [ HH.i
+          [ HP.class_ $ HH.ClassName "bi-door-open" ]
+          []
+      ]
+
+  handleAction :: Action -> H.HalogenM State Action Slots output m Unit
+  handleAction = case _ of
+    Initialize -> do
+      u <- liftAff $ getUser
+      H.modify_ _ { isAdmin = fromMaybe false $ _.isAdmin <$> u }
+      handleAction ReloadGroupMembers
+      handleAction $ FilterForMember ""
+    Receive { context } -> do
+      H.modify_ _ { translator = fromFpoTranslator context }
+    SetPage (P.Clicked p) -> do
+      H.modify_ _ { page = p }
+    FilterForMember mn -> do
+      s <- H.get
+      let allMembers = fromMaybe [] $ getGroupMembers <$> s.group
+      let
+        filteredMembers =
+          filter
+            (contains (Pattern mn) <<< getUserInfoName)
+            allMembers
+      H.modify_ _
+        { filteredMembers = filteredMembers, page = 0, memberNameFilter = mn }
+    RequestRemoveMember memberID -> do
+      H.modify_ _ { modalState = RemoveMemberModal memberID }
+    CancelModal -> do
+      H.modify_ \s -> s
+        { error = Nothing
+        , modalState = NoModal
+        }
+    ConfirmRemoveMember memberID -> do
+      s <- H.get
+      deleteResponse <- liftAff
+        (deleteIgnore ("/roles/" <> show s.groupID <> "/" <> memberID))
+      case deleteResponse of
+        Left err -> do
+          H.modify_ _
+            { error = Just (printError err)
+            , modalState = NoModal
+            }
+        Right _ -> do
+          log "Removed member successfully"
+          H.modify_ _
+            { error = Nothing
+            , modalState = NoModal
+            }
+
+      handleAction ReloadGroupMembers
+      handleAction (FilterForMember "")
+    ChangeSorting (TH.Clicked _ _) -> do
+      -- TODO: enable filtering using the columns
+      --       For this, we need to either change the group or additionally store
+      --       all members in the state.
+
+      H.tell _pagination unit $ P.SetPageQ 0
+    ReloadGroupMembers -> do
+      s <- H.get
+      g <- liftAff $ getGroup s.groupID
+      case g of
+        Just group -> do
+          H.modify_ _
+            { group = Just group
+            , filteredMembers = getGroupMembers group
+            , page = 0
+            }
+        Nothing -> do
+          navigate Login
+    NavigateToDocuments -> do
+      log "Routing to document overview"
+      s <- H.get
+      navigate (ViewGroupDocuments { groupID: s.groupID })
+    SetUserRole member role -> do
+      -- TODO: Instead of writing code like this, we should resort to using only high-level
+      --       requests in components. These high-level requests must then be implemented
+      --       in another module, and the component should only call them and easily handle the
+      --       result.
+      s <- H.get
+      let userID = getUserInfoID member
+      if getUserInfoRole member == role then
+        log "User already has this role, ignoring"
+      else do
+        response <- liftAff $ changeRole s.groupID userID role
+        case response of
+          Left err -> do
+            H.modify_ _
+              { error = Just (printError err)
+              , modalState = NoModal
+              }
+          Right status -> do
+            case getStatusCode status of
+              200 -> do
+                log "Changed user role successfully"
+                handleAction ReloadGroupMembers
+                handleAction (FilterForMember "")
+              _ -> do
+                H.modify_ _
+                  { error = Just $ "Failed to change role: " <> show status
+                  , modalState = NoModal
+                  }
+
+      handleAction ReloadGroupMembers
+      handleAction (FilterForMember "")

--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -30,7 +30,12 @@ import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request (getDocumentsFromURLWithPermission, getUser)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
-import FPO.Dto.DocumentDto (DocumentHeaderPlusPermission, DocumentID, getDHPPID, getDHPPName)
+import FPO.Dto.DocumentDto
+  ( DocumentHeaderPlusPermission
+  , DocumentID
+  , getDHPPID
+  , getDHPPName
+  )
 import FPO.Dto.UserDto (User)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)

--- a/frontend/src/FPO/Translations/Common.purs
+++ b/frontend/src/FPO/Translations/Common.purs
@@ -5,6 +5,7 @@ import Simple.I18n.Translation (Translation, fromRecord)
 
 type CommonLabels =
   ( "common_cancel"
+      ::: "common_confirmDelete"
       ::: "common_create"
       ::: "common_delete"
       ::: "common_deletePhraseA"
@@ -14,11 +15,15 @@ type CommonLabels =
       ::: "common_filterBy"
       ::: "common_group"
       ::: "common_home"
+      ::: "common_member"
       ::: "common_members"
+      ::: "common_membersOf"
       ::: "common_password"
       ::: "common_project"
+      ::: "common_projects"
       ::: "common_submit"
       ::: "common_theGroup"
+      ::: "common_user"
       ::: "common_userName"
       ::: SNil
   )
@@ -26,6 +31,7 @@ type CommonLabels =
 enCommon :: Translation CommonLabels
 enCommon = fromRecord
   { common_cancel: "Cancel"
+  , common_confirmDelete: "Confirm Delete"
   , common_create: "Create"
   , common_delete: "Delete"
   , common_deletePhraseA: "Are you sure you want to delete "
@@ -35,9 +41,13 @@ enCommon = fromRecord
   , common_filterBy: "Filter by"
   , common_group: "group"
   , common_home: "Home"
+  , common_member: "Member"
   , common_members: "Members"
+  , common_membersOf: "Members of "
   , common_password: "Password"
   , common_project: "project"
+  , common_projects: "Projects"
+  , common_user: "User"
   , common_userName: "User name"
   -- TODO: Change to "the group"? Not sure if this sounds better
   --       in english, but using the article might sound better in
@@ -49,6 +59,7 @@ enCommon = fromRecord
 deCommon :: Translation CommonLabels
 deCommon = fromRecord
   { common_cancel: "Abbrechen"
+  , common_confirmDelete: "Löschen bestätigen"
   , common_create: "Erstellen"
   , common_delete: "Löschen"
   , common_deletePhraseA: "Sind Sie sicher, dass Sie "
@@ -58,9 +69,13 @@ deCommon = fromRecord
   , common_filterBy: "Filtern nach"
   , common_group: "Gruppe"
   , common_home: "Start"
+  , common_member: "Mitglied"
   , common_members: "Mitglieder"
+  , common_membersOf: "Mitglieder von "
   , common_password: "Passwort"
   , common_project: "Projekt"
+  , common_projects: "Projekte"
+  , common_user: "Benutzer"
   , common_userName: "Benutzername"
   , common_theGroup: "die Gruppe"
   , common_submit: "Absenden"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -4,6 +4,7 @@ import Data.Function (($))
 import FPO.Translations.Common (deCommon, enCommon)
 import FPO.Translations.Components.Editor (deEditor, enEditor)
 import FPO.Translations.Components.Navbar (deNavbar, enNavbar)
+import FPO.Translations.Page.Admin.GroupMembers (deGroupMemberPage, enGroupMemberPage)
 import FPO.Translations.Page.Admin.GroupProjects
   ( deGroupProjectsPage
   , enGroupProjectsPage
@@ -20,80 +21,39 @@ import Record (merge)
 import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord, toRecord)
 
--- | Übersetzungen zusammenführen
 en :: Translation Labels
-en = fromRecord $
-  merge
-    ( merge
-        ( merge
-            ( merge (toRecord enAdminPanel)
-                (toRecord enAdminGroupPage)
-            )
-            ( merge (toRecord enAdminUserPage)
-                (toRecord enCommon)
-            )
-        )
-        ( merge
-            ( merge (toRecord enEditor)
-                (toRecord enNavbar)
-            )
-            ( merge (toRecord enHome)
-                (toRecord enLogin)
-            )
-        )
-    )
-
-    ( merge
-        ( merge
-            ( merge (toRecord enPage404)
-                (toRecord enPasswordReset)
-            )
-            ( merge (toRecord enProfile)
-                (toRecord enGroupProjectsPage)
-            )
-        )
-        ( merge
-            (merge {} {})
-            (merge {} {})
-        )
-    )
+en = fromRecord
+  $ merge (toRecord enAdminPanel)
+  $ merge (toRecord enAdminGroupPage)
+  $ merge (toRecord enAdminUserPage)
+  $ merge (toRecord enCommon)
+  $ merge (toRecord enEditor)
+  $ merge (toRecord enNavbar)
+  $ merge (toRecord enHome)
+  $ merge (toRecord enLogin)
+  $ merge (toRecord enPage404)
+  $ merge (toRecord enPasswordReset)
+  $ merge (toRecord enProfile)
+  $ merge (toRecord enGroupProjectsPage)
+  $
+    toRecord enGroupMemberPage
 
 de :: Translation Labels
-de = fromRecord $
-  merge
-    ( merge
-        ( merge
-            ( merge (toRecord deAdminPanel)
-                (toRecord deAdminGroupPage)
-            )
-            ( merge (toRecord deAdminUserPage)
-                (toRecord deCommon)
-            )
-        )
-        ( merge
-            ( merge (toRecord deEditor)
-                (toRecord deNavbar)
-            )
-            ( merge (toRecord deHome)
-                (toRecord deLogin)
-            )
-        )
-    )
-
-    ( merge
-        ( merge
-            ( merge (toRecord dePage404)
-                (toRecord dePasswordReset)
-            )
-            ( merge (toRecord deProfile)
-                (toRecord deGroupProjectsPage)
-            )
-        )
-        ( merge
-            (merge {} {})
-            (merge {} {})
-        )
-    )
+de = fromRecord
+  $ merge (toRecord deAdminPanel)
+  $ merge (toRecord deAdminGroupPage)
+  $ merge (toRecord deAdminUserPage)
+  $ merge (toRecord deCommon)
+  $ merge (toRecord deEditor)
+  $ merge (toRecord deNavbar)
+  $ merge (toRecord deHome)
+  $ merge (toRecord deLogin)
+  $ merge (toRecord dePage404)
+  $ merge (toRecord dePasswordReset)
+  $ merge (toRecord deProfile)
+  $ merge (toRecord deGroupProjectsPage)
+  $
+    toRecord deGroupMemberPage
 
 -- | All kinds of abstract labels representing UI texts,
 -- | detached from the actual language selection.
@@ -137,6 +97,7 @@ type Labels =
 
       -- | Common Phrases
       ::: "common_cancel"
+      ::: "common_confirmDelete"
       ::: "common_create"
       ::: "common_delete"
       ::: "common_deletePhraseA"
@@ -146,11 +107,15 @@ type Labels =
       ::: "common_filterBy"
       ::: "common_group"
       ::: "common_home"
+      ::: "common_member"
       ::: "common_members"
+      ::: "common_membersOf"
       ::: "common_password"
       ::: "common_project"
+      ::: "common_projects"
       ::: "common_submit"
       ::: "common_theGroup"
+      ::: "common_user"
       ::: "common_userName"
 
       -- | Editor Page
@@ -164,6 +129,14 @@ type Labels =
       ::: "editor_textUnderline"
       ::: "editor_undo"
 
+      -- | Group Members Page
+      ::: "gm_addMember"
+      ::: "gm_memberManagement"
+      ::: "gm_membersOfGroup"
+      ::: "gm_removeMember"
+      ::: "gm_role"
+      ::: "gm_searchMembers"
+
       -- | Group Projects Page
       ::: "gp_createNewProject"
       ::: "gp_documentName"
@@ -171,6 +144,7 @@ type Labels =
       ::: "gp_groupProjects"
       ::: "gp_newProject"
       ::: "gp_projectManagement"
+      ::: "gp_removeProject"
       ::: "gp_searchProjects"
 
       -- | Home Page

--- a/frontend/src/FPO/Translations/Page/Admin/GroupMembers.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/GroupMembers.purs
@@ -1,0 +1,34 @@
+module FPO.Translations.Page.Admin.GroupMembers where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type GroupMemberPageLabels =
+  ( "gm_addMember"
+      ::: "gm_memberManagement"
+      ::: "gm_membersOfGroup"
+      ::: "gm_removeMember"
+      ::: "gm_role"
+      ::: "gm_searchMembers"
+      ::: SNil
+  )
+
+enGroupMemberPage :: Translation GroupMemberPageLabels
+enGroupMemberPage = fromRecord
+  { gm_addMember: "Add Member"
+  , gm_memberManagement: "Member Management"
+  , gm_membersOfGroup: "Members of Group"
+  , gm_removeMember: "Remove Member"
+  , gm_role: "Role"
+  , gm_searchMembers: "Search for members"
+  }
+
+deGroupMemberPage :: Translation GroupMemberPageLabels
+deGroupMemberPage = fromRecord
+  { gm_addMember: "Mitglied hinzufügen"
+  , gm_memberManagement: "Mitgliederverwaltung"
+  , gm_membersOfGroup: "Mitglieder der Gruppe"
+  , gm_removeMember: "Mitglied entfernen"
+  , gm_role: "Rolle"
+  , gm_searchMembers: "Nach Mitgliedern suchen"
+  }

--- a/frontend/src/FPO/Translations/Page/Admin/GroupProjects.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/GroupProjects.purs
@@ -10,6 +10,7 @@ type GroupProjectsPageLabels =
       ::: "gp_groupProjects"
       ::: "gp_newProject"
       ::: "gp_projectManagement"
+      ::: "gp_removeProject"
       ::: "gp_searchProjects"
       ::: SNil
   )
@@ -22,6 +23,7 @@ enGroupProjectsPage = fromRecord
   , gp_groupProjects: "Projects of Group"
   , gp_newProject: "Create Project"
   , gp_projectManagement: "Project Management"
+  , gp_removeProject: "Remove Project"
   , gp_searchProjects: "Search for Projects"
   }
 
@@ -33,5 +35,6 @@ deGroupProjectsPage = fromRecord
   , gp_groupProjects: "Projekte der Gruppe"
   , gp_newProject: "Neues Projekt"
   , gp_projectManagement: "Projektverwaltung"
+  , gp_removeProject: "Projekt entfernen"
   , gp_searchProjects: "Suche nach Projekten"
   }


### PR DESCRIPTION
This PR adds the member overview page (slide 19/109 of the mockup) to the frontend. Currently, one can
1. view all members of the groups
2. change roles of all members (if one is an admin)
3. remove users from the group

Also, switching between the "documents" and "members" overview pages is now supported.

See issue #139 