### PR TITLE
Standardize document header type #257

### DIFF
--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -28,6 +28,7 @@ package:
     - maybe
     - newtype
     - now
+    - parsing
     - prelude
     - record
     - record-extra

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -23,7 +23,7 @@ import FPO.Components.Preview as Preview
 import FPO.Components.TOC as TOC
 import FPO.Data.Request as Request
 import FPO.Data.Store as Store
-import FPO.Dto.DocumentDto (DocumentID)
+import FPO.Dto.DocumentDto (DocumentID, getDHHeadCommit)
 import FPO.Dto.DocumentDto as DocumentDto
 import FPO.Dto.TreeDto (Tree(..), findTree)
 import FPO.Types
@@ -149,8 +149,7 @@ splitview
   => MonadStore Store.Action Store.Store m
   => DocumentID
   -> H.Component query Input Output m
--- _ was used for docID for Get, which is currently no longer functional.
-splitview _ = H.mkComponent
+splitview docID = H.mkComponent
   { initialState: \_ ->
       { mDragTarget: Nothing
       , startMouseRatio: 0.0
@@ -499,9 +498,7 @@ splitview _ = H.mkComponent
         st { tocEntries = tree }
       H.tell _toc unit (TOC.ReceiveTOCs tree)
     GET -> do
-      -- the previous implementation was no longer compatible with the new data structures and must be changed.
-      pure unit
-{-       -- TODO: As of now, the editor page and splitview are parametrized by the document ID
+      -- TODO: As of now, the editor page and splitview are parametrized by the document ID
       --       as given by the route. We could also handle the docID as an input to the component,
       --       instead, but parameters are more convenient and also there is no existence issue;
       --       in other words, the editor cannot exist with no document ID.
@@ -520,7 +517,7 @@ splitview _ = H.mkComponent
         pure $ documentTreeToTOCTree fetchedTree
 
       H.modify_ _ { tocEntries = finalTree }
-      H.tell _toc unit (TOC.ReceiveTOCs finalTree) -}
+      H.tell _toc unit (TOC.ReceiveTOCs finalTree)
     Init -> do
       -- exampleTOCEntries <- createExampleTOCEntries
       -- -- Comment it out for now, to let the other text show up first in editor

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -23,7 +23,7 @@ import FPO.Components.Preview as Preview
 import FPO.Components.TOC as TOC
 import FPO.Data.Request as Request
 import FPO.Data.Store as Store
-import FPO.Dto.DocumentDto (DocumentID, getDHHeadCommit)
+import FPO.Dto.DocumentDto (DocumentID)
 import FPO.Dto.DocumentDto as DocumentDto
 import FPO.Dto.TreeDto (Tree(..), findTree)
 import FPO.Types
@@ -149,7 +149,8 @@ splitview
   => MonadStore Store.Action Store.Store m
   => DocumentID
   -> H.Component query Input Output m
-splitview docID = H.mkComponent
+-- _ was used for docID for Get, which is currently no longer functional.
+splitview _ = H.mkComponent
   { initialState: \_ ->
       { mDragTarget: Nothing
       , startMouseRatio: 0.0
@@ -498,7 +499,9 @@ splitview docID = H.mkComponent
         st { tocEntries = tree }
       H.tell _toc unit (TOC.ReceiveTOCs tree)
     GET -> do
-      -- TODO: As of now, the editor page and splitview are parametrized by the document ID
+      -- the previous implementation was no longer compatible with the new data structures and must be changed.
+      pure unit
+{-       -- TODO: As of now, the editor page and splitview are parametrized by the document ID
       --       as given by the route. We could also handle the docID as an input to the component,
       --       instead, but parameters are more convenient and also there is no existence issue;
       --       in other words, the editor cannot exist with no document ID.
@@ -517,7 +520,7 @@ splitview docID = H.mkComponent
         pure $ documentTreeToTOCTree fetchedTree
 
       H.modify_ _ { tocEntries = finalTree }
-      H.tell _toc unit (TOC.ReceiveTOCs finalTree)
+      H.tell _toc unit (TOC.ReceiveTOCs finalTree) -}
     Init -> do
       -- exampleTOCEntries <- createExampleTOCEntries
       -- -- Comment it out for now, to let the other text show up first in editor

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -25,7 +25,13 @@ import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import FPO.Dto.CreateDocumentDto (DocumentCreateDto, NewDocumentCreateDto)
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader, DocumentQuery)
+import FPO.Dto.DocumentDto
+  ( DocumentHeader
+  , DocumentHeaderPlusPermission
+  , DocumentID
+  , DocumentQuery
+  , NewDocumentHeader
+  )
 import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview)
 import FPO.Dto.UserDto (FullUserDto, Role, UserID)
 import Foreign (renderForeignError)

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -24,8 +24,8 @@ import Effect.Aff as Exn
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
-import FPO.Dto.CreateDocumentDto (DocumentCreateDto)
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID)
+import FPO.Dto.CreateDocumentDto (DocumentCreateDto, NewDocumentCreateDto)
+import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader)
 import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview, Role, UserID)
 import FPO.Dto.UserDto (User, decodeUser)
 import Foreign (renderForeignError)
