### PR TITLE
Move core user functionality to components 

### DIFF
--- a/frontend/src/FPO/Components/UI/UserFilter.purs
+++ b/frontend/src/FPO/Components/UI/UserFilter.purs
@@ -1,0 +1,100 @@
+-- | Simple card / form box for filtering users.
+
+module FPO.Components.UI.UserFilter
+  ( Output(..)
+  , component
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Effect.Aff.Class (class MonadAff)
+import FPO.Data.Store as Store
+import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
+import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addButton, addCard, addColumn)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Properties (InputType(..), classes) as HP
+import Halogen.Store.Connect (Connected, connect)
+import Halogen.Store.Monad (class MonadStore)
+import Halogen.Themes.Bootstrap5 as HB
+import Simple.I18n.Translator (label, translate)
+
+type State = FPOState (username :: String, email :: String)
+
+data Action
+  = SetUsername String
+  | SetEmail String
+  | HandleFilter
+  | Receive (Connected FPOTranslator Unit)
+
+data Output = Filter { username :: String, email :: String }
+
+component
+  :: forall m q
+   . MonadAff m
+  => MonadStore Store.Action Store.Store m
+  => H.Component q Unit Output m
+component = connect selectTranslator $ H.mkComponent
+  { initialState
+  , render
+  , eval: H.mkEval H.defaultEval
+      { handleAction = handleAction
+      , receive = Just <<< Receive
+      }
+  }
+  where
+  initialState :: Connected FPOTranslator Unit -> State
+  initialState { context } =
+    { username: ""
+    , email: ""
+    , translator: fromFpoTranslator context
+    }
+
+  render :: State -> H.ComponentHTML Action () m
+  render state =
+    addCard (translate (label :: _ "common_filterBy") state.translator)
+      [ HP.classes [ HB.col12, HB.colMd3, HB.colLg3, HB.mb3 ] ] $ HH.div
+      [ HP.classes [ HB.row ] ]
+      [ HH.div [ HP.classes [ HB.col ] ]
+          [ addColumn
+              state.username
+              (translate (label :: _ "common_userName") state.translator)
+              (translate (label :: _ "common_userName") state.translator)
+              "bi-person"
+              HP.InputText
+              SetUsername
+          , addColumn
+              state.email
+              (translate (label :: _ "common_email") state.translator)
+              (translate (label :: _ "common_email") state.translator)
+              "bi-envelope-fill"
+              HP.InputEmail
+              SetEmail
+          ]
+      , HH.div [ HP.classes [ HB.col12, HB.textCenter ] ]
+          [ HH.div [ HP.classes [ HB.dInlineBlock ] ]
+              [ addButton
+                  true
+                  "Filter"
+                  (Just "bi-funnel")
+                  (const HandleFilter)
+              ]
+          ]
+      ]
+
+  handleAction
+    :: forall slots
+     . Action
+    -> H.HalogenM State Action slots Output m Unit
+  handleAction action = case action of
+    SetUsername u -> do
+      H.modify_ _ { username = u }
+    SetEmail e -> do
+      H.modify_ _ { email = e }
+    HandleFilter -> do
+      state <- H.get
+      H.raise (Filter { username: state.username, email: state.email })
+    Receive { context } -> do
+      H.modify_ _ { translator = fromFpoTranslator context }

