### PR TITLE
backend/ltml: Fix labeled keyword parser

### DIFF
--- a/backend/src/Language/Ltml/Parser/Keyword.hs
+++ b/backend/src/Language/Ltml/Parser/Keyword.hs
@@ -11,12 +11,11 @@ import Control.Monad (void)
 import Language.Lsd.AST.Common (Keyword (Keyword))
 import Language.Ltml.AST.Label (Label)
 import Language.Ltml.Parser (MonadParser)
-import Language.Ltml.Parser.Label (labelP)
-import Text.Megaparsec.Char (char, string)
+import Language.Ltml.Parser.Label (labelingP)
+import Text.Megaparsec.Char (string)
 
 keywordP :: (MonadParser m) => Keyword -> m ()
 keywordP (Keyword kw) = void $ string kw
 
 mlKeywordP :: (MonadParser m) => Keyword -> m (Maybe Label)
-mlKeywordP (Keyword kw) =
-    string kw *> optional (char '{' *> labelP <* char '}')
+mlKeywordP (Keyword kw) = string kw *> optional labelingP


### PR DESCRIPTION
It still expected {keyword}, not {keyword:}.