@@ -110,10 +110,17 @@ changeRole groupID userID role = do
 getDocumentHeader :: DocumentID -> Aff (Maybe DocumentHeader)
 getDocumentHeader docID = getFromJSONEndpoint decodeJson ("/documents/" <> show docID)
 
+-- | Currently, the old API is still needed so this is the new one for now.
+getNewDocumentHeader :: DocumentID -> Aff (Maybe NewDocumentHeader)
+getNewDocumentHeader docID = getFromJSONEndpoint decodeJson ("/docs/" <> show docID)
+
 -- | Creates a new document for the specified group.
 -- | TODO: This is according to the old API, might change in the future.
 createDocument :: DocumentCreateDto -> Aff (Either Error (Response Json))
 createDocument dto = postJson "/documents" (encodeJson dto)
+
+createNewDocument :: NewDocumentCreateDto -> Aff (Either Error (Response Json))
+createNewDocument dto = postJson "/docs" (encodeJson dto)
 
 getDocumentsFromURL :: String -> Aff (Maybe (Array DocumentHeader))
 getDocumentsFromURL url = getFromJSONEndpoint (decodeArray decodeJson) url

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -24,19 +24,8 @@ import Effect.Aff as Exn
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
-{- <<<<<<< HEAD
 import FPO.Dto.CreateDocumentDto (DocumentCreateDto, NewDocumentCreateDto)
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader)
-import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview, Role, UserID)
-import FPO.Dto.UserDto (User, decodeUser)
-=======
-import FPO.Dto.CreateDocumentDto (DocumentCreateDto)
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID)
-import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview)
-import FPO.Dto.UserDto (FullUserDto, Role, UserID)
->>>>>>> main -}
-import FPO.Dto.CreateDocumentDto (DocumentCreateDto, NewDocumentCreateDto)
-import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader)
+import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader, DocumentQuery)
 import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview)
 import FPO.Dto.UserDto (FullUserDto, Role, UserID)
 import Foreign (renderForeignError)
@@ -139,6 +128,9 @@ createNewDocument dto = postJson "/docs" (encodeJson dto)
 
 getDocumentsFromURL :: String -> Aff (Maybe (Array DocumentHeader))
 getDocumentsFromURL url = getFromJSONEndpoint (decodeArray decodeJson) url
+
+getDocumentsQueryFromURL :: String -> Aff (Maybe DocumentQuery)
+getDocumentsQueryFromURL url = getFromJSONEndpoint decodeJson url
 
 getDocumentsFromURLWithPermission
   :: String -> Aff (Maybe (Array DocumentHeaderPlusPermission))

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -37,7 +37,7 @@ import FPO.Dto.UserDto (FullUserDto, Role, UserID)
 >>>>>>> main -}
 import FPO.Dto.CreateDocumentDto (DocumentCreateDto, NewDocumentCreateDto)
 import FPO.Dto.DocumentDto (DocumentHeader, DocumentHeaderPlusPermission, DocumentID, NewDocumentHeader)
-import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview, Role, UserID)
+import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview)
 import FPO.Dto.UserDto (FullUserDto, Role, UserID)
 import Foreign (renderForeignError)
 import Web.DOM.Document (Document)

--- a/frontend/src/FPO/Dto/CreateDocumentDto.purs
+++ b/frontend/src/FPO/Dto/CreateDocumentDto.purs
@@ -9,7 +9,17 @@ newtype DocumentCreateDto = DocumentCreateDto
   , documentCreateName :: String
   }
 
+newtype NewDocumentCreateDto = NewDocumentCreateDto
+  { groupID :: Int
+  , title :: String
+  }
+
 derive instance newtypeDocumentCreateDto :: Newtype DocumentCreateDto _
 
 derive newtype instance encodeJsonDocumentCreateDto :: EncodeJson DocumentCreateDto
 derive newtype instance decodeJsonDocumentCreateDto :: DecodeJson DocumentCreateDto
+
+derive instance newtypeNewDocumentCreateDto :: Newtype NewDocumentCreateDto _
+
+derive newtype instance encodeJsonNewDocumentCreateDto :: EncodeJson NewDocumentCreateDto
+derive newtype instance decodeJsonNewDocumentCreateDto :: DecodeJson NewDocumentCreateDto