--- a/frontend/src/FPO/Components/UI/UserList.purs
+++ b/frontend/src/FPO/Components/UI/UserList.purs
@@ -1,0 +1,226 @@
+-- | Card containing a list of users. The users list is paginated and can be
+-- | filtered by username and email. Furthermore, it allows the refetching of
+-- | users (e.g., after a user has been created or deleted).
+-- |
+-- | Refer to the `Query` and `Output` types for interface documentation.
+
+module FPO.Components.UI.UserList where
+
+import Prelude
+
+import Data.Argonaut (decodeJson)
+import Data.Array (filter, length, null, replicate, slice)
+import Data.Maybe (Maybe(..))
+import Data.String (Pattern(..), contains)
+import Data.String as String
+import Effect.Aff.Class (class MonadAff)
+import Effect.Console (log)
+import FPO.Components.Pagination as P
+import FPO.Components.Pagination as P
+import FPO.Components.UI.UserFilter as Filter
+import FPO.Data.Request as R
+import FPO.Data.Store as Store
+import FPO.Dto.UserOverviewDto (UserOverviewDto(..))
+import FPO.Dto.UserOverviewDto as UserOverviewDto
+import FPO.Translations.Labels (Labels)
+import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
+import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addButton, addCard, addColumn, deleteButton)
+import FPO.UI.HTML (emptyEntryText)
+import Halogen (liftEffect)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Properties (InputType(..), classes) as HP
+import Halogen.Store.Connect (Connected, connect)
+import Halogen.Store.Monad (class MonadStore)
+import Halogen.Themes.Bootstrap5 (p4)
+import Halogen.Themes.Bootstrap5 as HB
+import Simple.I18n.Translator (Translator, label, translate)
+import Type.Proxy (Proxy(..))
+
+_pagination = Proxy :: Proxy "pagination"
+
+type State = FPOState
+  ( users :: Array UserOverviewDto
+  , filteredUsers :: Array UserOverviewDto
+  , page :: Int
+  , loading :: Boolean
+  )
+
+type Slots =
+  ( pagination :: H.Slot P.Query P.Output Unit
+  )
+
+data Action
+  = Receive (Connected FPOTranslator Unit)
+  | HandleFilter (Filter.Output)
+  | SetPage P.Output
+  | Initialize
+
+data Query a
+  -- | Query to reload the users list, for example,
+  -- | after the parent component has changed the
+  -- | user list using backend requests.
+  = ReloadUsersQ a
+  -- | Query to handle filter changes.
+  -- | The filter is passed as an argument, usually by
+  -- |   1. The parent component that received the filter change
+  -- |      from the `UserFilter` child.
+  -- |   2. The parent component that synthesizes the filter
+  -- |      itself.
+  | HandleFilterQ (Filter.Output) a
+
+data Output
+  -- | Output to indicate to the parent whether or not the user list is
+  -- | ready/loaded. This can be used to disable UI elements that depend on the
+  -- | user list, e.g., the "Create User" button, if wished.
+  = Loading Boolean
+  -- | Output to indicate an error, e.g., when the user list could not be loaded.
+  | Error String
+
+component
+  :: forall m
+   . MonadAff m
+  => MonadStore Store.Action Store.Store m
+  => H.Component Query Unit Output m
+component = connect selectTranslator $ H.mkComponent
+  { initialState
+  , render
+  , eval: H.mkEval H.defaultEval
+      { handleAction = handleAction
+      , receive = Just <<< Receive
+      , handleQuery = handleQuery
+      , initialize = Just Initialize
+      }
+  }
+  where
+  initialState :: Connected FPOTranslator Unit -> State
+  initialState { context } =
+    { users: []
+    , filteredUsers: []
+    , translator: fromFpoTranslator context
+    , page: 0
+    , loading: true
+    }
+
+  render :: State -> H.ComponentHTML Action Slots m
+  render state =
+    addCard (translate (label :: _ "admin_users_listOfUsers") state.translator)
+      [ HP.classes [ HB.col12, HB.colMd6, HB.colLg6, HB.mb3 ] ] $ HH.div_
+      if state.loading then
+        [ HH.div [ HP.classes [ HB.textCenter, HB.mt5 ] ]
+            [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
+        ]
+      else
+        [ HH.ul [ HP.classes [ HB.listGroup ] ]
+            $ map (createUserEntry state.translator) usrs
+                <> replicate (10 - length usrs)
+                  emptyEntryText
+        , HH.slot _pagination unit P.component ps SetPage
+        ]
+    where
+    usrs = slice (state.page * 10) ((state.page + 1) * 10) state.filteredUsers
+    ps =
+      { pages: P.calculatePageCount (length state.filteredUsers) 10
+      , style: P.Compact 1
+      , reaction: P.PreservePage
+      }
+
+  -- Creates a (dummy) user entry for the list.
+  createUserEntry
+    :: forall w. Translator Labels -> UserOverviewDto -> HH.HTML w Action
+  createUserEntry translator userOverviewDto =
+    HH.li
+      [ HP.classes
+          [ HB.listGroupItem
+          , HB.dFlex
+          , HB.justifyContentBetween
+          , HB.alignItemsCenter
+          ]
+      ]
+      [ HH.span [ HP.classes [ HB.col5 ] ]
+          [ HH.text $ UserOverviewDto.getName userOverviewDto ]
+      -- , HH.span [ HP.classes [ HB.col5 ] ]
+      --     [ HH.text $ UserOverviewDto.getEmail userOverviewDto ]
+      -- , HH.div [ HP.classes [ HB.col2, HB.dFlex, HB.justifyContentEnd, HB.gap1 ] ]
+      --     [ deleteButton (const $ RequestDeleteUser userOverviewDto)
+      --     , HH.button
+      --         [ HP.type_ HP.ButtonButton
+      --         , HP.classes [ HB.btn, HB.btnSm, HB.btnOutlinePrimary ]
+      --         , HE.onClick $ const $ GetUser (UserOverviewDto.getID userOverviewDto)
+      --         , HP.title
+      --             (translate (label :: _ "admin_users_goToProfilePage") translator)
+      --         ]
+      --         [ HH.i [ HP.classes [ HB.bi, (H.ClassName "bi-person-fill") ] ] []
+
+      --         ]
+      --     ]
+      ]
+
+  handleAction
+    :: Action
+    -> H.HalogenM State Action Slots Output m Unit
+  handleAction action = case action of
+    Initialize -> do
+      setLoading true
+      fetchAndLoadUsers
+      setLoading false
+    HandleFilter (Filter.Filter f) -> do
+      state <- H.get
+      let
+        filteredUsers = filter
+          ( \user ->
+              ( if String.null f.username then false
+                else
+                  contains (Pattern f.username)
+                    (UserOverviewDto.getName user)
+              )
+                ||
+                  ( if String.null f.email then false
+                    else
+                      contains
+                        (Pattern f.email)
+                        (UserOverviewDto.getEmail user)
+                  )
+          )
+          state.users
+      H.modify_ _ { filteredUsers = filteredUsers }
+    Receive { context } -> do
+      H.modify_ _ { translator = fromFpoTranslator context }
+    SetPage (P.Clicked p) -> do
+      H.modify_ _ { page = p }
+
+  handleQuery :: forall a. Query a -> H.HalogenM State Action Slots Output m (Maybe a)
+  handleQuery = case _ of
+    ReloadUsersQ a -> do
+      liftEffect $ log "ReloadUsersQ invoked..."
+      fetchAndLoadUsers
+      pure $ Just a
+    HandleFilterQ f a -> do
+      handleAction (HandleFilter f)
+      pure $ Just a
+
+  fetchAndLoadUsers
+    :: H.HalogenM State Action Slots Output m Unit
+  fetchAndLoadUsers = do
+    liftEffect $ log "Fetching user data, Loading=true..."
+    setLoading true
+    maybeUsers <- H.liftAff $ R.getFromJSONEndpoint decodeJson "/users"
+    case maybeUsers of
+      Nothing -> do
+        state <- H.get
+        H.raise $ Error $ translate (label :: _ "admin_users_failedToLoadUsers")
+          state.translator
+      Just users -> do
+        H.modify_ _ { users = users, filteredUsers = users }
+
+    liftEffect $ log "Done fetching, Loading=false!"
+    setLoading false
+
+  setLoading
+    :: MonadAff m
+    => Boolean
+    -> H.HalogenM State Action Slots Output m Unit
+  setLoading b = do
+    H.modify_ _ { loading = b }
+    H.raise $ Loading b

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -12,25 +12,17 @@ module FPO.Page.Admin.Users (component) where
 import Prelude
 
 import Affjax (printError)
-import Data.Argonaut (decodeJson, encodeJson)
-import Data.Array (filter, length, replicate, slice)
+import Data.Argonaut (encodeJson)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.String (contains, null)
-import Data.String.Pattern (Pattern(..))
+import Data.String (null)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Class.Console (log)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
-import FPO.Components.Pagination as P
+import FPO.Components.UI.UserFilter as Filter
+import FPO.Components.UI.UserList as UserList
 import FPO.Data.Email as Email
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request
-  ( LoadState(..)
-  , deleteIgnore
-  , getFromJSONEndpoint
-  , getUser
-  , postJson
-  )
+import FPO.Data.Request (deleteIgnore, getUser, postJson)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.CreateUserDto
@@ -45,46 +37,29 @@ import FPO.Dto.CreateUserDto
 import FPO.Dto.CreateUserDto as CreateUserDto
 import FPO.Dto.UserOverviewDto (UserOverviewDto)
 import FPO.Dto.UserOverviewDto as UserOverviewDto
-import FPO.Translations.Labels (Labels)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
-import FPO.UI.HTML
-  ( addButton
-  , addCard
-  , addColumn
-  , addError
-  , deleteButton
-  , emptyEntryText
-  )
+import FPO.UI.HTML (addButton, addCard, addColumn, addError)
 import Halogen as H
 import Halogen.HTML as HH
-import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore)
 import Halogen.Themes.Bootstrap5 as HB
