### PR TITLE
Add group member assignment functionality

### DIFF
--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -106,6 +106,10 @@ changeRole groupID userID role = do
   let body = encodeJson role
   putIgnore ("/roles/" <> show groupID <> "/" <> userID) body
 
+removeUser :: GroupID -> UserID -> Aff (Either Error (Response Unit))
+removeUser groupID userID = do
+  deleteIgnore ("/roles/" <> show groupID <> "/" <> userID)
+
 -- | Fetches the document header for a given document ID.
 getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
 getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)

--- a/frontend/src/FPO/Data/Route.purs
+++ b/frontend/src/FPO/Data/Route.purs
@@ -22,6 +22,7 @@ data Route
   | AdminViewGroups
   | ViewGroupDocuments { groupID :: GroupID }
   | ViewGroupMembers { groupID :: GroupID }
+  | GroupAddMembers { groupID :: GroupID }
   | Page404
   | Profile { loginSuccessful :: Maybe Boolean }
 
@@ -40,6 +41,7 @@ routeCodec = root $ sum
   , "AdminViewGroups": "admin-groups" / noArgs
   , "ViewGroupDocuments": "view-group-documents" ? { groupID: int }
   , "ViewGroupMembers": "view-group-members" ? { groupID: int }
+  , "GroupAddMembers": "group-add-members" ? { groupID: int }
   , "Page404": "404" / noArgs
   , "Profile": "profile" ? { loginSuccessful: optional <<< boolean }
   }
@@ -56,6 +58,7 @@ routeToString = case _ of
   AdminViewGroups -> "AdminViewGroups"
   ViewGroupDocuments groupID -> "ViewGroupDocuments:" <> show groupID
   ViewGroupMembers groupID -> "ViewGroupMembers:" <> show groupID
+  GroupAddMembers groupID -> "GroupAddMembers:" <> show groupID
   Page404 -> "Page404"
   Profile { loginSuccessful } -> "Profile" <>
     ( if loginSuccessful == Nothing then ""

--- a/frontend/src/FPO/Dto/GroupDto.purs
+++ b/frontend/src/FPO/Dto/GroupDto.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Array (find)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe, isJust)
 import Data.Newtype (class Newtype)
 import FPO.Dto.UserDto (Role, UserID)
 
@@ -50,6 +50,9 @@ getGroupMembers (GroupDto g) = g.groupMembers
 lookupUser :: GroupDto -> UserID -> Maybe GroupMemberDto
 lookupUser (GroupDto g) userID =
   find (\member -> getUserInfoID member == userID) g.groupMembers
+
+isUserInGroup :: GroupDto -> UserID -> Boolean
+isUserInGroup g = isJust <<< lookupUser g
 
 derive instance newtypeGroupDto :: Newtype GroupDto _
 derive newtype instance encodeJsonGroupDto :: EncodeJson GroupDto

--- a/frontend/src/FPO/Dto/UserDto.purs
+++ b/frontend/src/FPO/Dto/UserDto.purs
@@ -9,6 +9,7 @@ import Data.Argonaut
   , decodeJson
   , encodeJson
   )
+import Data.Array (any)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
@@ -35,6 +36,16 @@ getUserID (FullUserDto u) = u.fullUserID
 
 isUserSuperadmin :: FullUserDto -> Boolean
 isUserSuperadmin (FullUserDto u) = u.fullUserIsSuperadmin
+
+-- | Checks if the user is an admin of a specific group.
+-- | Returns `true` if the user is an admin of the group with the given ID,
+-- | detached from the superadmin state of the user.
+-- |
+-- | See `isUserSuperadmin` for checking if the user is a superadmin.
+isAdminOf :: FullUserDto -> Int -> Boolean
+isAdminOf (FullUserDto u) groupID =
+  any (\role -> getUserRoleGroupID role == groupID && getUserRole role == Admin)
+    u.fullUserRoles
 
 getUserName :: FullUserDto -> String
 getUserName (FullUserDto u) = u.fullUserName

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -19,6 +19,7 @@ import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..), routeCodec, routeToString)
 import FPO.Data.Store (loadLanguage)
 import FPO.Data.Store as Store