--- a/frontend/src/FPO/Dto/CreateDocumentDto.purs
+++ b/frontend/src/FPO/Dto/CreateDocumentDto.purs
@@ -21,5 +21,8 @@ derive newtype instance decodeJsonDocumentCreateDto :: DecodeJson DocumentCreate
 
 derive instance newtypeNewDocumentCreateDto :: Newtype NewDocumentCreateDto _
 
-derive newtype instance encodeJsonNewDocumentCreateDto :: EncodeJson NewDocumentCreateDto
-derive newtype instance decodeJsonNewDocumentCreateDto :: DecodeJson NewDocumentCreateDto
+derive newtype instance encodeJsonNewDocumentCreateDto ::
+  EncodeJson NewDocumentCreateDto
+
+derive newtype instance decodeJsonNewDocumentCreateDto ::
+  DecodeJson NewDocumentCreateDto

--- a/frontend/src/FPO/Dto/DocumentDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto.purs
@@ -48,13 +48,13 @@ import FPO.Dto.TreeDto (RootTree)
 import Parsing (ParserT, runParserT, fail)
 import Parsing.String (char, anyTill, rest)
 
-newtype NodeWithRef = NodeWithRef
+{- newtype NodeWithRef = NodeWithRef
   { id :: Int
   , kind :: String
   , content :: Maybe String
-  }
+  } -}
 
-type DocumentTree = Tree NodeWithRef
+-- type DocumentTree = Tree NodeWithRef
 
 
 type DocumentID = Int

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -498,7 +498,7 @@ component =
                         { name: h.name
                         , text: "This text should not be read, else there is an error"
                         }
