### PR TITLE
New docs api into editor

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -455,7 +455,7 @@ editor docID = connect selectTranslator $ H.mkComponent
         loadedContent <- H.liftAff $
           Request.getFromJSONEndpoint
             ContentDto.decodeContent
-            ("/docs/1/text/" <> show entry.id <> "/rev/latest")
+            ("/docs/" <> show docID <> "/text/" <> show entry.id <> "/rev/latest")
         let
           content = case loadedContent of
             Nothing -> ContentDto.failureContent
@@ -544,7 +544,7 @@ editor docID = connect selectTranslator $ H.mkComponent
 
           -- send the new content as POST to the server
           _ <- H.liftAff $ Request.postJson
-            ("/docs/1/text/" <> show entry.id <> "/rev")
+            ("/docs/" <> show docID <> "/text/" <> show entry.id <> "/rev")
             jsonContent
 
           H.modify_ \st -> st

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -40,6 +40,7 @@ import FPO.Data.Request as Request
 import FPO.Data.Store as Store
 import FPO.Dto.ContentDto (Content)
 import FPO.Dto.ContentDto as ContentDto
+import FPO.Dto.DocumentDto (DocumentID)
 import FPO.Dto.UserDto (getUserName)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
@@ -116,8 +117,9 @@ editor
   :: forall m
    . MonadAff m
   => MonadStore Store.Action Store.Store m
-  => H.Component Query Unit Output m
-editor = connect selectTranslator $ H.mkComponent
+  => DocumentID
+  -> H.Component Query Unit Output m
+editor docID = connect selectTranslator $ H.mkComponent
   { initialState
   , render
   , eval: H.mkEval H.defaultEval

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -4,7 +4,6 @@ module FPO.Components.Editor
   , Query(..)
   , State
   , LiveMarker
-  , _pdfSlideBar
   , addAnnotation
   , addChangeListener
   , editor
@@ -64,8 +63,6 @@ type State = FPOState
   , mTocEntry :: Maybe TOCEntry
   , mContent :: Maybe Content
   , liveMarkers :: Array LiveMarker
-  , pdfWarningAvailable :: Boolean
-  , pdfWarningIsShown :: Boolean
   , fontSize :: Int
   )
 
@@ -78,8 +75,6 @@ type LiveMarker =
   , ref :: Ref Int
   }
 
-_pdfSlideBar = Proxy :: Proxy "pdfSlideBar"
-
 data Output
   = ClickedQuery (Maybe (Array String))
   | DeletedComment TOCEntry (Array Int)
@@ -91,7 +86,6 @@ data Action
   = Init
   | Comment
   | DeleteComment
-  | ShowWarning
   | SelectComment
   | Bold
   | Italic
@@ -108,7 +102,6 @@ data Query a
   = QueryEditor a
   -- save the current content and send it to splitview
   | SaveSection a
-  | LoadPdf a
   -- receive the selected TOC and put its content into the editor
   | ChangeSection TOCEntry a
   | SendCommentSections a
@@ -136,8 +129,6 @@ editor = connect selectTranslator $ H.mkComponent
     , liveMarkers: []
     , mTocEntry: Nothing
     , mContent: Nothing
-    , pdfWarningAvailable: false
-    , pdfWarningIsShown: false
     , fontSize: 12
     }
 
@@ -407,9 +398,6 @@ editor = connect selectTranslator $ H.mkComponent
                   st { mTocEntry = Just newTOCEntry, liveMarkers = newLiveMarkers }
                 H.raise (DeletedComment newTOCEntry [ foundID ])
 
-    ShowWarning -> do
-      H.modify_ \state -> state { pdfWarningIsShown = not state.pdfWarningIsShown }
-
     SelectComment -> do
       H.gets _.mEditor >>= traverse_ \ed -> do
         state <- H.get
@@ -496,10 +484,6 @@ editor = connect selectTranslator $ H.mkComponent
         H.modify_ \st ->
           st { liveMarkers = newLiveMarkers }
 
-      pure (Just a)
-
-    LoadPdf a -> do
-      H.modify_ _ { pdfWarningAvailable = true }
       pure (Just a)
 
     SaveSection a -> do

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -442,6 +442,8 @@ editor = connect selectTranslator $ H.mkComponent
 
         -- Get the content from server here
         -- We need Aff for that and thus cannot go inside Eff
+        -- TODO: After creating a new Leaf, we get Nothing in loadedContent
+        -- See, why and fix it
         loadedContent <- H.liftAff $ 
           Request.getFromJSONEndpoint 
             ContentDto.decodeContent

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -43,7 +43,13 @@ import FPO.Dto.ContentDto as ContentDto
 import FPO.Dto.UserDto (getUserName)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
-import FPO.Types (AnnotatedMarker, TOCEntry, emptyTOCEntry, markerToAnnotation, sortMarkers)
+import FPO.Types
+  ( AnnotatedMarker
+  , TOCEntry
+  , emptyTOCEntry
+  , markerToAnnotation
+  , sortMarkers
+  )
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events (onClick) as HE
@@ -444,13 +450,13 @@ editor = connect selectTranslator $ H.mkComponent
         -- We need Aff for that and thus cannot go inside Eff
         -- TODO: After creating a new Leaf, we get Nothing in loadedContent
         -- See, why and fix it
-        loadedContent <- H.liftAff $ 
-          Request.getFromJSONEndpoint 
+        loadedContent <- H.liftAff $
+          Request.getFromJSONEndpoint
             ContentDto.decodeContent
-            ("/docs/1/text/"<> show entry.id <>"/rev/latest")
+            ("/docs/1/text/" <> show entry.id <> "/rev/latest")
         let
           content = case loadedContent of
-            Nothing  -> ContentDto.failureContent
+            Nothing -> ContentDto.failureContent
             Just res -> res
         H.modify_ \st -> st { mContent = Just content }
 
@@ -533,15 +539,16 @@ editor = connect selectTranslator $ H.mkComponent
             newEntry = entry
               { markers = updatedMarkers }
             jsonContent = ContentDto.encodeContent newContent
-          
+
           -- send the new content as POST to the server
-          _ <- H.liftAff $ Request.postJson 
+          _ <- H.liftAff $ Request.postJson
             ("/docs/1/text/" <> show entry.id <> "/rev")
             jsonContent
 
-          H.modify_ \st -> st 
+          H.modify_ \st -> st
             { mTocEntry = Just newEntry
-            , mContent = Just newContent }
+            , mContent = Just newContent
+            }
           H.raise (SavedSection newEntry)
           pure (Just a)
 

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -52,7 +52,6 @@ import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Simple.I18n.Translator (label, translate)
-import Type.Proxy (Proxy(Proxy))
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM.Element (toEventTarget)
 import Web.Event.EventTarget (addEventListener, eventListener)

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -43,7 +43,7 @@ import FPO.Dto.ContentDto (Content)
 import FPO.Dto.ContentDto as ContentDto
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
-import FPO.Types (AnnotatedMarker, TOCEntry, markerToAnnotation, sortMarkers)
+import FPO.Types (AnnotatedMarker, TOCEntry, emptyTOCEntry, markerToAnnotation, sortMarkers)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events (onClick) as HE
@@ -462,6 +462,7 @@ editor = connect selectTranslator $ H.mkComponent
           content = case loadedContent of
             Nothing  -> ContentDto.failureContent
             Just res -> res
+        H.modify_ \st -> st { mContent = Just content }
 
         newLiveMarkers <- H.liftEffect do
           session <- Editor.getSession ed
@@ -503,52 +504,60 @@ editor = connect selectTranslator $ H.mkComponent
 
     SaveSection a -> do
       state <- H.get
-      allLines <- H.gets _.mEditor >>= traverse \ed -> do
-        H.liftEffect $ Editor.getSession ed
-          >>= Session.getDocument
-          >>= Document.getAllLines
+      case state.mContent of
+        Nothing -> pure (Just a)
+        Just content -> do
+          allLines <- H.gets _.mEditor >>= traverse \ed -> do
+            H.liftEffect $ Editor.getSession ed
+              >>= Session.getDocument
+              >>= Document.getAllLines
 
-      -- Save the current content of the editor
-      let
-        contentText = case allLines of
-          Just ls -> intercalate "\n" ls
-          Nothing -> ""
+          -- Save the current content of the editor
+          let
+            contentText = case allLines of
+              Just ls -> intercalate "\n" ls
+              Nothing -> ""
 
-        -- extract the current TOC entry
-        entry = case state.mTocEntry of
-          Nothing ->
-            { id: -1
-            , name: "Section not found"
-            , newMarkerNextID: -1
-            , markers: []
-            }
-          Just e -> e
+            -- place it in content
+            newContent = ContentDto.setContentText contentText content
 
