### PR TITLE
Stack: Resolver `lts-23.27`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           working-directory: backend
-          stack-build-arguments: --fast --no-test
+          stack-build-arguments: --no-test
           test: false
           upgrade-stack: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           working-directory: backend
-          stack-build-arguments: --no-test --prefetch --force-dirty --reconfigure
+          stack-build-arguments: --no-test --fast
           test: false
           upgrade-stack: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: freckle/stack-action@v5
         with:
           working-directory: backend
-          stack-build-arguments: --no-test
+          stack-build-arguments: --no-test --prefetch --force-dirty --reconfigure
           test: false
           upgrade-stack: false
 

--- a/backend/src/Lib.hs
+++ b/backend/src/Lib.hs
@@ -82,7 +82,7 @@ someFunc :: IO ()
 someFunc = do
     Right connection <- getConnection
     Right _ <- migrate connection
-    -- Datenbank zumüllen :)
+    -- Datenbank zumüllen :))
     document <- testDocuments connection
     print document
     createTestDocument connection

--- a/backend/stack.yaml
+++ b/backend/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2023-01-01.yaml
-resolver: lts-23.26
+resolver: lts-23.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This PR switches to a new stack resolver (`lts-23.27`), as with `lts-23.26` the CI failed to get the dependency `clay` for some reason. 