+import FPO.Page.Admin.Group.AddMembers as GroupAddMembers
 import FPO.Page.Admin.Group.DocOverview as ViewGroupDocuments
 import FPO.Page.Admin.Group.MemberOverview as ViewGroupMembers
 import FPO.Page.Admin.Groups as AdminViewGroups
@@ -81,6 +82,7 @@ _adminUsers = Proxy :: Proxy "adminPanelUsers"
 _adminGroups = Proxy :: Proxy "adminPanelGroups"
 _viewGroupDocuments = Proxy :: Proxy "viewGroupDocuments"
 _viewGroupMembers = Proxy :: Proxy "viewGroupMembers"
+_groupAddMembers = Proxy :: Proxy "groupAddMembers"
 _page404 = Proxy :: Proxy "page404"
 _profile = Proxy :: Proxy "profile"
 
@@ -94,6 +96,7 @@ type Slots =
   , adminPanelGroups :: forall q. H.Slot q Void Unit
   , viewGroupDocuments :: forall q. H.Slot q Void Unit
   , viewGroupMembers :: forall q. H.Slot q Void Unit
+  , groupAddMembers :: forall q. H.Slot q Void Unit
   , page404 :: forall q. H.Slot q Void Unit
   , profile :: forall q. H.Slot q Void Unit
   )
@@ -141,6 +144,9 @@ component =
             groupID
           ViewGroupMembers { groupID } -> HH.slot_ _viewGroupMembers unit
             ViewGroupMembers.component
+            groupID
+          GroupAddMembers { groupID } -> HH.slot_ _groupAddMembers unit
+            GroupAddMembers.component
             groupID
           Page404 -> HH.slot_ _page404 unit Page404.component unit
           Profile { loginSuccessful } -> HH.slot_ _profile unit Profile.component

--- a/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
+++ b/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
@@ -92,7 +92,8 @@ component =
         , addError state.error
         ]
       Nothing -> HH.div [ HP.classes [ HB.textCenter, HB.my5 ] ]
-        [ HH.h1 [] [ HH.text $ translate (label :: _ "gmam_loadingGroup") state.translator ]
+        [ HH.h1 []
+            [ HH.text $ translate (label :: _ "gmam_loadingGroup") state.translator ]
         , HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] []
         ]
 
@@ -132,7 +133,12 @@ component =
         EffectAddUser -> do
           response <- liftAff $ changeRole s.groupID (getID userOverviewDto) Member
           handleIgnoreResponse
-            (\error -> H.modify_ _ { error = Just $ translate (label :: _ "gmam_failedToAdd") s.translator <> ": " <> error })
+            ( \error -> H.modify_ _
+                { error = Just $
+                    translate (label :: _ "gmam_failedToAdd") s.translator <> ": " <>
+                      error
+                }
+            )
             (handleAction ReloadGroup)
             response
         EffectRemoveUser -> do
@@ -140,8 +146,10 @@ component =
           handleIgnoreResponse
             ( \error -> H.modify_ _
                 { error
-                   = Just $
-                      translate (label :: _ "gmam_failedToRemove") s.translator <> ": " <> error }
+                    = Just $
+                    translate (label :: _ "gmam_failedToRemove") s.translator <> ": "
+                      <> error
+                }
             )
             (handleAction ReloadGroup)
             response
@@ -154,7 +162,9 @@ component =
             { group = Just group
             }
         Nothing -> do
-          H.modify_ _ { error = Just $ translate (label :: _ "gmam_groupNotFound") s.translator }
+          H.modify_ _
+            { error = Just $ translate (label :: _ "gmam_groupNotFound") s.translator
+            }
     where
     handleIgnoreResponse onError onSuccess response =
       case response of

