### PR TITLE
Backend Docs API: `user` and `group` Query Parameters for `/docs` Endpoint

### DIFF
--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -1,6 +1,7 @@
 module Docs.Database
     ( HasCheckPermission (..)
     , HasIsGroupAdmin (..)
+    , HasIsSuperAdmin (..)
     , HasExistsDocument (..)
     , HasExistsTextElement (..)
     , HasExistsTextRevision (..)
@@ -50,6 +51,9 @@ class (Monad m) => HasCheckPermission m where
 class (Monad m) => HasIsGroupAdmin m where
     isGroupAdmin :: UserID -> GroupID -> m Bool
 
+class (Monad m) => HasIsSuperAdmin m where
+    isSuperAdmin :: UserID -> m Bool
+
 -- exists
 
 class (Monad m) => HasExistsDocument m where
@@ -66,9 +70,10 @@ class (HasExistsDocument m) => HasExistsTreeRevision m where
 
 -- get
 
-class (HasCheckPermission m) => HasGetDocument m where
+class (HasCheckPermission m, HasIsGroupAdmin m, HasIsSuperAdmin m) => HasGetDocument m where
     getDocument :: DocumentID -> m (Maybe Document)
     getDocuments :: UserID -> m (Vector Document)
+    getDocumentsBy :: Maybe UserID -> Maybe GroupID -> m (Vector Document)
 
 class (HasCheckPermission m, HasExistsTreeRevision m) => HasGetTreeRevision m where
     getTreeRevision :: TreeRevisionRef -> m (TreeRevision TextElement)

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -19,6 +19,8 @@ import Hasql.Transaction.Sessions
 
 import Docs.Database
 
+import qualified UserManagement.Sessions as UserSessions
+
 import qualified Docs.Hasql.Sessions as Sessions
 import qualified Docs.Hasql.Transactions as Transactions
 
@@ -39,6 +41,9 @@ instance HasCheckPermission HasqlSession where
 instance HasIsGroupAdmin HasqlSession where
     isGroupAdmin = (HasqlSession .) . Sessions.isGroupAdmin
 
+instance HasIsSuperAdmin HasqlSession where
+    isSuperAdmin = HasqlSession . UserSessions.checkSuperadmin
+
 -- exists
 
 instance HasExistsDocument HasqlSession where
@@ -58,6 +63,7 @@ instance HasExistsTreeRevision HasqlSession where
 instance HasGetDocument HasqlSession where
     getDocument = HasqlSession . Sessions.getDocument
     getDocuments = HasqlSession . Sessions.getDocuments
+    getDocumentsBy = (HasqlSession .) . Sessions.getDocumentsBy
 
 instance HasGetTreeRevision HasqlSession where
     getTreeRevision = HasqlSession . Sessions.getTreeRevision

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -2,6 +2,7 @@ module Docs.Hasql.Sessions
     ( createDocument
     , getDocument
     , getDocuments
+    , getDocumentsBy
     , createTextElement
     , createTextRevision
     , getTextElementRevision
@@ -83,6 +84,9 @@ getDocument = (`statement` Statements.getDocument)
 
 getDocuments :: UserID -> Session (Vector Document)
 getDocuments = (`statement` Statements.getDocuments)
+
+getDocumentsBy :: Maybe UserID -> Maybe GroupID -> Session (Vector Document)
+getDocumentsBy = curry (`statement` Statements.getDocumentsBy)
 
 createTextElement :: DocumentID -> TextElementKind -> Session TextElement
 createTextElement = curry (`statement` Statements.createTextElement)


### PR DESCRIPTION
Currently, the `/docs` endpoint returns all documents by the group of the logged in user or which the logged in user has external document rights for. For all users except super admins, this meas `/docs` returns all documents visible for the user. Super admins can see more documents than this endpoint returns.

With this PR, the `/docs` endpoint still behaves the same, except it now takes two optional query parameters `user` and `group`. This allows super admins to also obtain documents of other users or by groups they are not a member of.

Thus, the following endpoints will not be updated to the new document management system and are replaced by `/docs`:
- `/user/{userID}/documents`: superseded by `/docs?user={userID}`
- `/groups/{groupID}/documents`: superseded by `/docs?group={groupID}`