### PR TITLE
Backend Docs API: Echo Query Params for `/docs`

### DIFF
--- a/backend/src/Server/DTOs/Documents.hs
+++ b/backend/src/Server/DTOs/Documents.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module Server.DTOs.Documents (Documents (..)) where
+module Server.DTOs.Documents (Documents (..), DocumentsQuery (..)) where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.OpenApi (ToSchema)
@@ -9,9 +9,12 @@ import Data.Vector (Vector)
 import GHC.Generics (Generic)
 
 import Docs.Document (Document)
+import UserManagement.Group (GroupID)
+import UserManagement.User (UserID)
 
-newtype Documents = Documents
+data Documents = Documents
     { documents :: Vector Document
+    , query :: DocumentsQuery
     }
     deriving (Generic)
 
@@ -20,3 +23,15 @@ instance ToJSON Documents
 instance FromJSON Documents
 
 instance ToSchema Documents
+
+data DocumentsQuery = DocumentsQuery
+    { user :: Maybe UserID
+    , group :: Maybe GroupID
+    }
+    deriving (Generic)
+
+instance ToJSON DocumentsQuery
+
+instance FromJSON DocumentsQuery
+
+instance ToSchema DocumentsQuery

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -79,7 +79,10 @@ import Server.DTOs.CreateTextElement (CreateTextElement)
 import qualified Server.DTOs.CreateTextElement as CreateTextElement
 import Server.DTOs.CreateTextRevision (CreateTextRevision)
 import qualified Server.DTOs.CreateTextRevision as CreateTextRevision
-import Server.DTOs.Documents (Documents (Documents))
+import Server.DTOs.Documents
+    ( Documents (Documents)
+    , DocumentsQuery (DocumentsQuery)
+    )
 import qualified Server.DTOs.Documents as Documents
 import UserManagement.Group (GroupID)
 
@@ -236,6 +239,11 @@ getDocumentsHandler auth byUserID byGroupID = do
     return $
         Documents
             { Documents.documents = result
+            , Documents.query =
+                DocumentsQuery
+                    { Documents.user = byUserID
+                    , Documents.group = byGroupID
+                    }
             }
 
 postTextElementHandler


### PR DESCRIPTION
This PR changes the `GET /docs` response to include query parameters in a successful API response. This is just for debugging and logging purposes.