-import Simple.I18n.Translator (Translator, label, translate)
+import Simple.I18n.Translator (label, translate)
 import Type.Proxy (Proxy(..))
 
-_pagination = Proxy :: Proxy "pagination"
+_filter = Proxy :: Proxy "filter"
+_userlist = Proxy :: Proxy "userlist"
 
 type Slots =
-  ( pagination :: H.Slot P.Query P.Output Unit
+  ( filter :: forall q. H.Slot q Filter.Output Unit
+  , userlist :: H.Slot UserList.Query UserList.Output Unit
   )
 
 data Action
   = Initialize
   | Receive (Connected FPOTranslator Unit)
-  | DoNothing -- Placeholder for future actions
-  | SetPage P.Output
-  -- TODO: Of course, we should add dedicated components for the filtering
-  --        and creation of users, but for now, we just use these actions to
-  --        demonstrate the functionality (mockup!). Or, might be even better,
-  --        to add a general component that allows us to create simple forms
-  --        with a label, input field(s), and a button. This way, we dont have to
-  --        repeat ourselves over and over again.
-  | ChangeFilterUsername String
-  | ChangeFilterEmail String
   | ChangeCreateUsername String
   | ChangeCreateEmail String
   | ChangeCreatePassword String
@@ -92,16 +67,12 @@ data Action
   | PerformDeleteUser String
   | CloseDeleteModal
   | GetUser String
-  | Filter
+  | HandleFilter Filter.Output
+  | HandleUserList UserList.Output
   | CreateUser
 
 type State = FPOState
   ( error :: Maybe String
-  , page :: Int
-  , users :: LoadState (Array UserOverviewDto)
-  , filteredUsers :: Array UserOverviewDto
-  , filterUsername :: String
-  , filterEmail :: String
   , createUserDto :: CreateUserDto
   , createUserError :: Maybe String
   , createUserSuccess :: Maybe String
@@ -130,11 +101,6 @@ component =
   initialState { context } =
     { translator: fromFpoTranslator context
     , error: Nothing
-    , page: 0
-    , users: Loading
-    , filteredUsers: []
-    , filterUsername: ""
-    , filterEmail: ""
     , createUserDto: CreateUserDto.empty
     , createUserError: Nothing
     , createUserSuccess: Nothing
@@ -156,16 +122,10 @@ component =
     Initialize -> do
       u <- H.liftAff $ getUser
       when (fromMaybe true (not <$> _.isAdmin <$> u)) $ navigate Page404
-      fetchAndLoadUsers
+      H.tell _userlist unit UserList.ReloadUsersQ
 
     Receive { context } -> do
       H.modify_ _ { translator = fromFpoTranslator context }
-    DoNothing -> do
-      pure unit
-    SetPage (P.Clicked p) -> do
-      H.modify_ _ { page = p }
-    ChangeFilterUsername username -> do H.modify_ _ { filterUsername = username }
-    ChangeFilterEmail email -> do H.modify_ _ { filterEmail = email }
     ChangeCreateUsername username -> do
       state <- H.get
       H.modify_ _ { createUserDto = withName username state.createUserDto }
@@ -191,32 +151,21 @@ component =
             }
         Right _ -> do
           H.modify_ _ { error = Nothing, requestDeleteUser = Nothing }
-          fetchAndLoadUsers
+          H.tell _userlist unit UserList.ReloadUsersQ
     CloseDeleteModal -> do H.modify_ _ { requestDeleteUser = Nothing }
     GetUser _ -> navigate (Profile { loginSuccessful: Nothing })
-    Filter -> do
-      state <- H.get
-      filteredUsers <- case state.users of
-        Loading -> pure []
-        Loaded userList ->
-          pure $ filter
-            ( \user ->
-                ( if null state.filterUsername then false
-                  else
-                    contains (Pattern state.filterUsername)
-                      (UserOverviewDto.getName user)
-                )
-                  ||
-                    ( if null state.filterEmail then false
-                      else
-                        contains
-                          (Pattern state.filterEmail)
-                          (UserOverviewDto.getEmail user)
-                    )
-            )
-            userList
-      log $ show (length filteredUsers)
-      H.modify_ _ { filteredUsers = filteredUsers }
+    HandleFilter f -> do
+      H.tell _userlist unit (UserList.HandleFilterQ f)
+    HandleUserList (UserList.Loading b) -> do
+      -- We do not care about the loading state here,
+      -- as the user list component handles it itself.
+      -- Would be nice to have a way to either render the user
+      -- list component (and the whole scene), or show a loading spinner
+      -- instead, but this doesnt work as the user list component
+      -- must be rendered in the scene in order to exist and do it's work :)
+      pure unit
+    HandleUserList (UserList.Error err) -> do
+      H.modify_ _ { error = Just err }
     CreateUser -> do
       state <- H.get
       response <- H.liftAff $ postJson "/register" (encodeJson state.createUserDto)
@@ -237,82 +186,32 @@ component =
                 )
             , createUserDto = CreateUserDto.empty
             }
