### PR TITLE
Allow group management for normal admins

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -32,6 +32,7 @@
             "maybe",
             "newtype",
             "now",
+            "parsing",
             "prelude",
             "record",
             "record-extra",

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -16,7 +16,7 @@ import FPO.Data.Request (getIgnore, getUser)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store (saveLanguage)
 import FPO.Data.Store as Store
-import FPO.Dto.UserDto (FullUserDto, getUserName, isUserSuperadmin)
+import FPO.Dto.UserDto (FullUserDto, getUserName, isAdmin, isUserSuperadmin)
 import FPO.Translations.Translator
   ( FPOTranslator(..)
   , fromFpoTranslator
@@ -95,30 +95,29 @@ navbar = connect (selectEq identity) $ H.mkComponent
                       [ navButton "Editor" (Editor { docID: 1 }) ]
                   ]
                     <>
-                      if (maybe false isUserSuperadmin state.user) then
-                        [ HH.li [ HP.classes [ HB.navItem ] ]
-                            [ navButton
-                                ( translate (label :: _ "navbar_users")
-                                    state.translator
-                                )
-                                AdminViewUsers
-                            ]
-                        , HH.li [ HP.classes [ HB.navItem ] ]
-                            [ navButton
-                                ( translate (label :: _ "navbar_groups")
-                                    state.translator
-                                )
-                                AdminViewGroups
-                            ]
-                        , HH.li [ HP.classes [ HB.navItem ] ]
-                            [ navButton
-                                ( translate (label :: _ "navbar_documents")
-                                    state.translator
-                                )
-                                (ViewGroupDocuments { groupID: 1 })
-                            ]
-                        ]
-                      else []
+                      ( if (maybe false isUserSuperadmin state.user) then
+                          [ HH.li [ HP.classes [ HB.navItem ] ]
+                              [ navButton
+                                  ( translate (label :: _ "navbar_users")
+                                      state.translator
+                                  )
+                                  AdminViewUsers
+                              ]
+                          ]
+                        else []
+                      )
+                    <>
+                      ( if (maybe false isAdmin state.user) then
+                          [ HH.li [ HP.classes [ HB.navItem ] ]
+                              [ navButton
+                                  ( translate (label :: _ "navbar_groups")
+                                      state.translator
+                                  )
+                                  AdminViewGroups
+                              ]
+                          ]
+                        else []
+                      )
                 )
 
             -- Right side of the navbar
@@ -201,17 +200,27 @@ navbar = connect (selectEq identity) $ H.mkComponent
               <>
                 ( if isUserSuperadmin user then
                     [ dropdownEntry
-                        (translate (label :: _ "au_userManagement") state.translator)
+                        ( translate (label :: _ "au_userManagement")
+                            state.translator
+                        )
                         "person-exclamation"
                         (Navigate AdminViewUsers) `addClass` HB.bgWarningSubtle
-                    , dropdownEntry
-                        (translate (label :: _ "au_groupManagement") state.translator)
+                    ]
+                  else []
+                )
+              <>
+                ( if isAdmin user then
+                    [ dropdownEntry
+                        ( translate (label :: _ "au_groupManagement")
+                            state.translator
+                        )
                         "people"
                         (Navigate AdminViewGroups) `addClass` HB.bgWarningSubtle
                     ]
                   else []
                 )
-              <> [ dropdownEntry "Logout" "box-arrow-right" Logout ]
+              <>
+                [ dropdownEntry "Logout" "box-arrow-right" Logout ]
           )
       ]
 

--- a/frontend/src/FPO/Dto/GroupDto.purs
+++ b/frontend/src/FPO/Dto/GroupDto.purs
@@ -5,8 +5,10 @@ import Prelude
 
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Array (find)
+import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe, isJust)
 import Data.Newtype (class Newtype)
+import Data.Show.Generic (genericShow)
 import FPO.Dto.UserDto (Role, UserID)
 
 type GroupID = Int
@@ -24,6 +26,9 @@ getGroupOverviewName (GroupOverview g) = g.groupOverviewName
 derive instance newtypeGroupOverview :: Newtype GroupOverview _
 derive newtype instance encodeJsonGroupOverview :: EncodeJson GroupOverview
 derive newtype instance decodeJsonGroupOverview :: DecodeJson GroupOverview