--- a/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
+++ b/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
@@ -1,0 +1,213 @@
+-- | Page used to assign users to a specific group.
+
+module FPO.Page.Admin.Group.AddMembers (component) where
+
+import Prelude
+
+import Affjax (printError)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Effect.Aff.Class (class MonadAff, liftAff)
+import FPO.Components.UI.UserFilter as Filter
+import FPO.Components.UI.UserList as UserList
+import FPO.Data.Navigate (class Navigate, navigate)
+import FPO.Data.Request (changeRole, getGroup, getStatusCode, getUser, removeUser)
+import FPO.Data.Route (Route(..))
+import FPO.Data.Store as Store
+import FPO.Dto.GroupDto (GroupDto, GroupID, getGroupName, isUserInGroup)
+import FPO.Dto.UserDto (Role(..), isAdminOf, isUserSuperadmin)
+import FPO.Dto.UserOverviewDto (getID)
+import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
+import FPO.Translations.Util (FPOState, selectTranslator)
+import FPO.UI.HTML (addError)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Halogen.Store.Connect (Connected, connect)
+import Halogen.Store.Monad (class MonadStore)
+import Halogen.Themes.Bootstrap5 as HB
+import Simple.I18n.Translator (label, translate)
+import Type.Proxy (Proxy(..))
+
+_filter = Proxy :: Proxy "filter"
+_userlist = Proxy :: Proxy "userlist"
+
+data ButtonEvent
+  = EffectAddUser
+  | EffectRemoveUser
+
+type Slots =
+  ( filter :: forall q. H.Slot q Filter.Output Unit
+  , userlist :: H.Slot UserList.Query (UserList.Output ButtonEvent) Unit
+  )
+
+data Action
+  = Initialize
+  | Receive (Connected FPOTranslator Input)
+  | HandleFilter Filter.Output
+  | HandleUserList (UserList.Output ButtonEvent)
+  | ReloadGroup
+
+type State = FPOState
+  ( error :: Maybe String
+  , group :: Maybe GroupDto
+  , groupID :: GroupID
+  )
+
+type Input = GroupID
+
+-- | Admin panel page component.
+component
+  :: forall query output m
+   . MonadStore Store.Action Store.Store m
+  => MonadAff m
+  => Navigate m
+  => H.Component query Input output m
+component =
+  connect selectTranslator $ H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval H.defaultEval
+        { handleAction = handleAction
+        , initialize = Just Initialize
+        , receive = Just <<< Receive
+        }
+    }
+  where
+  initialState :: Connected FPOTranslator Input -> State
+  initialState { context, input } =
+    { translator: fromFpoTranslator context
+    , error: Nothing
+    , group: Nothing
+    , groupID: input
+    }
+
+  render :: State -> H.ComponentHTML Action Slots m
+  render state =
+    case state.group of
+      Just g -> HH.div
+        [ HP.classes [ HB.containerXl, HB.my5 ]
+        ]
+        [ renderMemberManagement state g
+        , addError state.error
+        ]
+      Nothing -> HH.div [ HP.classes [ HB.textCenter, HB.my5 ] ]
+        [ HH.h1 [] [ HH.text $ translate (label :: _ "gmam_loadingGroup") state.translator ]
+        , HH.div [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] []
+        ]
+
+  handleAction :: Action -> H.HalogenM State Action Slots output m Unit
+  handleAction = case _ of
+    Initialize -> do
+      s <- H.get
+      u <- H.liftAff $ getUser
+      case u of
+        Nothing -> do
+          navigate Page404
+        Just user -> do
+          if isUserSuperadmin user || user `isAdminOf` s.groupID then do
+            handleAction ReloadGroup
+            -- User is either a superadmin or an admin of the group,
+            -- so we can proceed to load the group and user list.
+            H.tell _userlist unit UserList.ReloadUsersQ
+          else
+            -- User is not authorized to view this page, redirect to 404.
+            navigate Page404
+    Receive { context, input } -> do
+      H.modify_ _ { translator = fromFpoTranslator context }
+
+      s <- H.get
+      when (s.groupID /= input) $ do
+        H.modify_ _ { groupID = input }
+        handleAction ReloadGroup
+    HandleFilter f -> do
+      H.tell _userlist unit (UserList.HandleFilterQ f)
+    HandleUserList (UserList.Loading _) -> do
+      pure unit
+    HandleUserList (UserList.Error err) -> do
+      H.modify_ _ { error = Just err }
+    HandleUserList (UserList.ButtonPressed userOverviewDto effect) -> do
+      s <- H.get
+      case effect of
+        EffectAddUser -> do
+          response <- liftAff $ changeRole s.groupID (getID userOverviewDto) Member
+          handleIgnoreResponse
+            (\error -> H.modify_ _ { error = Just $ translate (label :: _ "gmam_failedToAdd") s.translator <> ": " <> error })
+            (handleAction ReloadGroup)
+            response
+        EffectRemoveUser -> do
+          response <- liftAff $ removeUser s.groupID (getID userOverviewDto)
+          handleIgnoreResponse
+            ( \error -> H.modify_ _
+                { error
+                   = Just $
+                      translate (label :: _ "gmam_failedToRemove") s.translator <> ": " <> error }
+            )
+            (handleAction ReloadGroup)
+            response
+    ReloadGroup -> do
+      s <- H.get
+      g <- liftAff $ getGroup s.groupID
+      case g of
+        Just group -> do
+          H.modify_ _
+            { group = Just group
+            }
+        Nothing -> do
+          H.modify_ _ { error = Just $ translate (label :: _ "gmam_groupNotFound") s.translator }
+    where
+    handleIgnoreResponse onError onSuccess response =
+      case response of
+        Left err -> onError $ printError err
+        Right status -> do
+          case getStatusCode status of
+            200 -> onSuccess
+            _ -> onError $ show status
+
+  renderMemberManagement :: State -> GroupDto -> H.ComponentHTML Action Slots m
+  renderMemberManagement state group =
+    HH.div_ $
+      [ HH.h2 [ HP.classes [ HB.textCenter, HB.mb4 ] ]
+          [ HH.text $
+              translate (label :: _ "gmam_assignMembers")
+                state.translator <> " "
+          , HH.span
+              [ HP.classes
+                  [ HB.textSecondary, HB.fwBolder, HB.dInlineBlock, HB.textWrap ]
+              ]
+              [ HH.text $ getGroupName group ]
+          ]
+      , renderUserListView state group
+      ]
+
+  renderUserListView :: State -> GroupDto -> H.ComponentHTML Action Slots m
+  renderUserListView state group =
+    HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
+      [ renderFilterBy
+      , renderUserList state group
+      ]
+
+  renderFilterBy :: H.ComponentHTML Action Slots m
+  renderFilterBy =
+    HH.slot _filter unit Filter.component unit HandleFilter
+
+  renderUserList :: State -> GroupDto -> H.ComponentHTML Action Slots m
+  renderUserList state group =
+    HH.slot _userlist unit UserList.component events HandleUserList
+    where
+    events = \u ->
+      [ if isUserInGroup group (getID u) then
+          { popover: translate (label :: _ "gmam_removeMember") state.translator
+          , effect: EffectRemoveUser
+          , icon: "bi-person-dash-fill"
+          , classes: [ HB.btn, HB.btnDanger, HB.btnSm ]
+          , disabled: false
+          }
+        else
+          { popover: translate (label :: _ "gmam_addMember") state.translator
+          , effect: EffectAddUser
+          , icon: "bi-person-plus-fill"
+          , classes: [ HB.btn, HB.btnPrimary, HB.btnSm ]
+          , disabled: false
+          }
+      ]