-      -- Since the ids and postions in liveMarkers are changing constantly, 
-      -- extract them now and store them 
-      updatedMarkers <- H.liftEffect do
-        for entry.markers \m -> do
-          case find (\lm -> lm.annotedMarkerID == m.id) state.liveMarkers of
-            -- TODO Should we add other markers in liveMarkers such as errors?
-            Nothing -> pure m
-            Just lm -> do
-              start <- Anchor.getPosition lm.startAnchor
-              end <- Anchor.getPosition lm.endAnchor
-              pure m
-                { startRow = Types.getRow start
-                , startCol = Types.getColumn start
-                , endRow = Types.getRow end
-                , endCol = Types.getColumn end
-                }
-      let
-        newEntry = entry
-          { markers = updatedMarkers }
-      
-      --TODO send the content (contentText) as POST to the server
+            -- extract the current TOC entry
+            entry = case state.mTocEntry of
+              Nothing -> emptyTOCEntry
+              Just e -> e
 
-      H.modify_ \st -> st { mTocEntry = Just newEntry }
-      H.raise (SavedSection newEntry)
-      pure (Just a)
+          -- Since the ids and postions in liveMarkers are changing constantly, 
+          -- extract them now and store them 
+          updatedMarkers <- H.liftEffect do
+            for entry.markers \m -> do
+              case find (\lm -> lm.annotedMarkerID == m.id) state.liveMarkers of
+                -- TODO Should we add other markers in liveMarkers such as errors?
+                Nothing -> pure m
+                Just lm -> do
+                  start <- Anchor.getPosition lm.startAnchor
+                  end <- Anchor.getPosition lm.endAnchor
+                  pure m
+                    { startRow = Types.getRow start
+                    , startCol = Types.getColumn start
+                    , endRow = Types.getRow end
+                    , endCol = Types.getColumn end
+                    }
+          -- update the markers in entry
+          let
+            newEntry = entry
+              { markers = updatedMarkers }
+            jsonContent = ContentDto.encodeContent newContent
+          
+          -- send the new content as POST to the server
+          _ <- H.liftAff $ Request.postJson 
+            ("/docs/1/text/" <> show entry.id <> "/rev")
+            jsonContent
+
+          H.modify_ \st -> st 
+            { mTocEntry = Just newEntry
+            , mContent = Just newContent }
+          H.raise (SavedSection newEntry)
+          pure (Just a)
 
     -- Because Session does not provide a way to get all lines directly,
     -- we need to take another indirect route to get the lines.

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -351,13 +351,8 @@ editor = connect selectTranslator $ H.mkComponent
             }
 
         mLiveMarker <- H.liftEffect $ addAnchor newMarker session
-        -- Textinhalt holen
-        allLines <- H.liftEffect do
-          doc <- Session.getDocument session
-          Document.getAllLines doc
 
         let
-          contentText = intercalate "\n" allLines
           newLiveMarkers = case mLiveMarker of
             Nothing -> state.liveMarkers
             Just lm -> lm : state.liveMarkers
@@ -368,7 +363,6 @@ editor = connect selectTranslator $ H.mkComponent
               newEntry =
                 { id: entry.id
                 , name: entry.name
-                , content: contentText
                 , newMarkerNextID: entry.newMarkerNextID + 1
                 , markers: sortMarkers (newMarker : entry.markers)
                 }
@@ -426,7 +420,6 @@ editor = connect selectTranslator $ H.mkComponent
             Nothing ->
               { id: -1
               , name: "No entry"
-              , content: ""
               , newMarkerNextID: -1
               , markers: []
               }
@@ -458,7 +451,7 @@ editor = connect selectTranslator $ H.mkComponent
           document <- Session.getDocument session
 
           -- Set editor content
-          let content = entry.content
+          let content = "TODO: get content from API"
           Document.setValue content document
 
           -- Reset Undo history
@@ -510,7 +503,6 @@ editor = connect selectTranslator $ H.mkComponent
           Nothing ->
             { id: -1
             , name: "Section not found"
-            , content: ""
             , newMarkerNextID: -1
             , markers: []
             }
@@ -534,9 +526,9 @@ editor = connect selectTranslator $ H.mkComponent
                 }
       let
         newEntry = entry
-          { content = contentText
-          , markers = updatedMarkers
-          }
+          { markers = updatedMarkers }
+      
+      --TODO send the content (contentText) as POST to the server
 
       H.modify_ \st -> st { mTocEntry = Just newEntry }
       H.raise (SavedSection newEntry)

--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -2,21 +2,15 @@ module FPO.Components.Preview where
 
 import Prelude
 
-import Affjax (printError)
-import Affjax.StatusCode (StatusCode(StatusCode))
 import Control.Monad.Rec.Class (forever)
-import Data.Either (Either(..))
-import Data.Maybe (Maybe(Just, Nothing), fromMaybe)
+import Data.Maybe (Maybe(Just, Nothing))
 import Data.Time.Duration (Milliseconds(Milliseconds))
 import Effect.Aff (delay, forkAff) as Aff
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import FPO.Components.Button (Output(Clicked), button) as Button
-import FPO.Data.Request (getIgnore)
 import Halogen as H
 import Halogen.HTML (div, div_, pre, slot, text) as HH
-import Halogen.HTML.Elements (embed)
-import Halogen.HTML.Properties (classes, src) as HP
+import Halogen.HTML.Properties (classes) as HP
 import Halogen.Subscription (create, notify) as HS
 import Halogen.Themes.Bootstrap5 as HB
 import Type.Proxy (Proxy(Proxy))

--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -12,7 +12,7 @@ import Effect.Aff (delay, forkAff) as Aff
 import Effect.Aff.Class (class MonadAff)
 import Effect.Console (log)
 import FPO.Components.Button (Output(Clicked), button) as Button
-import FPO.Data.Request (getIgnore, getString)
+import FPO.Data.Request (getIgnore)
 import Halogen as H
 import Halogen.HTML (div, div_, pre, slot, text) as HH
 import Halogen.HTML.Elements (embed)
@@ -27,8 +27,6 @@ data Action
   = HandleButton Button.Output
   | Initialize
   | Increment
-  | LoadPdf PdfState
-  | ShowOrHideWarning
   | Receive Input
 
 type Slots = (button :: forall query. H.Slot query Button.Output Int)
@@ -37,26 +35,14 @@ _button = Proxy :: Proxy "button"
 
 type State =
   { count :: Int
-  , dummyUser :: Maybe String
   , editorContent :: Maybe (Array String)
-  , pdf :: PdfState
-  , showWarning :: Boolean
-  , pdfURL :: Maybe String
   }
 
 type Input =
   { editorContent :: Maybe (Array String) }
 
 data Query a
-  = TellLoadPdf a
-  | GotEditorQuery (Maybe (Array String)) a
-  | TellShowOrHideWarning a
-  | TellClickedHttpRequest a
-
-data PdfState
-  = Empty
-  | AskedButError String -- to load a default PDF
-  | PdfAvailable
+  = GotEditorQuery (Maybe (Array String)) a
 
 preview :: forall m. MonadAff m => H.Component Query Input Output m
 preview = H.mkComponent
@@ -73,98 +59,58 @@ preview = H.mkComponent
   initialState :: State
   initialState =
     { count: 0
-    , dummyUser: Nothing
     , editorContent: Nothing
-    , pdf: Empty
-    , showWarning: false
-    , pdfURL: Nothing
     }
 
   render :: State -> H.ComponentHTML Action Slots m