-                    , header: { updatedTs: now, id: h.id, archivedStatus: false }
+                    , header: { updatedTs: now, id: h.identifier, archivedStatus: false }
                     }
                 H.modify_ \s' -> s'
                   { documents = newDoc : s'.documents

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -33,8 +33,7 @@ import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request
-  ( createDocument
-  , createNewDocument
+  ( createNewDocument
   , deleteIgnore
   , getDocumentsFromURL
   , getDocumentsQueryFromURL
@@ -44,17 +43,12 @@ import FPO.Data.Request
   )
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
-import FPO.Dto.CreateDocumentDto (DocumentCreateDto(..), NewDocumentCreateDto(..))
+import FPO.Dto.CreateDocumentDto (NewDocumentCreateDto(..))
 import FPO.Dto.DocumentDto
-  ( DocDate(..)
-  , DocumentHeader(..)
-  , DocumentID
+  ( DocumentID
   , NewDocumentHeader(..)
-  , User(..)
   , convertOptionalToMandatory
   , docDateToDateTime
-  , getDHID
-  , getDHName
   , getDQDocuments
   , getNDHID
   , getNDHLastEdited

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -512,14 +512,13 @@ component =
         Just docs -> do
           H.modify_ _ { documents = toDocs now docs }
         Nothing -> do
-<<<<<<< HEAD
           log "No Document Found."
           handleAction DoNithing
           -- navigate Login
       handleAction Filter -}
     Initialize -> do
       u <- liftAff $ getUser
-      when (fromMaybe true (not <$> _.isAdmin <$> u)) $
+      when (fromMaybe true (not <$> isUserSuperadmin <$> u)) $
         navigate Page404
       now <- H.liftEffect nowDateTime
       H.modify_ _
@@ -544,10 +543,6 @@ component =
             (pure unit)
             docs
         Nothing -> do
-          log "No Document Found."
-          handleAction DoNothing
-          -- navigate Login
-=======
           navigate Page404
 
       g <- liftAff $ getGroup s.groupID
@@ -556,8 +551,6 @@ component =
           H.modify_ _ { group = Just group }
         Nothing -> do
           navigate Page404
-
->>>>>>> main
       handleAction Filter
     Receive { context } -> do
       H.modify_ _ { translator = fromFpoTranslator context }

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -32,11 +32,34 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request (createDocument, createNewDocument, deleteIgnore, getDocumentsFromURL, getDocumentsQueryFromURL, getNewDocumentHeader, getGroup, getUser)
+import FPO.Data.Request
+  ( createDocument
+  , createNewDocument
+  , deleteIgnore
+  , getDocumentsFromURL
+  , getDocumentsQueryFromURL
+  , getGroup
+  , getNewDocumentHeader
+  , getUser
+  )
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.CreateDocumentDto (DocumentCreateDto(..), NewDocumentCreateDto(..))
-import FPO.Dto.DocumentDto (convertOptionalToMandatory, DocDate(..), docDateToDateTime, DocumentHeader(..), DocumentID, getDHID, getDHName, getDQDocuments,getNDHID, getNDHLastEdited, getNDHName, NewDocumentHeader(..), User(..))
+import FPO.Dto.DocumentDto
+  ( DocDate(..)
+  , DocumentHeader(..)
+  , DocumentID
+  , NewDocumentHeader(..)
+  , User(..)
+  , convertOptionalToMandatory
+  , docDateToDateTime
+  , getDHID
+  , getDHName
+  , getDQDocuments
+  , getNDHID
+  , getNDHLastEdited
+  , getNDHName
+  )
 import FPO.Dto.GroupDto (GroupDto, GroupID, getGroupName)
 import FPO.Dto.UserDto (isUserSuperadmin)
 import FPO.Page.Home (formatRelativeTime)
@@ -283,7 +306,7 @@ component =
         }
       ]
 
-    -- Renders a single project row in the table.
+  -- Renders a single project row in the table.
   renderDocumentRow :: forall w. State -> Document -> HH.HTML w Action
   renderDocumentRow state document =
     HH.tr
@@ -293,7 +316,9 @@ component =
       [ HH.td [ HP.classes [ HB.textCenter ] ]
           [ HH.text (getNDHName document) ]
       , HH.td [ HP.classes [ HB.textCenter ] ]
-          [ HH.text $ formatRelativeTime state.currentTime (docDateToDateTime (getNDHLastEdited document)) ]
+          [ HH.text $ formatRelativeTime state.currentTime
+              (docDateToDateTime (getNDHLastEdited document))
+          ]
       -- archiving feature not supported for now
       {-       , HH.td [ HP.classes [ HB.textCenter ] ]
       [ HH.text (show document.header.archivedStatus) ] -}
@@ -437,11 +462,12 @@ component =
       case documents of
         Just docs -> do
           modDocs <- pure $ foldr
-            (\doc res -> case doc of
-              Just someDoc -> someDoc : res
-              Nothing -> res)
+            ( \doc res -> case doc of
+                Just someDoc -> someDoc : res
+                Nothing -> res
+            )
             []
-            (map convertOptionalToMandatory (getDQDocuments docs)) 
+            (map convertOptionalToMandatory (getDQDocuments docs))
           H.modify_ _ { documents = modDocs }
         Nothing -> do
           navigate Page404
@@ -508,7 +534,7 @@ component =
                       , currentTime = Just now
                       }
                   Nothing ->
-                    H.modify_ _{ currentTime = Just now }
+                    H.modify_ _ { currentTime = Just now }
 
                 -- Reset the page view
                 H.modify_ _ { documentNameFilter = "" }
@@ -544,18 +570,21 @@ component =
           case documents of
             Just docs -> do
               modDocs <- pure $ foldr
-                (\doc res -> case doc of
-                  Just someDoc -> someDoc : res
-                  Nothing -> res)
+                ( \doc res -> case doc of
+                    Just someDoc -> someDoc : res
+                    Nothing -> res
+                )
                 []
-                (map convertOptionalToMandatory (getDQDocuments docs)) 
-              H.modify_ _ { error = Nothing 
-                          , documents = modDocs 
-                          , modalState = NoModal}
+                (map convertOptionalToMandatory (getDQDocuments docs))
+              H.modify_ _
+                { error = Nothing
+                , documents = modDocs
+                , modalState = NoModal
+                }
             Nothing -> do
               log "No Document Found."
               handleAction DoNothing
-              -- navigate Login
+      -- navigate Login
       handleAction Filter
     ViewDocument documentID -> do
       s <- H.get
@@ -616,6 +645,6 @@ component =
 
   docNameFromID :: State -> Int -> String
   docNameFromID state id =
-    case head (filter (\ (NDH doc) -> doc.id == id) state.documents) of
+    case head (filter (\(NDH doc) -> doc.id == id) state.documents) of
       Just (NDH doc) -> doc.name
       Nothing -> "Unknown Name"

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -35,10 +35,8 @@ import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request
   ( createNewDocument
   , deleteIgnore
-  , getDocumentsFromURL
   , getDocumentsQueryFromURL
   , getGroup
-  , getNewDocumentHeader
   , getUser
   )
 import FPO.Data.Route (Route(..))


### PR DESCRIPTION
This pull requests contains parts of #257. Notably, the document headers in DocOverview were changed. That being said, some problems remain:  First of all, the document header of the home page remain unchanged. Furthermore, there are still 2 more API related issues i could not change yet. 

Previously, not the entirety of the previous Endpoints had been adapted, meaning the old API had to remain for now. As such, some of the new code that should replace previous code didn't do so yet, quite notably the DocumentHeader type. As such, old API code remains, and new code has been added. In places where it collides with previous codes, new code names have been appended witth "New", such as "NewDocumentHeader". Ideally, these new types should replace them. 
      
 Furthermore, some of the endpoints send incomplete data, such as "lastEdited" often missing for many documents. This has been remedied for now, but once that problem has been fixed, unnecessary code should ideally be removed. 
      
For both of these problems a majority of the relevant frontend code can be found in "DocumentDto.purs"