--- a/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
@@ -70,6 +70,7 @@ data Action
   | ReloadGroupMembers
   | NavigateToDocuments
   | SetUserRole GroupMemberDto Role
+  | NavigateToUserAdder
 
 -- | Simple "state machine" for the modal system.
 data ModalState
@@ -335,7 +336,7 @@ component =
   renderAddMemberButton state =
     HH.button
       [ Style.cyanStyle
-      -- , HE.onClick (const $ DoNothing) -- TODO: Actually implement
+      , HE.onClick (const $ NavigateToUserAdder)
       ]
       [ HH.text $ translate (label :: _ "gm_addMember") state.translator ]
 
@@ -450,6 +451,8 @@ component =
                   { error = Just $ "Failed to change role: " <> show status
                   , modalState = NoModal
                   }
-
       handleAction ReloadGroupMembers
       handleAction (FilterForMember "")
+    NavigateToUserAdder -> do
+      s <- H.get
+      navigate (GroupAddMembers { groupID: s.groupID })

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -228,20 +228,24 @@ component =
     HH.slot _userlist unit UserList.component events HandleUserList
     where
     events = \u ->
-      [ { popover: translate (label :: _ "admin_users_deleteUser") state.translator
-        , effect: EffectDeleteUser
-        , icon: "bi-trash"
-        , classes: [ HB.btn, HB.btnOutlineDanger, HB.btnSm, HB.me2 ]
-        , disabled: state.userID == Just (UOD.getID u)
-        }
-      , { popover: translate (label :: _ "admin_users_goToProfilePage")
-            state.translator
-        , effect: EffectGoToProfilePage
-        , icon: "bi-person-fill"
-        , classes: [ HB.btn, HB.btnOutlinePrimary, HB.btnSm ]
-        , disabled: false
-        }
-      ]
+      let
+        isMe = state.userID == Just (UOD.getID u)
+      in
+        [ { popover: translate (label :: _ "admin_users_deleteUser") state.translator
+          , effect: EffectDeleteUser
+          , icon: "bi-trash"
+          , classes: [ HB.btn, HB.btnOutlineDanger, HB.btnSm, HB.me2 ]
+              <> (if isMe then [ HB.opacity25 ] else [])
+          , disabled: isMe
+          }
+        , { popover: translate (label :: _ "admin_users_goToProfilePage")
+              state.translator
+          , effect: EffectGoToProfilePage
+          , icon: "bi-person-fill"
+          , classes: [ HB.btn, HB.btnOutlinePrimary, HB.btnSm ]
+          , disabled: false
+          }
+        ]
 
   -- Creates a form to create a new (dummy) user.
   renderNewUserForm :: forall w. State -> HH.HTML w Action

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -3,9 +3,6 @@
 -- | TODO:
 -- | - Implement the `goToProfilePage` funcionality
 -- |   (for users other than the one logged in).