+derive instance genericGroupOverview :: Generic GroupOverview _
+instance showGroupOverview :: Show GroupOverview where
+  show = genericShow
 
 -- | A group creation request DTO, as sent to the `POST /groups` endpoint.
 newtype GroupCreate = GroupCreate
@@ -39,6 +44,12 @@ newtype GroupDto = GroupDto
   , groupID :: GroupID
   , groupMembers :: Array GroupMemberDto
   , groupName :: String
+  }
+
+demoteToGroupOverview :: GroupDto -> GroupOverview
+demoteToGroupOverview (GroupDto g) = GroupOverview
+  { groupOverviewName: g.groupName
+  , groupOverviewID: g.groupID
   }
 
 getGroupName :: GroupDto -> String
@@ -57,6 +68,9 @@ isUserInGroup g = isJust <<< lookupUser g
 derive instance newtypeGroupDto :: Newtype GroupDto _
 derive newtype instance encodeJsonGroupDto :: EncodeJson GroupDto
 derive newtype instance decodeJsonGroupDto :: DecodeJson GroupDto
+derive instance genericGroupDto :: Generic GroupDto _
+instance showGroupDto :: Show GroupDto where
+  show = genericShow
 
 -- | Represents a group member entity, as returned by the `GET /groups/{groupID}` endpoint.
 newtype GroupMemberDto = GroupMemberDto
@@ -78,3 +92,6 @@ getUserInfoID (GroupMemberDto m) = m.userInfoID
 derive instance newtypeGroupMemberDto :: Newtype GroupMemberDto _
 derive newtype instance encodeJsonGroupMemberDto :: EncodeJson GroupMemberDto
 derive newtype instance decodeJsonGroupMemberDto :: DecodeJson GroupMemberDto
+derive instance genericGroupMemberDto :: Generic GroupMemberDto _
+instance showGroupMemberDto :: Show GroupMemberDto where
+  show = genericShow

--- a/frontend/src/FPO/Dto/UserDto.purs
+++ b/frontend/src/FPO/Dto/UserDto.purs
@@ -37,6 +37,12 @@ getUserID (FullUserDto u) = u.fullUserID
 isUserSuperadmin :: FullUserDto -> Boolean
 isUserSuperadmin (FullUserDto u) = u.fullUserIsSuperadmin
 
+-- | Checks if the user is admin of at least one group, or even a superadmin.
+isAdmin :: FullUserDto -> Boolean
+isAdmin (FullUserDto u) = u.fullUserIsSuperadmin || any
+  (\role -> getUserRole role == Admin)
+  u.fullUserRoles
+
 -- | Checks if the user is an admin of a specific group.
 -- | Returns `true` if the user is an admin of the group with the given ID,
 -- | detached from the superadmin state of the user.

--- a/frontend/src/FPO/Page/Admin/Groups.purs
+++ b/frontend/src/FPO/Page/Admin/Groups.purs
@@ -24,9 +24,9 @@ import FPO.Data.Request
   ( LoadState(..)
   , addGroup
   , deleteIgnore
-  , getGroups
   , getStatusCode
   , getUser
+  , getUserGroups
   , printError
   )
 import FPO.Data.Route (Route(..))
@@ -38,7 +38,7 @@ import FPO.Dto.GroupDto
   , getGroupOverviewID
   , getGroupOverviewName
   )
-import FPO.Dto.UserDto (isUserSuperadmin)
+import FPO.Dto.UserDto (isAdmin)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
 import FPO.UI.HTML (addButton, addCard, addColumn, addError, addModal, emptyEntryGen)
@@ -160,10 +160,10 @@ component =
   handleAction = case _ of
     Initialize -> do
       u <- liftAff $ getUser
-      when (fromMaybe true (not <$> isUserSuperadmin <$> u)) $
+      when (fromMaybe true (not <$> isAdmin <$> u)) $
         navigate Page404
 
-      g <- liftAff getGroups
+      g <- liftAff getUserGroups
       case g of
         Just gs -> do
           H.modify_ _ { groups = Loaded gs }


### PR DESCRIPTION
Normal admins can now access the "groups" page via the navbar and they can change roles, add documents and add members to their groups.

Closes #289.