-          fetchAndLoadUsers
+          H.tell _userlist unit UserList.ReloadUsersQ
 
   renderUserManagement :: State -> H.ComponentHTML Action Slots m
   renderUserManagement state =
-    HH.div_
+    HH.div_ $
       [ HH.h1 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
           [ HH.text $ translate (label :: _ "au_userManagement") state.translator
           ]
-      , case state.users of
-          Loading ->
-            HH.div [ HP.classes [ HB.textCenter, HB.mt5 ] ]
-              [ HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] [] ]
-          Loaded _ -> renderUserListView state
+      , renderUserListView state
       ]
 
   renderUserListView :: State -> H.ComponentHTML Action Slots m
   renderUserListView state =
     HH.div [ HP.classes [ HB.row, HB.justifyContentAround ] ]
-      [ renderFilterBy state
-      , renderUserList state
+      [ renderFilterBy
+      , renderUserList
       , renderNewUserForm state
       ]
 
-  renderFilterBy :: State -> H.ComponentHTML Action Slots m
-  renderFilterBy state =
-    addCard (translate (label :: _ "common_filterBy") state.translator)
-      [ HP.classes [ HB.col12, HB.colMd3, HB.colLg3, HB.mb3 ] ] $ HH.div
-      [ HP.classes [ HB.row ] ]
-      [ HH.div [ HP.classes [ HB.col ] ]
-          [ addColumn
-              state.filterUsername
-              (translate (label :: _ "common_userName") state.translator)
-              (translate (label :: _ "common_userName") state.translator)
-              "bi-person"
-              HP.InputText
-              ChangeFilterUsername
-          , addColumn
-              ""
-              (translate (label :: _ "common_email") state.translator)
-              (translate (label :: _ "common_email") state.translator)
-              "bi-envelope-fill"
-              HP.InputEmail
-              ChangeFilterEmail
-          ]
-      , HH.div [ HP.classes [ HB.col12, HB.textCenter ] ]
-          [ HH.div [ HP.classes [ HB.dInlineBlock ] ]
-              [ addButton
-                  true
-                  "Filter"
-                  (Just "bi-funnel")
-                  (const Filter)
-              ]
-          ]
-      ]
+  renderFilterBy :: H.ComponentHTML Action Slots m
+  renderFilterBy =
+    HH.slot _filter unit Filter.component unit HandleFilter
 
-  -- Creates a list of (dummy) users with pagination.
-  renderUserList :: State -> H.ComponentHTML Action Slots m
-  renderUserList state =
-    addCard (translate (label :: _ "admin_users_listOfUsers") state.translator)
-      [ HP.classes [ HB.col12, HB.colMd6, HB.colLg6, HB.mb3 ] ] $ HH.div_
-      [ HH.ul [ HP.classes [ HB.listGroup ] ]
-          $ map (createUserEntry state.translator) usrs
-              <> replicate (10 - length usrs)
-                emptyEntryText
-      -- TODO: ^ Artificially inflating the list to 10 entries
-      --         allows for a fixed overall height of the list,
-      --         but it's not a clean solution at all.
-      , HH.slot _pagination unit P.component ps SetPage
-      ]
-    where
-    usrs = slice (state.page * 10) ((state.page + 1) * 10) state.filteredUsers
-    ps =
-      { pages: P.calculatePageCount (length state.filteredUsers) 10
-      , style: P.Compact 1
-      , reaction: P.PreservePage
-      }
+  renderUserList :: H.ComponentHTML Action Slots m
+  renderUserList =
+    HH.slot _userlist unit UserList.component unit HandleUserList
 
   -- Creates a form to create a new (dummy) user.
   renderNewUserForm :: forall w. State -> HH.HTML w Action
@@ -363,37 +262,6 @@ component =
           Nothing -> HH.text ""
       ]
 