--- | - Trying to delete oneself fails in the backend,
--- |   but no error is shown in the UI. Perhaps, we should
--- |   simply prohibit deleting oneself in the UI?
 
 module FPO.Page.Admin.Users (component) where
 

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -6,7 +6,10 @@ import FPO.Translations.Components.Editor (deEditor, enEditor)
 import FPO.Translations.Components.Navbar (deNavbar, enNavbar)
 import FPO.Translations.Page.Admin.AddMembers (deAddMembersPage, enAddMembersPage)
 import FPO.Translations.Page.Admin.GroupMembers (deGroupMemberPage, enGroupMemberPage)
-import FPO.Translations.Page.Admin.GroupProjects (deGroupProjectsPage, enGroupProjectsPage)
+import FPO.Translations.Page.Admin.GroupProjects
+  ( deGroupProjectsPage
+  , enGroupProjectsPage
+  )
 import FPO.Translations.Page.Admin.PageGroups (deAdminGroupPage, enAdminGroupPage)
 import FPO.Translations.Page.Admin.PageUsers (deAdminUserPage, enAdminUserPage)
 import FPO.Translations.Page.AdminPanel (deAdminPanel, enAdminPanel)

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -4,11 +4,9 @@ import Data.Function (($))
 import FPO.Translations.Common (deCommon, enCommon)
 import FPO.Translations.Components.Editor (deEditor, enEditor)
 import FPO.Translations.Components.Navbar (deNavbar, enNavbar)
+import FPO.Translations.Page.Admin.AddMembers (deAddMembersPage, enAddMembersPage)
 import FPO.Translations.Page.Admin.GroupMembers (deGroupMemberPage, enGroupMemberPage)
-import FPO.Translations.Page.Admin.GroupProjects
-  ( deGroupProjectsPage
-  , enGroupProjectsPage
-  )
+import FPO.Translations.Page.Admin.GroupProjects (deGroupProjectsPage, enGroupProjectsPage)
 import FPO.Translations.Page.Admin.PageGroups (deAdminGroupPage, enAdminGroupPage)
 import FPO.Translations.Page.Admin.PageUsers (deAdminUserPage, enAdminUserPage)
 import FPO.Translations.Page.AdminPanel (deAdminPanel, enAdminPanel)
@@ -26,6 +24,7 @@ en = fromRecord
   $ merge (toRecord enAdminPanel)
   $ merge (toRecord enAdminGroupPage)
   $ merge (toRecord enAdminUserPage)
