### PR TITLE
Frontend: Fix HTML Preview Rendering

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -712,7 +712,7 @@ splitview docID = H.mkComponent
     HandleEditor output -> case output of
 
       Editor.ClickedQuery response -> do
-        renderedHtml' <- H.liftAff $ Request.postRenderHtml (joinWith "" response)
+        renderedHtml' <- H.liftAff $ Request.postRenderHtml (joinWith "\n" response)
         case renderedHtml' of
           Left _ -> pure unit -- Handle error
           Right { body } -> do


### PR DESCRIPTION
This PR addresses a bug introduced in #320.

I noticed, that the HTML preview was just the raw editors text inside a `h1` tag. Upon further research, it turned out that this is not a problem with the render HTML endpoint, but with its usage by the frontend. When requesting an HTML render, all editor lines are currently joined on an empty string. Thus, all line breaks get removed.

This PR fixes this by joining on newlines rather than an empty string, thus the content of the request body is now the same is the editors content. With this fix, the HTML preview seems to work *mostly* as intended. Enumerations are still not displayed correctly. However, this seems to be a problem with the rendering endpoint, maybe enumerations aren't implemented yet?

| before | now |
|-|-|
| <img width="833" height="703" alt="grafik" src="https://github.com/user-attachments/assets/c3f11478-523f-4228-a2c8-ecfcc689bf58" />| <img width="833" height="697" alt="grafik" src="https://github.com/user-attachments/assets/2ff5d972-14cb-42b3-b413-e17a81129044" /> |