-  render { count, dummyUser, editorContent, pdf, showWarning, pdfURL } =
-    case pdf of
-      Empty -> HH.div
-        [ HP.classes
-            [ HB.dFlex
-            , HB.flexColumn
-            , HB.flexGrow1
-            , HB.textCenter
-            , HB.bgInfoSubtle
-            , HB.overflowHidden
-            ]
-        ]
-        [ HH.div_ [ HH.text "Preview:" ]
-        , HH.div_
-            [ HH.text $
-                if dummyUser == Nothing then
-                  "Press the HTTP request button to load a dummy user"
-                else "Wow, we have successfully loaded a dummy user with name: " <>
-                  fromMaybe "err" dummyUser
-            ]
-        , HH.slot _button 0 Button.button { label: show count } HandleButton
-        , HH.div
-            [ HP.classes [ HB.dFlex, HB.flexColumn, HB.flexGrow1, HB.overflowHidden ]
-            ]
-            [ case editorContent of
-                Nothing ->
-                  HH.text "The editor has no content!"
-                Just content ->
-                  HH.div
-                    [ HP.classes
-                        [ HB.dFlex, HB.flexColumn, HB.flexGrow1, HB.overflowHidden ]
-                    ]
-                    [ HH.text "Editor Content:"
-                    , HH.div
-                        [ HP.classes
-                            [ HB.dFlex
-                            , HB.flexColumn
-                            , HB.flexGrow1
-                            , H.ClassName "mt-1"
-                            , HB.overflowAuto
-                            ]
-                        ]
-                        [ HH.pre
-                            [ HP.classes
-                                [ HB.flexGrow1
-                                , H.ClassName "border rounded p-1 bg-light"
-                                , HB.h100
-                                ]
-                            ]
-                            ( content <#> \line ->
-                                HH.div_ [ HH.text $ preserveEmptyLine line ]
-                            )
-                        ]
-                    ]
-            ]
-        ]
-      AskedButError reason -> HH.div
-        [ HP.classes
-            [ HB.dFlex
-            , HB.flexColumn
-            , HB.flexGrow1
-            , HB.textCenter
-            , HB.bgInfoSubtle
-            , HB.overflowHidden
-            ]
-        ]
-        if showWarning then [ HH.text reason ]
-        else [ embed [ HP.src "/api/document", HP.classes [ HB.w100, HB.h100 ] ] [] ]
-      PdfAvailable -> HH.div
-        [ HP.classes
-            [ HB.dFlex
-            , HB.flexColumn
-            , HB.flexGrow1
-            , HB.textCenter
-            , HB.bgInfoSubtle
-            , HB.overflowHidden
-            ]
-        ]
-        [ case pdfURL of
-            Nothing -> embed
-              [ HP.src "/api/document", HP.classes [ HB.w100, HB.h100 ] ]
-              []
-            Just url -> embed [ HP.src url, HP.classes [ HB.w100, HB.h100 ] ] []
-        ]
+  render { count, editorContent } =
+    HH.div
+      [ HP.classes
+          [ HB.dFlex
+          , HB.flexColumn
+          , HB.flexGrow1
+          , HB.textCenter
+          , HB.bgInfoSubtle
+          , HB.overflowHidden
+          ]
+      ]
+      [ HH.div_ [ HH.text "Preview:" ]
+      , HH.slot _button 0 Button.button { label: show count } HandleButton
+      , HH.div
+          [ HP.classes [ HB.dFlex, HB.flexColumn, HB.flexGrow1, HB.overflowHidden ]
+          ]
+          [ case editorContent of
+              Nothing ->
+                HH.text "The editor has no content!"
+              Just content ->
+                HH.div
+                  [ HP.classes
+                      [ HB.dFlex, HB.flexColumn, HB.flexGrow1, HB.overflowHidden ]
+                  ]
+                  [ HH.text "Editor Content:"
+                  , HH.div
+                      [ HP.classes
+                          [ HB.dFlex
+                          , HB.flexColumn
+                          , HB.flexGrow1
+                          , H.ClassName "mt-1"
+                          , HB.overflowAuto
+                          ]
+                      ]
+                      [ HH.pre
+                          [ HP.classes
+                              [ HB.flexGrow1
+                              , H.ClassName "border rounded p-1 bg-light"
+                              , HB.h100
+                              ]
+                          ]
+                          ( content <#> \line ->
+                              HH.div_ [ HH.text $ preserveEmptyLine line ]
+                          )
+                      ]
+                  ]
+          ]
+      ]
 
   handleAction :: MonadAff m => Action -> H.HalogenM State Action Slots Unit m Unit
   handleAction = case _ of
@@ -183,11 +129,6 @@ preview = H.mkComponent
 
     Increment -> H.modify_ \state -> state { count = state.count + 1 }
 
-    LoadPdf pdfState -> H.modify_ \state -> state { pdf = pdfState }
-
-    ShowOrHideWarning -> H.modify_ \state -> state
-      { showWarning = not state.showWarning }
-
     Receive { editorContent } -> H.modify_ \state -> state
       { editorContent = editorContent }
 
@@ -196,39 +137,10 @@ preview = H.mkComponent
      . Query a
     -> H.HalogenM State Action Slots Output m (Maybe a)
   handleQuery = case _ of
-    TellLoadPdf a -> do
-      response <- H.liftAff $ getIgnore "/document"
-      case response of
-        Right { status } -> do
-          if status == (StatusCode 201) then H.modify_ _ { pdf = PdfAvailable }
-          else H.modify_ _
-            { pdf = AskedButError
-                ( "Could not load pdf properly. Here should be a detailed warning message"
-                    <>
-                      "in the future that returned from the compiled pdf. This is just a dummy pdf for now"
-                )
-            }
-        Left err -> do
-          H.liftEffect $ log $ printError err
-          H.modify_ _ { pdf = AskedButError "Error loading PDF." }
-      pure (Just a)
 
     GotEditorQuery mEditorContent a -> do
       H.modify_ \state ->
         state { editorContent = mEditorContent }
-      pure (Just a)
-
-    TellShowOrHideWarning a -> do
-      H.modify_ \state -> state { showWarning = not state.showWarning }
-      pure (Just a)
-
-    TellClickedHttpRequest a -> do
-      response <- H.liftAff $ getString "/users"
-      case response of
-        Right { body } ->
-          H.modify_ _ { dummyUser = Just body }
-        Left _ -> do
-          H.modify_ _ { dummyUser = Nothing }
       pure (Just a)
 
   -- Forces the string to be at least one character long.

--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -35,8 +35,7 @@ type State =
 type Input =
   { editorContent :: Maybe (Array String) }
 
-data Query a
-  = GotEditorQuery (Maybe (Array String)) a
+data Query a = GotEditorQuery (Maybe (Array String)) a
 
 preview :: forall m. MonadAff m => H.Component Query Input Output m
 preview = H.mkComponent

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -478,8 +478,9 @@ splitview docID = H.mkComponent
     -- H.liftEffect $ Console.log "Successfully posted TOC to server"
     ForceGET -> do
       -- Forces a GET request to fetch the latest document tree of commit #1.