+  $ merge (toRecord enAddMembersPage)
   $ merge (toRecord enCommon)
   $ merge (toRecord enEditor)
   $ merge (toRecord enNavbar)
@@ -43,6 +42,7 @@ de = fromRecord
   $ merge (toRecord deAdminPanel)
   $ merge (toRecord deAdminGroupPage)
   $ merge (toRecord deAdminUserPage)
+  $ merge (toRecord deAddMembersPage)
   $ merge (toRecord deCommon)
   $ merge (toRecord deEditor)
   $ merge (toRecord deNavbar)
@@ -137,6 +137,15 @@ type Labels =
       ::: "gm_removeMember"
       ::: "gm_role"
       ::: "gm_searchMembers"
+
+      -- | Group Manamgent - Add Members Page
+      ::: "gmam_addMember"
+      ::: "gmam_assignMembers"
+      ::: "gmam_failedToAdd"
+      ::: "gmam_failedToRemove"
+      ::: "gmam_groupNotFound"
+      ::: "gmam_loadingGroup"
+      ::: "gmam_removeMember"
 
       -- | Group Projects Page
       ::: "gp_createNewProject"

--- a/frontend/src/FPO/Translations/Page/Admin/AddMembers.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/AddMembers.purs
@@ -1,0 +1,37 @@
+module FPO.Translations.Page.Admin.AddMembers where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type AddMembersPageLabels =
+  (   "gmam_addMember"
+  ::: "gmam_assignMembers"
+  ::: "gmam_failedToAdd"
+  ::: "gmam_failedToRemove"
+  ::: "gmam_groupNotFound"
+  ::: "gmam_loadingGroup"
+  ::: "gmam_removeMember"
+      ::: SNil
+  )
+
+enAddMembersPage :: Translation AddMembersPageLabels
+enAddMembersPage = fromRecord
+  { gmam_addMember: "Add Member to Group"
+  , gmam_assignMembers: "Assign Members to"
+  , gmam_failedToAdd: "Failed to add user"
+  , gmam_failedToRemove: "Failed to remove user"
+  , gmam_groupNotFound: "Failed to retrieve group info"
+  , gmam_loadingGroup: "Loading group information..."
+  , gmam_removeMember: "Remove Member from Group"
+  }
+
+deAddMembersPage :: Translation AddMembersPageLabels
+deAddMembersPage = fromRecord
+  { gmam_addMember: "Mitglied zur Gruppe hinzufügen"
+  , gmam_assignMembers: "Mitgliederzuweisung für"
+  , gmam_failedToAdd: "Fehler beim Hinzufügen des Benutzers"
+  , gmam_failedToRemove: "Fehler beim Entfernen des Benutzers"
+  , gmam_groupNotFound: "Fehler beim Abrufen der Gruppeninformationen"
+  , gmam_loadingGroup: "Lade Gruppeninformationen..."
+  , gmam_removeMember: "Mitglied aus Gruppe entfernen"
+  }

--- a/frontend/src/FPO/Translations/Page/Admin/AddMembers.purs
+++ b/frontend/src/FPO/Translations/Page/Admin/AddMembers.purs
@@ -4,13 +4,13 @@ import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord)
 
 type AddMembersPageLabels =
-  (   "gmam_addMember"
-  ::: "gmam_assignMembers"
-  ::: "gmam_failedToAdd"
-  ::: "gmam_failedToRemove"
-  ::: "gmam_groupNotFound"
-  ::: "gmam_loadingGroup"
-  ::: "gmam_removeMember"
+  ( "gmam_addMember"
+      ::: "gmam_assignMembers"
+      ::: "gmam_failedToAdd"
+      ::: "gmam_failedToRemove"
+      ::: "gmam_groupNotFound"
+      ::: "gmam_loadingGroup"
+      ::: "gmam_removeMember"
       ::: SNil
   )
 


### PR DESCRIPTION
This PR adds member assignment functionality; i.e., the cyan "Add Member" button in the group overview page finally works and redirects to a new page with the complete user list. Here, the group-/superadmin can simply select who to add to the group. 

Closes #139!