### PR TITLE
Refining preview component

### DIFF
--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -22,7 +22,7 @@ data Query a = NoQuery a
 type Slots = (button :: forall query. H.Slot query Button.Output Int)
 
 type State =
-  { renderedHtml :: Maybe (String)
+  { renderedHtml :: Maybe String
   }
 
 type Input = { renderedHtml :: Maybe String }
@@ -58,8 +58,14 @@ preview = H.mkComponent
         Just ref -> do
           case renderedHtml of
             Just htmlContent -> do
-              H.modify_ \st -> st { renderedHtml = Just htmlContent }
-              H.liftEffect $ setInnerHtml ref htmlContent
-              pure unit
+              currentState <- H.get
+              if currentState.renderedHtml /= Just htmlContent then do
+                -- Update the state and set the inner HTML only if it has changed
+                -- otherwise, selecting text would trigger a re-render
+                H.modify_ \st -> st { renderedHtml = Just htmlContent }
+                H.liftEffect $ setInnerHtml ref htmlContent
+                pure unit
+              else
+                pure unit
             Nothing -> pure unit
         Nothing -> pure unit

--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -29,7 +29,7 @@ type Input = { renderedHtml :: Maybe String }
 
 preview :: forall m. MonadAff m => H.Component Query Input Output m
 preview = H.mkComponent
-  { initialState: const initialState
+  { initialState
   , render
   , eval: H.mkEval H.defaultEval
       { handleAction = handleAction
@@ -38,10 +38,9 @@ preview = H.mkComponent
       }
   }
   where
-  initialState :: State
-  initialState =
-    { renderedHtml: Nothing
-    }
+  initialState :: Input -> State
+  initialState { renderedHtml } =
+    { renderedHtml: renderedHtml }
 
   render :: State -> H.ComponentHTML Action Slots m
   render _ =
@@ -50,7 +49,20 @@ preview = H.mkComponent
   handleAction :: MonadAff m => Action -> H.HalogenM State Action Slots Unit m Unit
   handleAction = case _ of
     Initialize -> do
-      pure unit
+      -- On initialization, we check if there is already rendered HTML in the state
+      -- and inject it into the HTML element if it exists.
+      -- This is useful when we open the preview component again after it has been rendered before.
+      state <- H.get
+      let renderedHtml = state.renderedHtml
+      htmlElementRef <- getHTMLElementRef (RefLabel "injectHtml")
+      case htmlElementRef of
+        Just ref -> do
+          case renderedHtml of
+            Just htmlContent -> do
+              H.liftEffect $ setInnerHtml ref htmlContent
+              pure unit
+            Nothing -> pure unit
+        Nothing -> pure unit
 
     Receive { renderedHtml } -> do
       htmlElementRef <- getHTMLElementRef (RefLabel "injectHtml")

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -216,7 +216,7 @@ splitview docID = H.mkComponent
         , HP.classes [ HB.dFlex, HB.overflowHidden ]
         , HP.style
             ( "height: calc(100vh - " <> show (navbarHeight + toolbarHeight) <>
-                "px); max-height: 100%; user-select: none"
+                "px); max-height: 100%;"
             )
         ]
         ( -- TOC Sidebar
@@ -442,7 +442,7 @@ splitview docID = H.mkComponent
               "flex: 1 1 "
                 <> show (state.previewRatio * 100.0)
                 <>
-                  "%; box-sizing: border-box; min-height: 0; overflow: hidden; min-width: 6ch; position: relative;"
+                  "%; box-sizing: border-box; min-height: 0; overflow: auto; min-width: 6ch; position: relative;"
           ]
           [ HH.div
               [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]


### PR DESCRIPTION
This PR addresses some issues regarding the usability of the preview component. 

It wasn't possible to select and highlight some text in the preview component due to a inherited attribute from way above that - in my opinion - was not necessary (`user-select: none`). I fixed that, because it feels weird not to be able to highlight text.

Also when the preview got closed and reopened, the rendered file from before was only visible after you clicked into the preview once. Now it shows up immediately after opening the preview again.