-      fetchedTree <- H.liftAff $
-        Request.getFromJSONEndpoint DocumentDto.decodeDocument $ "/docs/" <> show docID <> "/tree/latest"
+      fetchedTree <- H.liftAff
+        $ Request.getFromJSONEndpoint DocumentDto.decodeDocument
+        $ "/docs/" <> show docID <> "/tree/latest"
       let
         tree = case fetchedTree of
           Nothing -> Empty

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -187,7 +187,7 @@ splitview docID = H.mkComponent
       [ HP.classes [ HB.bgDark, HB.overflowAuto, HB.dFlex, HB.flexRow ] ]
       [ toolbarButton "[=]" ToggleSidebar
       , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
-      , toolbarButton "ForceGETPH" ForceGET
+      , toolbarButton "ForceGET" ForceGET
       , toolbarButton "GET" GET
       , toolbarButton "POST" POST
       , toolbarButton "All Comments" (ToggleCommentOverview true)
@@ -500,7 +500,6 @@ splitview docID = H.mkComponent
       -- pure unit
       fetchedTree <- H.liftAff $
         Request.getFromJSONEndpoint DocumentDto.decodeDocument "/docs/1/tree/latest"
-      --H.liftEffect $ log $ "ForceGET: " <> show fetchedTree
       let
         tree = case fetchedTree of
           Nothing -> Empty
@@ -780,11 +779,11 @@ splitview docID = H.mkComponent
 
     HandleTOC output -> case output of
 
-      TOC.ChangeSection selectEntry -> do
+      TOC.ChangeSection selectedId -> do
         H.tell _editor unit Editor.SaveSection
         state <- H.get
         let
-          entry = case (findTOCEntry selectEntry.id state.tocEntries) of
+          entry = case (findTOCEntry selectedId state.tocEntries) of
             Nothing -> emptyTOCEntry
             Just e -> e
         H.tell _editor unit (Editor.ChangeSection entry)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -487,7 +487,7 @@ splitview docID = H.mkComponent
         tree = case fetchedTree of
           Nothing -> Empty
           Just t -> documentTreeToTOCTree t
-        docName = case mDoc of 
+        docName = case mDoc of
           Nothing -> ""
           Just doc -> DocumentDto.getDHName doc
       -- Get document name
@@ -764,7 +764,7 @@ splitview docID = H.mkComponent
             Nothing -> emptyTOCEntry
             Just e -> e
         H.tell _editor unit (Editor.ChangeSection entry)
-      
+
       TOC.AddNode path node -> do
         state <- H.get
         let
@@ -785,34 +785,35 @@ findCommentSection tocEntries tocID markerID = do
   marker.mCommentSection
 
 -- Add a node in TOC tree
-addRootNode 
-  :: Array Int 
+addRootNode
+  :: Array Int
   -> Tree TOCEntry
   -> TOCTree
   -> TOCTree
-addRootNode [] entry (RootTree { children, header }) = 
+addRootNode [] entry (RootTree { children, header }) =
   RootTree { children: snoc children (Edge entry), header }
 addRootNode _ entry Empty =
-  RootTree { children: [Edge entry], header: { headerKind: "root", headerType: "root" } }
-addRootNode path entry (RootTree {children, header}) = 
+  RootTree
+    { children: [ Edge entry ], header: { headerKind: "root", headerType: "root" } }
+addRootNode path entry (RootTree { children, header }) =
   case uncons path of
-    Nothing -> 
+    Nothing ->
       RootTree { children: snoc children (Edge entry), header }
-    Just { head, tail } -> 
+    Just { head, tail } ->
       let
-        child = 
-          fromMaybe 
-            (Edge (Leaf { title: "Error", node: emptyTOCEntry })) 
+        child =
+          fromMaybe
+            (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
             (children !! head)
-        newChildren = 
+        newChildren =
           case updateAt head (addNode tail entry child) children of
             Nothing -> children
             Just res -> res
       in
         RootTree { children: newChildren, header }
-        
-addNode 
-  :: Array Int 
+
+addNode
+  :: Array Int
   -> Tree TOCEntry
   -> Edge TOCEntry
   -> Edge TOCEntry
@@ -822,15 +823,15 @@ addNode [] entry (Edge (Node { title, children, header })) =
   Edge (Node { title, children: snoc children (Edge entry), header })
 addNode path entry (Edge (Node { title, children, header })) =
   case uncons path of
-    Nothing -> 
+    Nothing ->
       Edge (Node { title, children: snoc children (Edge entry), header })
-    Just { head, tail } -> 
+    Just { head, tail } ->
       let
-        child = 
-          fromMaybe 
-            (Edge (Leaf { title: "Error", node: emptyTOCEntry })) 
+        child =
+          fromMaybe
+            (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
             (children !! head)
-        newChildren' = 
+        newChildren' =
           case updateAt head (addNode tail entry child) children of
             Nothing -> children
             Just res -> res

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -772,8 +772,14 @@ splitview docID = H.mkComponent
         state <- H.get
         let
           newTree = addRootNode path node state.tocEntries
+          docTree = tocTreeToDocumentTree newTree
+          encodeTree = DocumentDto.encodeDocumentTree docTree
+        _ <- H.liftAff $
+          Request.postJson "/docs/1/tree" encodeTree
         H.modify_ \st -> st { tocEntries = newTree }
         H.tell _toc unit (TOC.ReceiveTOCs state.docName newTree)
+
+        pure unit
 
 findCommentSection :: TOCTree -> Int -> Int -> Maybe CommentSection
 findCommentSection tocEntries tocID markerID = do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -63,11 +63,8 @@ data Action
   | StopResize MouseEvent
   | HandleMouseMove MouseEvent
   -- Toolbar buttons
-  | ClickedHTTPRequest
   | SaveSection
   | QueryEditor
-  | ClickLoadPdf
-  | ShowWarning
   -- Toggle buttons
   | ToggleComment
   | ToggleCommentOverview Boolean
@@ -178,10 +175,10 @@ splitview docID = H.mkComponent
   render :: State -> H.ComponentHTML Action Slots m
   render state =
     HH.div_
-      [ renderToolbar state, renderSplit state ]
+      [ renderToolbar, renderSplit state ]
 
-  renderToolbar :: State -> H.ComponentHTML Action Slots m
-  renderToolbar state =
+  renderToolbar :: H.ComponentHTML Action Slots m
+  renderToolbar =
     -- First Toolbar
     HH.div
       [ HP.classes [ HB.bgDark, HB.overflowAuto, HB.dFlex, HB.flexRow ] ]
@@ -191,13 +188,8 @@ splitview docID = H.mkComponent
       , toolbarButton "GET" GET
       , toolbarButton "POST" POST
       , toolbarButton "All Comments" (ToggleCommentOverview true)
-      , toolbarButton "Click Me for HTTPRequest" ClickedHTTPRequest
       , toolbarButton "Save" SaveSection
       , toolbarButton "Query Editor" QueryEditor
-      , toolbarButton "Load PDF" ClickLoadPdf
-      , toolbarButton
-          ((if state.pdfWarningIsShown then "Hide" else "Show") <> " Warning")
-          ShowWarning
       ]
     where
     toolbarButton label act = HH.button
@@ -614,22 +606,11 @@ splitview docID = H.mkComponent
 
     -- Toolbar button actions
 
-    ClickedHTTPRequest -> H.tell _preview unit Preview.TellClickedHttpRequest
-
     SaveSection -> H.tell _editor unit Editor.SaveSection
 
     QueryEditor -> do
       H.tell _editor unit Editor.SaveSection
       H.tell _editor unit Editor.QueryEditor
-
-    ShowWarning -> do
-      H.modify_ \st -> st { pdfWarningIsShown = not st.pdfWarningIsShown }
-      H.tell _preview unit Preview.TellShowOrHideWarning
-
-    ClickLoadPdf -> do
-      H.modify_ \st -> st { pdfWarningAvailable = true }
-      H.tell _editor unit Editor.LoadPdf
-      H.tell _preview unit Preview.TellLoadPdf
 
     -- Toggle actions
 

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -46,9 +46,6 @@ import Web.HTML as Web.HTML
 import Web.HTML.Window as Web.HTML.Window
 import Web.UIEvent.MouseEvent (MouseEvent, clientX)
 
-import Effect.Console (log)
-import Data.Argonaut.Core (stringify)
-
 data DragTarget = ResizeLeft | ResizeRight
 
 derive instance eqDragTarget :: Eq DragTarget

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -2,9 +2,9 @@ module FPO.Components.TOC where
 
 import Prelude
 
-import Data.Array (concatMap)
+import Data.Array (concat, mapWithIndex, snoc, uncons, updateAt, (!!))
 import Data.Int (toNumber)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Effect.Aff.Class (class MonadAff)
 import FPO.Dto.TreeDto (Edge(..), RootTree(..), Tree(..))
 import FPO.Types (ShortendTOCEntry, TOCTree, shortenTOC)
@@ -21,17 +21,24 @@ data Output = ChangeSection Int
 data Action
   = Init
   | JumpToSection Int
+  | ToggleAddMenu (Array Int)
+  | CreateNewSubsection (Array Int)
+  | CreateNewSection (Array Int)
 
 data Query a = ReceiveTOCs (TOCTree) a
 
 type State =
   { tocEntries :: RootTree ShortendTOCEntry
   , mSelectedTocEntry :: Maybe Int
+  , showAddMenu :: Array Int
   }
 
 tocview :: forall m. MonadAff m => H.Component Query Input Output m
 tocview = H.mkComponent
-  { initialState: \_ -> { tocEntries: Empty, mSelectedTocEntry: Nothing }
+  { initialState: \_ -> 
+    { tocEntries: Empty
+    , mSelectedTocEntry: Nothing
+    , showAddMenu: [-1] }
   , render
   , eval: H.mkEval $ H.defaultEval
       { initialize = Just Init
@@ -44,7 +51,7 @@ tocview = H.mkComponent
   render :: State -> forall slots. H.ComponentHTML Action slots m
   render state =
     HH.div_
-      (rootTreeToHTML state.mSelectedTocEntry state.tocEntries)
+      (rootTreeToHTML state.showAddMenu state.mSelectedTocEntry state.tocEntries)
 
   handleAction :: Action -> forall slots. H.HalogenM State Action slots Output m Unit
   handleAction = case _ of
@@ -56,6 +63,31 @@ tocview = H.mkComponent
       H.modify_ \state ->
         state { mSelectedTocEntry = Just id }
       H.raise (ChangeSection id)
+    
+    ToggleAddMenu path -> do
+      H.modify_ \state ->
+        state { showAddMenu = 
+          if state.showAddMenu == [-1] || state.showAddMenu /= path
+            then path 
+            else [-1] }
+    
+    CreateNewSubsection path -> do
+      state <- H.get
+      let 
+        newEntry = Leaf { title: "New Subsection", node: { id: -1, name: "New Subsection" } }
+        newTree = addRootNode path newEntry state.tocEntries
+      H.modify_ \st ->
+        st { tocEntries = newTree, showAddMenu = [-1] }
+
+    CreateNewSection path -> do
+      state <- H.get
+      let
+        newEntry = Node { title: "New Section", children: [], header: { headerKind: "section", headerType: "section" } }
+        newTree = addRootNode path newEntry state.tocEntries
+      H.modify_ \st ->
+        st { tocEntries = newTree, showAddMenu = [-1] }
+
+
 
   handleQuery
     :: forall slots a
@@ -71,15 +103,16 @@ tocview = H.mkComponent
       pure (Just a)
 
   rootTreeToHTML
-    :: Maybe Int
+    :: Array Int
+    -> Maybe Int
     -> RootTree ShortendTOCEntry
     -> forall slots
      . Array (H.ComponentHTML Action slots m)
-  rootTreeToHTML _ Empty = []
-  rootTreeToHTML mSelectedTocEntry (RootTree { children }) =
+  rootTreeToHTML _ _ Empty = []
+  rootTreeToHTML menuPath mSelectedTocEntry (RootTree { children }) =
     [ HH.div
         [ HP.style
-            "white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0.25rem 0; padding-left: "
+            "white-space: nowrap; text-overflow: ellipsis; padding: 0.25rem 0; display: flex; align-items: center;"
         ]
         [ HH.span
             ( 
@@ -87,24 +120,55 @@ tocview = H.mkComponent
               , HP.style " font-size: 2rem;"
               ]
             )
+            --TODO: use the actual document name
             [ HH.text "Documentname" ]
+        -- Wrapper für Button + Dropdown
+        , HH.div
+          [ HP.style "position: relative; margin-left: 0.5rem;" ]
+          [ -- ➕ Button
+            HH.button
+              [ HE.onClick \_ -> ToggleAddMenu []
+              , HP.style "font-size: 1.5rem; cursor: pointer; background: none; border: none;" ]
+              [ HH.text "➕" ]
+
+            -- Dropdown-Menü
+          , if menuPath == [] then
+              HH.div
+                [ HP.style
+                    "position: absolute; top: 100%; left: 0; background: white; border: 1px solid #ccc; box-shadow: 0 2px 5px rgba(0,0,0,0.1); z-index: 1000;"
+                ]
+                [ HH.button
+                    [ HE.onClick \_ -> CreateNewSubsection []
+                    , HP.style "display: block; padding: 0.5rem 1rem; width: 100%; text-align: left; background: white; border: none; cursor: pointer;" ]
+                    [ HH.text "➕ Unterabschnitt" ]
+                , HH.button
+                    [ HE.onClick \_ -> CreateNewSection []
+                    , HP.style "display: block; padding: 0.5rem 1rem; width: 100%; text-align: left; background: white; border: none; cursor: pointer;" ]
+                    [ HH.text "➕ Abschnitt" ]
+                ]
+            else
+              HH.text ""
+          ]
         ]
-    ] <> concatMap
-      ( \(Edge child) ->
-          treeToHTML 1 mSelectedTocEntry child
-      )
-      children
+    ] <> concat (mapWithIndex
+          (\ix (Edge child) ->
+            treeToHTML menuPath 1 mSelectedTocEntry [ix] child
+          )
+          children)
 
   treeToHTML
-    :: Int
+    :: Array Int
+    -> Int
     -> Maybe Int
+    -- Path to the current section, used for adding new sections
+    -> Array Int
     -> Tree ShortendTOCEntry
     -> forall slots
      . Array (H.ComponentHTML Action slots m)
-  treeToHTML n mSelectedTocEntry (Node { title, children }) =
+  treeToHTML menuPath n mSelectedTocEntry path (Node { title, children }) =
     [ HH.div
       [ HP.style
-          ( "white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0.25rem 0; padding-left: "
+          ( "white-space: nowrap; text-overflow: ellipsis; padding: 0.25rem 0; display: flex; align-items: center;"
               <> (show (1.5 * toNumber n))
               <> "rem;"
           )
@@ -114,13 +178,40 @@ tocview = H.mkComponent
         , HP.style $ if n == 1 then " font-size: 1.25rem;" else ""
         ]
         [ HH.text (title) ]
+        -- Wrapper für Button + Dropdown
+        , HH.div
+          [ HP.style "position: relative; margin-left: 0.5rem;" ]
+          [ -- ➕ Button
+            HH.button
+              [ HE.onClick \_ -> ToggleAddMenu path
+              , HP.style "font-size: 1.5rem; cursor: pointer; background: none; border: none;" ]
+              [ HH.text "➕" ]
+
+            -- Dropdown-Menü
+          , if menuPath == path then
+              HH.div
+                [ HP.style
+                    "position: absolute; top: 100%; left: 0; background: white; border: 1px solid #ccc; box-shadow: 0 2px 5px rgba(0,0,0,0.1); z-index: 1000;"
+                ]
+                [ HH.button
+                    [ HE.onClick \_ -> CreateNewSubsection path
+                    , HP.style "display: block; padding: 0.5rem 1rem; width: 100%; text-align: left; background: white; border: none; cursor: pointer;" ]
+                    [ HH.text "➕ Unterabschnitt" ]
+                , HH.button
+                    [ HE.onClick \_ -> CreateNewSection path
+                    , HP.style "display: block; padding: 0.5rem 1rem; width: 100%; text-align: left; background: white; border: none; cursor: pointer;" ]
+                    [ HH.text "➕ Abschnitt" ]
+                ]
+            else
+              HH.text ""
+          ]
       ]
-    ] <> concatMap
-      ( \(Edge child) ->
-          treeToHTML (n + 1) mSelectedTocEntry child
-      )
-      children
-  treeToHTML n mSelectedTocEntry (Leaf { title, node }) =
+    ] <> concat (mapWithIndex
+          (\ix (Edge child) ->
+            treeToHTML menuPath (n + 1) mSelectedTocEntry (path <> [ix]) child
+          )
+          children)
+  treeToHTML _ n mSelectedTocEntry _ (Leaf { title, node }) =
     [ HH.div
         [ HP.title ("Jump to section " <> title)
         , HP.style
@@ -154,3 +245,56 @@ tocview = H.mkComponent
     ]
     where
       { id, name:_ } = node
+
+addRootNode 
+  :: Array Int 
+  -> Tree ShortendTOCEntry
+  -> RootTree ShortendTOCEntry 
+  -> RootTree ShortendTOCEntry
+addRootNode [] entry (RootTree { children, header }) = 
+  RootTree { children: snoc children (Edge entry), header }
+addRootNode _ entry Empty =
+  RootTree { children: [Edge entry], header: { headerKind: "root", headerType: "root" } }
+addRootNode path entry (RootTree {children, header}) = 
+  case uncons path of
+    Nothing -> 
+      RootTree { children: snoc children (Edge entry), header }
+    Just { head, tail } -> 
+      let
+        child = 
+          fromMaybe 
+            (Edge (Leaf { title: "Error", node: {id: (-1), name: "error"} })) 
+            (children !! head)
+        newChildren = 
+          case updateAt head (addNode tail entry child) children of
+            Nothing -> children
+            Just res -> res
+      in
+        RootTree { children: newChildren, header }
+        
+addNode 
+  :: Array Int 
+  -> Tree ShortendTOCEntry
+  -> Edge ShortendTOCEntry 
+  -> Edge ShortendTOCEntry
+addNode _ _ (Edge (Leaf { title, node })) =
+  Edge (Leaf { title, node }) -- Cannot add to a leaf
+addNode [] entry (Edge (Node { title, children, header })) =
+  Edge (Node { title, children: snoc children (Edge entry), header })
+addNode path entry (Edge (Node { title, children, header })) =
+  case uncons path of
+    Nothing -> 
+      Edge (Node { title, children: snoc children (Edge entry), header })
+    Just { head, tail } -> 
+      let
+        child = 
+          fromMaybe 
+            (Edge (Leaf { title: "Error", node: {id: (-1), name: "error"} })) 
+            (children !! head)
+        newChildren' = 
+          case updateAt head (addNode tail entry child) children of
+            Nothing -> children
+            Just res -> res
+      in
+        Edge (Node { title, children: newChildren', header })
+

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -201,7 +201,7 @@ tocview = H.mkComponent
         [ HP.classes [ HB.textTruncate ]
         , HP.style $ if n == 1 then " font-size: 1.25rem;" else ""
         ]
-        [ HH.text (title) ]
+        [ HH.text title ]
         -- Wrapper für Button + Dropdown
         , HH.div
           [ HP.style "position: relative; margin-left: 0.5rem;" ]

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -101,15 +101,34 @@ tocview = H.mkComponent
     -> Tree ShortendTOCEntry
     -> forall slots
      . Array (H.ComponentHTML Action slots m)
-  treeToHTML n mSelectedTocEntry (Node { children }) =
-    concatMap
+  treeToHTML n mSelectedTocEntry (Node { title, children }) =
+    [ HH.div
+      [ HP.style
+          ( "white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0.25rem 0; padding-left: "
+              <> (show (1.5 * toNumber n))
+              <> "rem;"
+          )
+      ]
+      [ HH.span
+        [ HP.classes [ HB.textTruncate ]
+        , HP.style
+            ( if n == 0 then " font-size: 2rem;"
+              else "cursor: pointer; display: inline-block; min-width: 6ch;"
+                <>
+                  if n == 1 then " font-size: 1.25rem;"
+                  else ""
+            )
+        ]
+        [ HH.text (title) ]
+      ]
+    ] <> concatMap
       ( \(Edge child) ->
           treeToHTML (n + 1) mSelectedTocEntry child
       )
       children
-  treeToHTML n mSelectedTocEntry (Leaf { node }) =
+  treeToHTML n mSelectedTocEntry (Leaf { title, node }) =
     [ HH.div
-        [ HP.title ("Jump to section " <> name)
+        [ HP.title ("Jump to section " <> title)
         , HP.style
             ( "white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0.25rem 0; padding-left: "
                 <> (show (1.5 * toNumber n))
@@ -118,7 +137,7 @@ tocview = H.mkComponent
         ]
         [ HH.span
             ( ( if n == 0 then []
-                else [ HE.onClick \_ -> JumpToSection { id, name } ]
+                else [ HE.onClick \_ -> JumpToSection { id, name: title } ]
               )
                 <>
                   [ HP.classes
@@ -129,16 +148,15 @@ tocview = H.mkComponent
                             else []
                       )
                   , HP.style
-                      ( if n == 0 then " font-size: 2rem;"
-                        else "cursor: pointer; display: inline-block; min-width: 6ch;"
-                          <>
-                            if n == 1 then " font-size: 1.25rem;"
-                            else ""
+                      ( "cursor: pointer; display: inline-block; min-width: 6ch;"
+                        <>
+                          if n == 1 then " font-size: 1.25rem;"
+                          else ""
                       )
                   ]
             )
-            [ HH.text ((if n == 1 then "§" else "") <> name) ]
+            [ HH.text (title) ]
         ]
     ]
     where
-      { id, name } = node
+      { id, name:_ } = node

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -7,10 +7,10 @@ import Data.Either (Either(..))
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
-import FPO.Dto.DocumentDto (DocumentID)
-import FPO.Dto.DocumentDto as DocumentDto
 import FPO.Data.Request as Request
 import FPO.Data.Store as Store
+import FPO.Dto.DocumentDto (DocumentID)
+import FPO.Dto.DocumentDto as DocumentDto
 import FPO.Dto.PostTextDto (PostTextDto(..))
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Dto.TreeDto (Edge(..), RootTree(..), Tree(..))
@@ -44,9 +44,9 @@ type State =
   , showAddMenu :: Array Int
   }
 
-tocview 
+tocview
   :: forall m
-   . MonadAff m 
+   . MonadAff m
   => MonadStore Store.Action Store.Store m
   => DocumentID
   -> H.Component Query Input Output m

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -16,11 +16,11 @@ import Halogen.Themes.Bootstrap5 as HB
 
 type Input = Unit
 
-data Output = ChangeSection ShortendTOCEntry
+data Output = ChangeSection Int
 
 data Action
   = Init
-  | JumpToSection ShortendTOCEntry
+  | JumpToSection Int
 
 data Query a = ReceiveTOCs (TOCTree) a
 
@@ -52,10 +52,10 @@ tocview = H.mkComponent
     Init -> do
       pure unit
 
-    JumpToSection entry -> do
+    JumpToSection id -> do
       H.modify_ \state ->
-        state { mSelectedTocEntry = Just entry.id }
-      H.raise (ChangeSection entry)
+        state { mSelectedTocEntry = Just id }
+      H.raise (ChangeSection id)
 
   handleQuery
     :: forall slots a
@@ -111,13 +111,7 @@ tocview = H.mkComponent
       ]
       [ HH.span
         [ HP.classes [ HB.textTruncate ]
-        , HP.style
-            ( if n == 0 then " font-size: 2rem;"
-              else "cursor: pointer; display: inline-block; min-width: 6ch;"
-                <>
-                  if n == 1 then " font-size: 1.25rem;"
-                  else ""
-            )
+        , HP.style $ if n == 1 then " font-size: 1.25rem;" else ""
         ]
         [ HH.text (title) ]
       ]
@@ -137,7 +131,7 @@ tocview = H.mkComponent
         ]
         [ HH.span
             ( ( if n == 0 then []
-                else [ HE.onClick \_ -> JumpToSection { id, name: title } ]
+                else [ HE.onClick \_ -> JumpToSection id ]
               )
                 <>
                   [ HP.classes

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -108,7 +108,7 @@ changeRole groupID userID role = do
 
 -- | Fetches the document header for a given document ID.
 getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
-getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)
+getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/docs/" <> show docID <> "/tree/latest")
 
 -- | Creates a new document for the specified group.
 -- | TODO: This is according to the old API, might change in the future.

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -108,7 +108,7 @@ changeRole groupID userID role = do
 
 -- | Fetches the document header for a given document ID.
 getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
-getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/docs/" <> show docID <> "/tree/latest")
+getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)
 
 -- | Creates a new document for the specified group.
 -- | TODO: This is according to the old API, might change in the future.

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -1,0 +1,41 @@
+module FPO.Dto.ContentDto where
+
+import Prelude
+
+import Data.Argonaut (Json)
+import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, (.:))
+import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Either (Either)
+import Data.Newtype (class Newtype)
+
+newtype Content = Content
+  { content :: String
+  , parent :: Int
+  }
+
+derive instance newtypeContent :: Newtype Content _
+
+instance decodeJsonContent :: DecodeJson Content where
+  decodeJson json = do
+    obj <- decodeJson json
+    rev <- obj .: "revision"
+    con <- rev .: "content"
+    header <- rev .: "header"
+    id <- header .: "identifier"
+    pure $ Content { content: con, parent: id }
+
+instance encodeJsonContent :: EncodeJson Content where
+  encodeJson (Content {content, parent}) = 
+    encodeJson { content: content, parent: parent }
+
+instance showContent :: Show Content where
+  show (Content {content, parent}) = "Content { content: " <> content <> ", parent: " <> show parent <> " }"
+
+decodeContent :: Json -> Either JsonDecodeError Content
+decodeContent json = decodeJson json
+
+getContentText :: Content -> String
+getContentText (Content { content }) = content
+
+failureContent :: Content
+failureContent = Content { content: "Error decoding content", parent: -1 }

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -25,11 +25,14 @@ instance decodeJsonContent :: DecodeJson Content where
     pure $ Content { content: con, parent: id }
 
 instance encodeJsonContent :: EncodeJson Content where
-  encodeJson (Content {content, parent}) = 
+  encodeJson (Content { content, parent }) =
     encodeJson { content: content, parent: parent }
 
 instance showContent :: Show Content where
-  show (Content {content, parent}) = "Content { content: " <> content <> ", parent: " <> show parent <> " }"
+  show (Content { content, parent }) = "Content { content: " <> content
+    <> ", parent: "
+    <> show parent
+    <> " }"
 
 decodeContent :: Json -> Either JsonDecodeError Content
 decodeContent json = decodeJson json

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -34,8 +34,14 @@ instance showContent :: Show Content where
 decodeContent :: Json -> Either JsonDecodeError Content
 decodeContent json = decodeJson json
 
+encodeContent :: Content -> Json
+encodeContent content = encodeJson content
+
 getContentText :: Content -> String
 getContentText (Content { content }) = content
+
+setContentText :: String -> Content -> Content
+setContentText newText (Content { parent }) = Content { content: newText, parent }
 
 failureContent :: Content
 failureContent = Content { content: "Error decoding content", parent: -1 }

--- a/frontend/src/FPO/Dto/DocumentDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto.purs
@@ -90,6 +90,5 @@ decodeDocument json = do
   root <- obj .: "root"
   decodeJson root
 
-
 encodeDocumentTree :: DocumentTree -> Json
 encodeDocumentTree tree = encodeJson $ map (\(NodeHeader { id }) -> id) tree

--- a/frontend/src/FPO/Dto/DocumentDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto.purs
@@ -7,8 +7,8 @@ import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, (.:)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Either (Either)
 import Data.Maybe (Maybe)
-import Data.Newtype (class Newtype, unwrap)
-import FPO.Dto.TreeDto (Edge(..), RootTree(..), Tree(..))
+import Data.Newtype (class Newtype)
+import FPO.Dto.TreeDto (RootTree)
 
 type DocumentID = Int
 type CommitID = Int
@@ -90,31 +90,6 @@ decodeDocument json = do
   root <- obj .: "root"
   decodeJson root
 
--- Encode instances
--- | Erzeugt ein JSON-Objekt mit Dummy-Daten passend zur Upload-Schnittstelle
-encodeCreateCommit :: DocumentTree -> Json
-encodeCreateCommit tree =
-  encodeJson
-    { info:
-        { author: "00000000-0000-0000-0000-000000000000"
-        , message: "Initial commit"
-        , parents: [ 1 ]
-        }
-    , root: encodeRootTree tree
-    }
 
-encodeRootTree :: DocumentTree -> Json
-encodeRootTree Empty = encodeJson {}
-encodeRootTree (RootTree { children }) =
-  encodeJson { children: map encodeEdge children }
-
-encodeTree :: Tree NodeHeader -> Json
-encodeTree (Node { children }) = encodeJson { edges: map encodeEdge children}
-encodeTree (Leaf { node }) =
-  let
-    { id, kind } = unwrap node
-  in
-  encodeJson { node: encodeJson { identifier: id, kind } }
-
-encodeEdge :: Edge NodeHeader -> Json
-encodeEdge (Edge child) = encodeJson { child: encodeTree child }
+encodeDocumentTree :: DocumentTree -> Json
+encodeDocumentTree tree = encodeJson $ map (\(NodeHeader { id }) -> id) tree

--- a/frontend/src/FPO/Dto/DocumentDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto.purs
@@ -6,20 +6,19 @@ import Data.Argonaut (Json)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, (.:))
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Either (Either)
-import Data.Maybe (Maybe, fromMaybe)
+import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, unwrap)
-import FPO.Dto.TreeDto (Edge(..), Tree(..))
-
-newtype NodeWithRef = NodeWithRef
-  { id :: Int
-  , kind :: String
-  , content :: Maybe String
-  }
-
-type DocumentTree = Tree NodeWithRef
+import FPO.Dto.TreeDto (Edge(..), RootTree(..), Tree(..))
 
 type DocumentID = Int
 type CommitID = Int
+
+newtype NodeHeader = NodeHeader
+  { id :: Int
+  , kind :: String
+  }
+
+type DocumentTree = RootTree NodeHeader
 
 newtype DocumentHeader = DH
   { group :: Int, headCommit :: Maybe CommitID, id :: DocumentID, name :: String }
@@ -31,7 +30,7 @@ derive instance newtypeDocumentHeader :: Newtype DocumentHeader _
 derive instance newtypeDocumentHeaderPlusPermission ::
   Newtype DocumentHeaderPlusPermission _
 
-derive instance newtypeNodeWithRef :: Newtype NodeWithRef _
+derive instance newtypeNodeHeader :: Newtype NodeHeader _
 
 instance decodeJsonHeader :: DecodeJson DocumentHeader where
   decodeJson json = do
@@ -64,37 +63,31 @@ getDHPPName (DHPP dhpp) = getDHName dhpp.document
 getDHPPID :: DocumentHeaderPlusPermission -> Int
 getDHPPID (DHPP dhpp) = getDHID dhpp.document
 
-instance decodeJsonNodeWithRef :: DecodeJson NodeWithRef where
+instance decodeJsonNodeHeader :: DecodeJson NodeHeader where
   decodeJson json = do
     obj <- decodeJson json
-    inner <- obj .: "content" -- neu: extrahiere das innere Objekt
-    id <- inner .: "id"
-    kind <- inner .: "kind"
-    content <- inner .: "content"
-    pure $ NodeWithRef { id, kind, content }
+    id <- obj .: "identifier"
+    kind <- obj .: "kind"
+    pure $ NodeHeader { id, kind }
 
-instance encodeJsonNodeWithRef :: EncodeJson NodeWithRef where
-  encodeJson (NodeWithRef { id, kind, content }) =
+instance encodeJsonNodeHeader :: EncodeJson NodeHeader where
+  encodeJson (NodeHeader { id, kind }) =
     encodeJson
       { content:
           { id
           , kind
-          , content
           }
       }
 
 -- show instances for debugging purposes
-instance showNodeWithRef :: Show NodeWithRef where
-  show (NodeWithRef { id, kind, content }) =
-    "NodeWithRef { id: " <> show id <> ", kind: " <> show kind <> ", content: "
-      <> show content
-      <> " }"
+instance showNodeHeader :: Show NodeHeader where
+  show (NodeHeader { id, kind }) =
+    "NodeHeader { id: " <> show id <> ", kind: " <> show kind <> " }"
 
 decodeDocument :: Json -> Either JsonDecodeError DocumentTree
 decodeDocument json = do
   obj <- decodeJson json
-  body <- obj .: "body"
-  root <- body .: "root"
+  root <- obj .: "root"
   decodeJson root
 
 -- Encode instances
@@ -107,27 +100,21 @@ encodeCreateCommit tree =
         , message: "Initial commit"
         , parents: [ 1 ]
         }
-    , root: encodeTree tree
+    , root: encodeRootTree tree
     }
 
