### PR TITLE
Backend Docs: Fix OpenAPI Types

### DIFF
--- a/backend/src/Docs/Tree.hs
+++ b/backend/src/Docs/Tree.hs
@@ -36,6 +36,8 @@ import Data.OpenApi
     , type_
     )
 
+import qualified Data.Text as Text
+import Data.Typeable (typeRep)
 import Docs.TextElement (TextElement, TextElementID)
 import qualified Docs.TextElement as TextElement
 import Docs.TextRevision
@@ -98,7 +100,7 @@ instance (ToSchema a) => ToSchema (Tree a) where
         leafSchema <- declareSchemaRef (Proxy :: Proxy a)
 
         return $
-            NamedSchema (Just "Tree") $
+            NamedSchema (Just $ withTypeName "Tree") $
                 mempty
                     & type_ ?~ OpenApiObject
                     & oneOf
@@ -127,6 +129,8 @@ instance (ToSchema a) => ToSchema (Tree a) where
             mempty
                 & type_ ?~ OpenApiString
                 & enum_ ?~ [toJSON val]
+        withTypeName s = Text.pack $ s ++ " " ++ typeName
+        typeName = show $ typeRep (Proxy :: Proxy a)
 
 -- | An edge (from a node) to a node or leaf.
 data Edge a = Edge

--- a/backend/src/Docs/TreeRevision.hs
+++ b/backend/src/Docs/TreeRevision.hs
@@ -54,6 +54,7 @@ import Web.HttpApiData (FromHttpApiData (..))
 
 import UserManagement.User (UserID)
 
+import Data.Typeable (typeRep)
 import Docs.Document (DocumentID (..))
 import Docs.TextElement (TextElement, TextElementID)
 import Docs.TextRevision (TextElementRevision, TextRevision)
@@ -190,14 +191,18 @@ instance (ToSchema a) => ToSchema (TreeRevision a) where
     declareNamedSchema _ = do
         headerSchema <- declareSchemaRef (Proxy :: Proxy TreeRevisionHeader)
         rootSchema <- declareSchemaRef (Proxy :: Proxy (Node a))
-        return $
-            NamedSchema (Just "TreeRevision") $
-                mempty
-                    & type_ ?~ OpenApiObject
-                    & properties
-                        .~ InsOrd.fromList
-                            [("header", headerSchema), ("root", rootSchema)]
-                    & required .~ ["header", "root"]
+        return
+            $ NamedSchema
+                (Just $ withTypeName "TreeRevision")
+            $ mempty
+                & type_ ?~ OpenApiObject
+                & properties
+                    .~ InsOrd.fromList
+                        [("header", headerSchema), ("root", rootSchema)]
+                & required .~ ["header", "root"]
+      where
+        withTypeName s = Text.pack $ s ++ " " ++ typeName
+        typeName = show $ typeRep (Proxy :: Proxy a)
 
 -- | Sequence of revisions for a document tree.
 data TreeRevisionHistory


### PR DESCRIPTION
This PR fixes wrong OpenAPI schemas for the new docs API.