### PR TITLE
Backend Docs: Fix `EXISTS` SQL Queries

### DIFF
--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -100,12 +100,14 @@ existsDocument =
     lmap
         unDocumentID
         [singletonStatement|
-            SELECT
-                1 :: bool
-            FROM
-                docs
-            WHERE
-                id = $1 :: int4
+            SELECT EXISTS (
+                SELECT
+                    1 :: bool
+                FROM
+                    docs
+                WHERE
+                    id = $1 :: int4
+            ) :: bool
         |]
 
 existsTreeRevision :: Statement TreeRevisionRef Bool
@@ -113,13 +115,15 @@ existsTreeRevision =
     lmap
         uncurryTreeRevisionRef
         [singletonStatement|
-            SELECT
-                1 :: bool
-            FROM
-                doc_tree_revisions
-            WHERE
-                document = $1 :: int4
-                AND ($2 :: int4? IS NULL OR id = $2 :: int4?)
+            SELECT EXISTS (
+                SELECT
+                    1
+                FROM
+                    doc_tree_revisions
+                WHERE
+                    document = $1 :: int4
+                    AND ($2 :: int4? IS NULL OR id = $2 :: int4?)
+            ) :: bool
         |]
 
 existsTextElement :: Statement TextElementRef Bool
@@ -127,13 +131,15 @@ existsTextElement =
     lmap
         uncurryTextElementRef
         [singletonStatement|
-            SELECT
-                1 :: bool
-            FROM
-                doc_text_elements
-            WHERE
-                document = $1 :: int4
-                AND id = $2 :: int4
+            SELECT EXISTS (
+                SELECT
+                    1
+                FROM
+                    doc_text_elements
+                WHERE
+                    document = $1 :: int4
+                    AND id = $2 :: int4
+            ) :: bool
         |]
 
 existsTextRevision :: Statement TextRevisionRef Bool
@@ -141,15 +147,17 @@ existsTextRevision =
     lmap
         uncurryTextRevisionRef
         [singletonStatement|
-            SELECT
-                1 :: bool
-            FROM
-                doc_text_revisions tr
-                JOIN doc_text_elements te on tr.text_element = te.id
-            WHERE
-                te.document = $1 :: int4
-                AND tr.text_element = $2 :: int4
-                AND ($3 :: int4? IS NULL OR tr.id = $3 :: int4?)
+            SELECT EXISTS (
+                SELECT
+                    1
+                FROM
+                    doc_text_revisions tr
+                    JOIN doc_text_elements te on tr.text_element = te.id
+                WHERE
+                    te.document = $1 :: int4
+                    AND tr.text_element = $2 :: int4
+                    AND ($3 :: int4? IS NULL OR tr.id = $3 :: int4?)
+            ) :: bool
         |]
 
 uncurryDocument

--- a/scripts/test_api.py
+++ b/scripts/test_api.py
@@ -42,6 +42,14 @@ class Client:
         query = f"?{query}" if query else ""
         return self.get_json(f"docs/{doc_id}/history{query}")
 
+    def document_text_revision(
+        self,
+        doc_id: int,
+        text_id: int,
+        revision: Literal["latest"] | int
+    ) -> str:
+        return self.get_json(f"docs/{doc_id}/text/{text_id}/rev/{revision}")
+
     def post(self, endpoint: str, payload: object) -> Response:
         return self.__session.post(
             url=f"{self.__host}/{endpoint}",
@@ -83,3 +91,4 @@ if __name__ == "__main__":
     print(client.document(1))
     print(client.document_tree_full(1, "latest"))
     print(client.document_history(1, limit=5))
+    print(client.document_text_revision(1, 1, "latest"))


### PR DESCRIPTION
Currently, the text and tree revision endpoints fail with a database error if no specific revision is specified (i.e. the latest revision is requested). This PR fixes the issue.