-encodeTree :: DocumentTree -> Json
-encodeTree Empty = encodeJson {}
-encodeTree (Node { node, children }) =
+encodeRootTree :: DocumentTree -> Json
+encodeRootTree Empty = encodeJson {}
+encodeRootTree (RootTree { children }) =
+  encodeJson { children: map encodeEdge children }
+
+encodeTree :: Tree NodeHeader -> Json
+encodeTree (Node { children }) = encodeJson { edges: map encodeEdge children}
+encodeTree (Leaf { node }) =
   let
-    { id, kind, content } = unwrap node
+    { id, kind } = unwrap node
   in
-    encodeJson
-      { node:
-          { id
-          , kind
-          , content: fromMaybe "" content
-          }
-      , edges: map encodeEdge children
-      }
+  encodeJson { node: encodeJson { identifier: id, kind } }
 
-encodeEdge :: Edge NodeWithRef -> Json
-encodeEdge (Edge { title, child }) =
-  encodeJson
-    { title
-    , child: encodeTree child
-    }
+encodeEdge :: Edge NodeHeader -> Json
+encodeEdge (Edge child) = encodeJson { child: encodeTree child }

--- a/frontend/src/FPO/Dto/PostTextDto.purs
+++ b/frontend/src/FPO/Dto/PostTextDto.purs
@@ -1,0 +1,40 @@
+module FPO.Dto.PostTextDto where
+
+import Prelude
+
+import Data.Argonaut (Json)
+import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson, (.:))
+import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Either (Either)
+import Data.Newtype (class Newtype)
+
+newtype PostTextDto = PostTextDto
+  { identifier :: Int
+  , kind :: String
+  }
+
+derive instance newtypePostTextDto :: Newtype PostTextDto _
+
+instance decodeJsonPostTextDto :: DecodeJson PostTextDto where
+  decodeJson json = do
+    obj <- decodeJson json
+    id <- obj .: "identifier"
+    kind <- obj .: "kind"
+    pure $ PostTextDto { identifier: id, kind: kind }
+
+instance encodeJsonPostTextDto :: EncodeJson PostTextDto where
+  encodeJson (PostTextDto { kind }) =
+    encodeJson { kind: kind }
+
+instance showPostTextDto :: Show PostTextDto where
+  show (PostTextDto { identifier, kind }) =
+    "PostTextDto { identifier: " <> show identifier <> ", kind: " <> kind <> " }"
+
+decodePostTextDto :: Json -> Either JsonDecodeError PostTextDto
+decodePostTextDto json = decodeJson json
+
+encodePostTextDto :: PostTextDto -> Json
+encodePostTextDto postTextDto = encodeJson postTextDto
+
+getID :: PostTextDto -> Int
+getID (PostTextDto { identifier }) = identifier