-  -- Creates a (dummy) user entry for the list.
-  createUserEntry
-    :: forall w. Translator Labels -> UserOverviewDto -> HH.HTML w Action
-  createUserEntry translator userOverviewDto =
-    HH.li
-      [ HP.classes
-          [ HB.listGroupItem
-          , HB.dFlex
-          , HB.justifyContentBetween
-          , HB.alignItemsCenter
-          ]
-      ]
-      [ HH.span [ HP.classes [ HB.col5 ] ]
-          [ HH.text $ UserOverviewDto.getName userOverviewDto ]
-      , HH.span [ HP.classes [ HB.col5 ] ]
-          [ HH.text $ UserOverviewDto.getEmail userOverviewDto ]
-      , HH.div [ HP.classes [ HB.col2, HB.dFlex, HB.justifyContentEnd, HB.gap1 ] ]
-          [ deleteButton (const $ RequestDeleteUser userOverviewDto)
-          , HH.button
-              [ HP.type_ HP.ButtonButton
-              , HP.classes [ HB.btn, HB.btnSm, HB.btnOutlinePrimary ]
-              , HE.onClick $ const $ GetUser (UserOverviewDto.getID userOverviewDto)
-              , HP.title
-                  (translate (label :: _ "admin_users_goToProfilePage") translator)
-              ]
-              [ HH.i [ HP.classes [ HB.bi, (H.ClassName "bi-person-fill") ] ] []
-
-              ]
-          ]
-      ]
-
 renderDeleteModal :: forall m. State -> HH.HTML m Action
 renderDeleteModal state =
   case state.requestDeleteUser of
