### PR TITLE
Allow `GET /docs?group=..` endpoint for superadmin

### DIFF
--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -267,7 +267,8 @@ guardPermission
     -> ExceptT Error m ()
 guardPermission perms docID userID = do
     hasPermission <- lift $ DB.checkDocumentPermission userID docID perms
-    unless hasPermission $
+    superAdmin <- lift $ DB.isSuperAdmin userID
+    unless (hasPermission || superAdmin) $
         throwError (NoPermission docID perms)
 
 guardGroupAdmin
@@ -277,7 +278,8 @@ guardGroupAdmin
     -> ExceptT Error m ()
 guardGroupAdmin groupID userID = do
     hasPermission <- lift $ DB.isGroupAdmin userID groupID
-    unless hasPermission $
+    superAdmin <- lift $ DB.isSuperAdmin userID
+    unless (hasPermission || superAdmin) $
         throwError (NoPermissionInGroup groupID)
 
 guardUserRights

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -115,6 +115,8 @@ getDocument userID docID = runExceptT $ do
 
 -- | Gets all documents visible by the user
 --   OR all documents by the specified group and / or user
+--
+--   Notice that this endpoint is always accessible to super admins.
 getDocuments
     :: (HasGetDocument m)
     => UserID
@@ -124,8 +126,10 @@ getDocuments
 getDocuments userID byUserID byGroupID = case (byUserID, byGroupID) of
     (Nothing, Nothing) -> Right <$> DB.getDocuments userID
     _ -> runExceptT $ do
-        maybe (pure ()) (guardUserRights userID) byUserID
-        maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
+        sup <- lift $ DB.isSuperAdmin userID
+        unless sup $ do
+            maybe (pure ()) (guardUserRights userID) byUserID
+            maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
         lift $ DB.getDocumentsBy byUserID byGroupID
 
 createTextElement

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -115,8 +115,6 @@ getDocument userID docID = runExceptT $ do
 
 -- | Gets all documents visible by the user
 --   OR all documents by the specified group and / or user
---
---   Notice that this endpoint is always accessible to super admins.
 getDocuments
     :: (HasGetDocument m)
     => UserID
@@ -126,10 +124,8 @@ getDocuments
 getDocuments userID byUserID byGroupID = case (byUserID, byGroupID) of
     (Nothing, Nothing) -> Right <$> DB.getDocuments userID
     _ -> runExceptT $ do
-        sup <- lift $ DB.isSuperAdmin userID
-        unless sup $ do
-            maybe (pure ()) (guardUserRights userID) byUserID
-            maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
+        maybe (pure ()) (guardUserRights userID) byUserID
+        maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
         lift $ DB.getDocumentsBy byUserID byGroupID
 
 createTextElement

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -45,10 +45,10 @@ import Docs.Tree (Node)
 import Docs.TreeRevision (TreeRevision, TreeRevisionHistory, TreeRevisionRef)
 import GHC.Int (Int32)
 
-class (Monad m) => HasCheckPermission m where
+class (HasIsSuperAdmin m) => HasCheckPermission m where
     checkDocumentPermission :: UserID -> DocumentID -> Permission -> m Bool
 
-class (Monad m) => HasIsGroupAdmin m where
+class (HasIsSuperAdmin m) => HasIsGroupAdmin m where
     isGroupAdmin :: UserID -> GroupID -> m Bool
 
 class (Monad m) => HasIsSuperAdmin m where

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -20,6 +20,7 @@ import Hasql.Transaction.Sessions
 import Docs.Database
 
 import qualified UserManagement.Sessions as UserSessions
+import qualified UserManagement.Transactions as UserTransactions
 
 import qualified Docs.Hasql.Sessions as Sessions
 import qualified Docs.Hasql.Transactions as Transactions
@@ -104,6 +105,9 @@ instance HasCheckPermission HasqlTransaction where
 
 instance HasIsGroupAdmin HasqlTransaction where
     isGroupAdmin = (HasqlTransaction .) . Transactions.isGroupAdmin
+
+instance HasIsSuperAdmin HasqlTransaction where
+    isSuperAdmin = HasqlTransaction . UserTransactions.checkSuperadmin
 
 -- exists
 

--- a/backend/src/UserManagement/Transactions.hs
+++ b/backend/src/UserManagement/Transactions.hs
@@ -1,0 +1,9 @@
+module UserManagement.Transactions (checkSuperadmin) where
+
+import Hasql.Transaction (Transaction, statement)
+
+import qualified UserManagement.Statements as Statements
+import UserManagement.User (UserID)
+
+checkSuperadmin :: UserID -> Transaction Bool
+checkSuperadmin uid = statement uid Statements.checkSuperadmin


### PR DESCRIPTION
This PR changes the way the `docs?group=<...>` endpoint (function `Docs.getDocuments`) checks for group authentification. Before, only group admins were allowed to access the documents overview, now also superadmins are allowed to do so.

Not sure if this bruteforce change to the docs authentification system is reasonable. Seems a bit misplaced, and is not at all scalable. Perhaps `guardGroupAdmin` should account for superadmins in general; this depends entirely on what the superaminds should actually be allowed to do compared to group admins.

See issue #307 