--- a/frontend/src/FPO/Dto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/TreeDto.purs
@@ -2,6 +2,7 @@ module FPO.Dto.TreeDto
   ( Tree(..)
   , Edge(..)
   , RootTree(..)
+  , TreeHeader(..)
   , findRootTree
   ) where
 
@@ -16,9 +17,15 @@ import Data.Foldable (foldr)
 import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse)
 
+type TreeHeader =
+  { kind :: String
+  , type :: String
+  }
+
 data RootTree a 
   = Empty
-  | RootTree { children :: Array (Edge a) }
+  | RootTree { children :: Array (Edge a)
+             , header :: TreeHeader }
 
 data Tree a 
   = Node { title :: String, children :: Array (Edge a) }
@@ -40,9 +47,10 @@ derive instance functorEdge :: Functor Edge
 instance decodeJsonRootTree :: DecodeJson a => DecodeJson (RootTree a) where
   decodeJson json = do
     obj <- decodeJson json
+    header <- obj .: "header"
     childrenArr <- obj .: "children"
     children <- traverse (map Edge <<< decodeJson) childrenArr
-    pure $ RootTree { children }
+    pure $ RootTree { children, header }
 
 instance decodeJsonEdge :: DecodeJson a => DecodeJson (Edge a) where
   decodeJson json = Edge <$> decodeJson json