@@ -412,17 +280,3 @@ isCreateUserFormValid createUserDto =
     && not (null $ getEmail createUserDto)
     && not (null $ getPassword createUserDto)
     && Email.isValidEmailStrict (getEmail createUserDto)
-
-fetchAndLoadUsers
-  :: forall output m. MonadAff m => H.HalogenM State Action Slots output m Unit
-fetchAndLoadUsers = do
-  maybeUsers <- H.liftAff $ getFromJSONEndpoint decodeJson "/users"
-  case maybeUsers of
-    Nothing -> do
-      state <- H.get
-      H.modify_ _
-        { error = Just $ translate (label :: _ "admin_users_failedToLoadUsers")
-            state.translator
-        }
-    Just users -> do
-      H.modify_ _ { users = Loaded users, filteredUsers = users }

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -83,6 +83,7 @@ type Labels =
       -- | Admin Users Page
       ::: "admin_users_create"
       ::: "admin_users_createNewUser"
+      ::: "admin_users_deleteUser"
       ::: "admin_users_failedToCreateUser"
       ::: "admin_users_failedToDeleteUser"
       ::: "admin_users_failedToLoadUsers"

--- a/frontend/src/FPO/Translations/Page/Admin/PageUsers.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/PageUsers.purs
@@ -6,6 +6,7 @@ import Simple.I18n.Translation (Translation, fromRecord)
 type AdminUserPageLabels =
   ( "admin_users_create"
       ::: "admin_users_createNewUser"
+      ::: "admin_users_deleteUser"
       ::: "admin_users_failedToCreateUser"
       ::: "admin_users_failedToDeleteUser"
       ::: "admin_users_failedToLoadUsers"
@@ -20,6 +21,7 @@ enAdminUserPage :: Translation AdminUserPageLabels
 enAdminUserPage = fromRecord
   { admin_users_listOfUsers: "List of Users"
   , admin_users_createNewUser: "Create New User"
+  , admin_users_deleteUser: "Delete User"
   , admin_users_failedToCreateUser: "Failed to create user"
   , admin_users_failedToDeleteUser: "Failed to delete user"
   , admin_users_failedToLoadUsers: "Failed to load users"
@@ -33,6 +35,7 @@ deAdminUserPage :: Translation AdminUserPageLabels
 deAdminUserPage = fromRecord
   { admin_users_listOfUsers: "Liste der Nutzer"
   , admin_users_createNewUser: "Neuen Nutzer erstellen"
+  , admin_users_deleteUser: "Nutzer löschen"
   , admin_users_failedToCreateUser: "Fehler beim Erstellen des Nutzers"
   , admin_users_failedToDeleteUser: "Fehler beim Löschen des Nutzers"
   , admin_users_failedToLoadUsers: "Fehler beim Laden der Nutzer"


### PR DESCRIPTION
We might want to reuse some functionality regarding user management (user filtering, list of all users)
in other components (for example, in the group management section - we might want to see all users and
select which ones to add).

To provide greater flexibility, the user list now allows you to specify which buttons should appear.
The main component can then handle the corresponding business logic, enabling to implement
any desired functionality (for example, deletion of users, adding to groups, viewing profile page, ...).

We can then easily create a new page similar to the _admin user management page_ that can be used to 
assign users to groups, see issue #139.

Furthermore, this PR greatly improves the user list row presentation (username, email, and buttons). 