### PR TITLE
Backend Docs: Update Titles on New Tree Revision

### DIFF
--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -76,7 +76,7 @@ class (HasCheckPermission m, HasIsGroupAdmin m, HasIsSuperAdmin m) => HasGetDocu
     getDocumentsBy :: Maybe UserID -> Maybe GroupID -> m (Vector Document)
 
 class (HasCheckPermission m, HasExistsTreeRevision m) => HasGetTreeRevision m where
-    getTreeRevision :: TreeRevisionRef -> m (TreeRevision TextElement)
+    getTreeRevision :: TreeRevisionRef -> m (Maybe (TreeRevision TextElement))
 
 class
     (HasCheckPermission m, HasExistsTextRevision m) =>

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -118,11 +118,14 @@ createTreeRevision authorID docID rootNode =
 
 getTreeRevision
     :: TreeRevisionRef
-    -> Session (TreeRevision TextElement)
+    -> Session (Maybe (TreeRevision TextElement))
 getTreeRevision ref = do
-    (rootHash, treeRevision) <- getRevision
-    root <- getTree rootHash
-    return $ treeRevision root
+    revision <- getRevision
+    case revision of
+        Just (rootHash, treeRevision) -> do
+            root <- getTree rootHash
+            return $ Just $ treeRevision root
+        Nothing -> return Nothing
   where
     getRevision = statement ref Statements.getTreeRevision
 

--- a/backend/src/Docs/Hasql/TreeEdge.hs
+++ b/backend/src/Docs/Hasql/TreeEdge.hs
@@ -30,3 +30,11 @@ data TreeEdge = TreeEdge
     , title :: Text
     , child :: TreeEdgeChildRef
     }
+
+instance Hashable TreeEdge where
+    updateHash = flip updateHash'
+      where
+        updateHash' edge =
+            flip updateHash (position edge)
+                . flip updateHash (title edge)
+                . flip updateHash (child edge)

--- a/backend/src/DocumentManagement/Hash.hs
+++ b/backend/src/DocumentManagement/Hash.hs
@@ -39,7 +39,7 @@ import Web.HttpApiData (FromHttpApiData (..))
 newtype Hash = Hash
     { unHash :: ByteString
     }
-    deriving (Show)
+    deriving (Show, Eq)
 
 instance ToJSON Hash where
     toJSON (Hash bs) = Aeson.String $ TE.decodeUtf8 $ encode bs

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -155,7 +155,7 @@ type GetTreeRevision =
         :> Capture "documentID" DocumentID
         :> "tree"
         :> Capture "treeRevision" TreeRevisionSelector
-        :> Get '[JSON] (TreeRevision TextElement)
+        :> Get '[JSON] (Maybe (TreeRevision TextElement))
 
 type GetTreeRevisionFull =
     Auth AuthMethod Auth.Token
@@ -163,7 +163,7 @@ type GetTreeRevisionFull =
         :> "tree"
         :> Capture "treeRevision" TreeRevisionSelector
         :> "full"
-        :> Get '[JSON] (TreeRevision TextElementRevision)
+        :> Get '[JSON] (Maybe (TreeRevision TextElementRevision))
 
 type GetTextHistory =
     Auth AuthMethod Auth.Token
@@ -302,7 +302,7 @@ getTreeRevisionFullHandler
     :: AuthResult Auth.Token
     -> DocumentID
     -> TreeRevisionSelector
-    -> Handler (TreeRevision TextElementRevision)
+    -> Handler (Maybe (TreeRevision TextElementRevision))
 getTreeRevisionFullHandler auth docID revision = do
     userID <- getUser auth
     withDB $
@@ -314,7 +314,7 @@ getTreeRevisionHandler
     :: AuthResult Auth.Token
     -> DocumentID
     -> TreeRevisionSelector
-    -> Handler (TreeRevision TextElement)
+    -> Handler (Maybe (TreeRevision TextElement))
 getTreeRevisionHandler auth docID revision = do
     userID <- getUser auth
     withDB $ run $ Docs.getTreeRevision userID $ TreeRevisionRef docID revision


### PR DESCRIPTION
This PR fixes the problem mentioned in #326, where updating node titles via the api is not persistant.

Note, this is not an intended feature and will be removed again in the future.
It is only a temporary solution. As soon as auto-generation of titles in the backend is fully implemented, the frontend will not be able to change titles anymore, as these will be generated by the backend, using information only the backend has access to.