--- a/frontend/src/FPO/Dto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/TreeDto.purs
@@ -9,8 +9,8 @@ module FPO.Dto.TreeDto
 import Prelude
 
 import Control.Alt ((<|>))
-import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:))
 import Control.Monad.Except (throwError)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:))
 import Data.Argonaut.Decode.Error (JsonDecodeError(TypeMismatch))
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Foldable (foldr)
@@ -22,12 +22,14 @@ type TreeHeader =
   , headerType :: String
   }
 
-data RootTree a 
+data RootTree a
   = Empty
-  | RootTree { children :: Array (Edge a)
-             , header :: TreeHeader }
+  | RootTree
+      { children :: Array (Edge a)
+      , header :: TreeHeader
+      }
 
-data Tree a 
+data Tree a
   = Node { title :: String, children :: Array (Edge a), header :: TreeHeader }
   | Leaf { title :: String, node :: a }
 
@@ -77,12 +79,11 @@ instance decodeJsonTree :: DecodeJson a => DecodeJson (Tree a) where
 
       _ -> throwError $ TypeMismatch $ "Unknown node type: " <> typ
 
-
 -- EncodeJson instances
 
 instance encodeJsonRootTree :: EncodeJson a => EncodeJson (RootTree a) where
-  encodeJson Empty               = encodeJson {}
-  encodeJson (RootTree root ) = encodeJson root
+  encodeJson Empty = encodeJson {}
+  encodeJson (RootTree root) = encodeJson root
 
 instance encodeJsonEdge :: EncodeJson a => EncodeJson (Edge a) where
   encodeJson (Edge child) = encodeJson child
@@ -116,7 +117,7 @@ instance showRootTree :: Show a => Show (RootTree a) where
     "RootTree { children: " <> show children <> " }"
 
 instance showEdge :: Show a => Show (Edge a) where
-  show (Edge child ) =
+  show (Edge child) =
     "Edge { child: " <> show child <> " }"
 
 instance showTree :: Show a => Show (Tree a) where
@@ -135,12 +136,11 @@ findRootTree predicate (RootTree { children }) =
     Nothing
     children
 
-
 findTree :: forall a. (a -> Boolean) -> Tree a -> Maybe a
-findTree predicate (Node { children }) = 
+findTree predicate (Node { children }) =
   foldr
-      (\(Edge child) acc -> acc <|> findTree predicate child)
-      Nothing
-      children
+    (\(Edge child) acc -> acc <|> findTree predicate child)
+    Nothing
+    children
 findTree predicate (Leaf { node }) =
   if predicate node then Just node else Nothing

--- a/frontend/src/FPO/Dto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/TreeDto.purs
@@ -1,80 +1,128 @@
 module FPO.Dto.TreeDto
   ( Tree(..)
   , Edge(..)
-  , findTree
+  , RootTree(..)
+  , findRootTree
   ) where
 
 import Prelude
 
 import Control.Alt ((<|>))
 import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:))
+import Control.Monad.Except (throwError)
+import Data.Argonaut.Decode.Error (JsonDecodeError(TypeMismatch))
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Foldable (foldr)
 import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse)
 
-data Tree a
+data RootTree a 
   = Empty
-  | Node { node :: a, children :: Array (Edge a) }
+  | RootTree { children :: Array (Edge a) }
 
-data Edge a = Edge
-  { title :: String
-  , child :: Tree a
-  }
+data Tree a 
+  = Node { title :: String, children :: Array (Edge a) }
+  | Leaf { title :: String, node :: a }
 
