### PR TITLE
Backend Docs: Prevent Duplicate Text Revisions

### DIFF
--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -113,6 +113,14 @@ instance HasExistsDocument HasqlTransaction where
 instance HasExistsTextElement HasqlTransaction where
     existsTextElement = HasqlTransaction . Transactions.existsTextElement
 
+instance HasExistsTextRevision HasqlTransaction where
+    existsTextRevision = HasqlTransaction . Transactions.existsTextRevision
+
+-- get
+
+instance HasGetTextElementRevision HasqlTransaction where
+    getTextElementRevision = HasqlTransaction . Transactions.getTextElementRevision
+
 -- create
 
 instance HasCreateTextRevision HasqlTransaction where

--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE TupleSections #-}
 
 module Docs.Hasql.Transactions
-    ( createTextRevision
+    ( getTextElementRevision
+    , existsTextRevision
+    , createTextRevision
     , putTree
     , createTreeRevision
     , existsDocument
@@ -30,8 +32,10 @@ import Docs.Hasql.TreeEdge (TreeEdge (TreeEdge), TreeEdgeChildRef (..))
 import qualified Docs.Hasql.TreeEdge as TreeEdge
 import Docs.TextElement (TextElementID, TextElementRef (..))
 import Docs.TextRevision
-    ( TextRevision
+    ( TextElementRevision
+    , TextRevision
     , TextRevisionID
+    , TextRevisionRef
     )
 import Docs.Tree (Edge (Edge), Node (Node), Tree (Leaf, Tree))
 import Docs.TreeRevision (TreeRevision)
@@ -39,6 +43,14 @@ import DocumentManagement.Hash
     ( Hash (Hash)
     , Hashable (..)
     )
+
+getTextElementRevision
+    :: TextRevisionRef
+    -> Transaction (Maybe TextElementRevision)
+getTextElementRevision = flip statement Statements.getTextElementRevision
+
+existsTextRevision :: TextRevisionRef -> Transaction Bool
+existsTextRevision = flip statement Statements.existsTextRevision
 
 existsDocument :: DocumentID -> Transaction Bool
 existsDocument = flip statement Statements.existsDocument


### PR DESCRIPTION
Currently, if one attempts to create a new text revision with the same content as the latest revision, the backend will just do that. This behavior turns out to be undesirable, as the frontend requests to create a new revision on each context switch, regardless of whether the text was edited or not. This results in *a lot* of unnecessary database entries.

With this PR, the backend now checks if the content has changed. If the content is unmodified, the backend will not create a new revision but just return the existing one instead. Thus, the database as well as the revision history will be less polluted. 