+data Edge a = Edge (Tree a)
+
+-- automatically derive instances for Functor
+
+derive instance functorRootTree :: Functor RootTree
 derive instance functorTree :: Functor Tree
--- map f (Tree { node, children }) = Tree { node: f node, children: map (map f) children }
 derive instance functorEdge :: Functor Edge
--- map f (Edge { title, child }) = Edge { title, child: map f child }
 
 -- derive instance newtypeTree :: Newtype (Tree a) _
 -- derive instance newtypeEdge :: Newtype (Edge a) _
 
-instance decodeJsonEdge :: DecodeJson a => DecodeJson (Edge a) where
+-- DecodeJson instances
+
+instance decodeJsonRootTree :: DecodeJson a => DecodeJson (RootTree a) where
   decodeJson json = do
     obj <- decodeJson json
-    title <- obj .: "title"
-    child <- obj .: "child"
-    pure $ Edge { title, child }
+    childrenArr <- obj .: "children"
+    children <- traverse (map Edge <<< decodeJson) childrenArr
+    pure $ RootTree { children }
+
+instance decodeJsonEdge :: DecodeJson a => DecodeJson (Edge a) where
+  decodeJson json = Edge <$> decodeJson json
 
 instance decodeJsonTree :: DecodeJson a => DecodeJson (Tree a) where
   decodeJson json = do
     obj <- decodeJson json
-    node <- obj .: "node"
-    children <- obj .: "children"
-    pure $ Node { node, children }
+    title <- obj .: "title"
+    content <- obj .: "content"
+    typ <- content .: "type"
+
+    case typ of
+      "leaf" -> do
+        leafVal <- content .: "leaf"
+        node <- decodeJson leafVal
+        pure $ Leaf { title, node }
+
+      "tree" -> do
+        node <- content .: "node"
+        childrenArr <- node .: "children"
+        children <- traverse (map Edge <<< decodeJson) childrenArr
+        pure $ Node { title, children }
+
+      _ -> throwError $ TypeMismatch $ "Unknown node type: " <> typ
+
+
+-- EncodeJson instances
+
+instance encodeJsonRootTree :: EncodeJson a => EncodeJson (RootTree a) where
+  encodeJson Empty               = encodeJson {}
+  encodeJson (RootTree children) = encodeJson { children }
 
 instance encodeJsonEdge :: EncodeJson a => EncodeJson (Edge a) where
-  encodeJson (Edge { title, child }) =
-    encodeJson
-      { title
-      , child
-      }
+  encodeJson (Edge child) = encodeJson { child }
 
 instance encodeJsonTree :: EncodeJson a => EncodeJson (Tree a) where
-  encodeJson Empty = encodeJson {}
-  encodeJson (Node { node, children }) =
+  encodeJson (Node { title, children }) =
     encodeJson
-      { node
+      { title
       , children
       }
+  encodeJson (Leaf { title, node }) =
+    encodeJson
+      { title
+      , node
+      }
+
+-- Show instances
+
+instance showRootTree :: Show a => Show (RootTree a) where
+  show Empty = "Empty"
+  show (RootTree children) =
+    "RootTree { children: " <> show children <> " }"
 
 instance showEdge :: Show a => Show (Edge a) where
-  show (Edge { title, child }) =
-    "Edge { title: " <> show title <> ", child: " <> show child <> " }"
+  show (Edge child ) =
+    "Edge { child: " <> show child <> " }"
 
 instance showTree :: Show a => Show (Tree a) where
-  show Empty = "Empty"
-  show (Node { node, children }) =
-    "Tree { node: " <> show node <> ", children: " <> show children <> " }"
+  show (Node { title, children }) =
+    "Tree { title: " <> title <> ", children: " <> show children <> " }"
+  show (Leaf { title, node }) =
+    "Tree { title: " <> title <> ", node: " <> show node <> " }"
 
 -- TODO: DFS. Maybe use a different search method? But maybe not necessary,
 -- because the document tree may never be that large to notice. 
+findRootTree :: forall a. (a -> Boolean) -> RootTree a -> Maybe a
+findRootTree _ Empty = Nothing
+findRootTree predicate (RootTree { children }) =
+  foldr
+    (\(Edge child) acc -> acc <|> findTree predicate child)
+    Nothing
+    children
+
+
 findTree :: forall a. (a -> Boolean) -> Tree a -> Maybe a
-findTree _ Empty = Nothing
-findTree predicate (Node { node, children }) =
-  if predicate node then Just node
-  else
-    foldr
-      (\(Edge { child }) acc -> acc <|> findTree predicate child)
+findTree predicate (Node { children }) = 
+  foldr
+      (\(Edge child) acc -> acc <|> findTree predicate child)
       Nothing
       children
+findTree predicate (Leaf { node }) =
+  if predicate node then Just node else Nothing

--- a/frontend/src/FPO/Types.purs
+++ b/frontend/src/FPO/Types.purs
@@ -38,7 +38,6 @@ type Comment =
 type TOCEntry =
   { id :: Int
   , name :: String
-  , content :: String
   -- Is stored as 32bit Int = 2,147,483,647
   -- Schould not create so many markers, right?
   , newMarkerNextID :: Int
@@ -59,7 +58,6 @@ emptyTOCEntry :: TOCEntry
 emptyTOCEntry =
   { id: -1
   , name: "Error"
-  , content: "Error"
   , newMarkerNextID: -1
   , markers: []
   }
@@ -146,7 +144,6 @@ nodeHeaderToTOCEntry :: NodeHeader -> TOCEntry
 nodeHeaderToTOCEntry (NodeHeader { id, kind }) =
   { id: id
   , name: kind
-  , content: ""
   , newMarkerNextID: 0
   , markers: []
   }

--- a/frontend/src/FPO/Types.purs
+++ b/frontend/src/FPO/Types.purs
@@ -7,9 +7,9 @@ import Data.Array (find, sortBy)
 import Data.DateTime (DateTime)
 import Data.Formatter.DateTime (Formatter, FormatterCommand(..))
 import Data.List (List(..), (:))
-import Data.Maybe (Maybe(..), fromMaybe)
-import FPO.Dto.DocumentDto (DocumentTree, NodeWithRef(..))
-import FPO.Dto.TreeDto (Tree, findTree)
+import Data.Maybe (Maybe)
+import FPO.Dto.DocumentDto (DocumentTree, NodeHeader(..))
+import FPO.Dto.TreeDto (RootTree, findRootTree)
 
 -- TODO We can also store different markers, such as errors. But do we want to?
 type AnnotatedMarker =
@@ -52,7 +52,7 @@ type ShortendTOCEntry =
   , name :: String
   }
 
-type TOCTree = Tree TOCEntry
+type TOCTree = RootTree TOCEntry
 
 -- Empty TOCEntry in case of errors
 emptyTOCEntry :: TOCEntry
@@ -65,7 +65,7 @@ emptyTOCEntry =
   }
 
 findTOCEntry :: Int -> TOCTree -> Maybe TOCEntry
-findTOCEntry tocID tocEntries = findTree (\e -> e.id == tocID) tocEntries
+findTOCEntry tocID tocEntries = findRootTree (\e -> e.id == tocID) tocEntries
 
 findCommentSection :: Int -> Int -> TOCTree -> Maybe CommentSection
 findCommentSection tocID markerID tocEntries = do
@@ -142,21 +142,21 @@ timeStampsVersions =
 
 -- Tree functions for TOC
 
-nodeWithRefToTOCEntry :: NodeWithRef -> TOCEntry
-nodeWithRefToTOCEntry (NodeWithRef { id, kind, content }) =
+nodeHeaderToTOCEntry :: NodeHeader -> TOCEntry
+nodeHeaderToTOCEntry (NodeHeader { id, kind }) =
   { id: id
   , name: kind
-  , content: fromMaybe "" content
+  , content: ""
   , newMarkerNextID: 0
   , markers: []
   }
 
-tocEntryToNodeWithRef :: TOCEntry -> NodeWithRef
-tocEntryToNodeWithRef { id, name, content } =
-  NodeWithRef { id, kind: name, content: Just content }
+tocEntryToNodeHeader :: TOCEntry -> NodeHeader
+tocEntryToNodeHeader { id, name } =
+  NodeHeader { id, kind: name }
 
 documentTreeToTOCTree :: DocumentTree -> TOCTree
-documentTreeToTOCTree = map nodeWithRefToTOCEntry
+documentTreeToTOCTree = map nodeHeaderToTOCEntry
 
 tocTreeToDocumentTree :: TOCTree -> DocumentTree
-tocTreeToDocumentTree = map tocEntryToNodeWithRef
+tocTreeToDocumentTree = map tocEntryToNodeHeader


### PR DESCRIPTION
Closes #280 
Closes #254 
Closes #255 

Implemented the new docs API into the editor. Can now load the right tree into the editor, and clicking the TOC can now load the right text from the server. It also saves the content to the server (by clicking the save button or changing the TOC). 

Can also add a new Node or Leaf into the tree, but only at the end of the array. This also gets updated in the server. It partially work on Issue #256 

It also opens the right document when selected. But the logic of GET has to be reworked. 