### PR TITLE
Toolbar overhaul

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -151,88 +151,62 @@ editor docID = connect selectTranslator $ H.mkComponent
       ]
       [ HH.div -- Second toolbar
 
-          [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
-          [ HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title (translate (label :: _ "editor_textBold") state.translator)
-              , HE.onClick \_ -> Bold
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-type-bold" ] ] [] ]
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title (translate (label :: _ "editor_textItalic") state.translator)
-              , HE.onClick \_ -> Italic
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-type-italic" ] ] [] ]
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+          [ HP.classes [ HB.dFlex, HB.justifyContentBetween ] ]
+          [ HH.div
+              [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
+              [ makeEditorToolbarButton
+                  (translate (label :: _ "editor_textBold") state.translator)
+                  Bold
+                  "bi-type-bold"
+              , makeEditorToolbarButton
+                  (translate (label :: _ "editor_textItalic") state.translator)
+                  Italic
+                  "bi-type-italic"
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_textUnderline") state.translator)
-              , HE.onClick \_ -> Underline
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-type-underline" ] ] [] ]
-          , HH.div
-              [ HP.classes [ HB.vr, HB.mx1 ]
-              , HP.style "height: 1.5rem"
-              ]
-              []
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  Underline
+                  "bi-type-underline"
+
+              , buttonDivisor
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_fontSizeUp") state.translator)
-              , HE.onClick \_ -> FontSizeUp
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-plus-square" ] ] [] ]
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  FontSizeUp
+                  "bi-plus-square"
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_fontSizeDown") state.translator)
-              , HE.onClick \_ -> FontSizeDown
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-dash-square" ] ] [] ]
-          , HH.div
-              [ HP.classes [ HB.vr, HB.mx1 ]
-              , HP.style "height: 1.5rem"
-              ]
-              []
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  FontSizeDown
+                  "bi-dash-square"
+
+              , buttonDivisor
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_undo") state.translator)
-              , HE.onClick \_ -> Undo
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-arrow-counterclockwise" ] ]
-                  []
-              ]
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  Undo
+                  "bi-arrow-counterclockwise"
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_redo") state.translator)
-              , HE.onClick \_ -> Redo
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-arrow-clockwise" ] ] [] ]
-          , HH.div
-              [ HP.classes [ HB.vr, HB.mx1 ]
-              , HP.style "height: 1.5rem"
-              ]
-              []
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  Redo
+                  "bi-arrow-clockwise"
+
+              , buttonDivisor
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_comment") state.translator)
-              , HE.onClick \_ -> Comment
-              ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-chat-square-text" ] ]
-                  []
-              ]
-          , HH.button
-              [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
-              , HP.title
+                  Comment
+                  "bi-chat-square-text"
+              , makeEditorToolbarButton
                   (translate (label :: _ "editor_deleteComment") state.translator)
-              , HE.onClick \_ -> DeleteComment
+                  DeleteComment
+                  "bi-chat-square-text-fill"
+
               ]
-              [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-chat-square-text-fill" ] ]
-                  []
+          , HH.div
+              [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
+              [ HH.button
+                  [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
+                  , HP.title
+                      (translate (label :: _ "editor_textBold") state.translator)
+                  , HE.onClick \_ -> Bold
+                  ]
+                  [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-type-bold" ] ] [] ]
               ]
           ]
       , HH.div -- Editor container
@@ -734,3 +708,23 @@ cursorInRange lms cursor =
       else
         cursorInRange ls cursor
     Nothing -> pure Nothing
+
+makeEditorToolbarButton
+  :: forall m. String -> Action -> String -> H.ComponentHTML Action () m
+makeEditorToolbarButton tooltip action biName = HH.button
+  [ HP.classes [ HB.btn, HB.p0, HB.m0 ]
+  , HP.title tooltip
+  , HE.onClick \_ -> action
+  ]
+  [ HH.i
+      [ HP.classes [ HB.bi, H.ClassName biName ]
+      ]
+      []
+  ]
+
+buttonDivisor :: forall m. H.ComponentHTML Action () m
+buttonDivisor = HH.div
+  [ HP.classes [ HB.vr, HB.mx1 ]
+  , HP.style "height: 1.5rem"
+  ]
+  []

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -94,6 +94,7 @@ data Output
   | SavedSection Boolean String TOCEntry
   | SelectedCommentSection Int Int
   | SendingTOC TOCEntry
+  | ShowAllCommentsOutput
 
 data Action
   = Init
@@ -109,6 +110,7 @@ data Action
   | Redo
   | Save
   | RenderHTML
+  | ShowAllComments
   | Receive (Connected FPOTranslator Unit)
 
 -- We use a query to get the content of the editor
@@ -221,6 +223,17 @@ editor docID = connect selectTranslator $ H.mkComponent
                       [ HP.classes [ HB.ms1, HB.bi, H.ClassName "bi-file-richtext" ] ]
                       []
                   ]
+              , HH.button
+                  [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px2, HB.py0, HB.m0 ]
+                  , HP.title "Render HTML" -- TODO editor_render_html einfügen
+                  , HE.onClick \_ -> ShowAllComments
+                  ]
+                  [ HH.small_
+                      [ HH.text "All comments" ]
+                  , HH.i
+                      [ HP.classes [ HB.ms1, HB.bi, H.ClassName "bi-chat-square" ] ]
+                      []
+                  ]
               ]
           ]
       , HH.div -- Editor container
@@ -314,6 +327,9 @@ editor docID = connect selectTranslator $ H.mkComponent
     RenderHTML -> do
       _ <- handleQuery (QueryEditor unit)
       pure unit
+
+    ShowAllComments -> do
+      H.raise ShowAllCommentsOutput
 
     Save -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -108,6 +108,7 @@ data Action
   | Undo
   | Redo
   | Save
+  | RenderHTML
   | Receive (Connected FPOTranslator Unit)
 
 -- We use a query to get the content of the editor
@@ -209,6 +210,17 @@ editor docID = connect selectTranslator $ H.mkComponent
                   "" -- TODO editor_save einfügen
                   Save
                   "bi-floppy"
+              , HH.button
+                  [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px2, HB.py0, HB.m0 ]
+                  , HP.title "Render HTML" -- TODO editor_render_html einfügen
+                  , HE.onClick \_ -> RenderHTML
+                  ]
+                  [ HH.small_
+                      [ HH.text "Render" ]
+                  , HH.i
+                      [ HP.classes [ HB.ms1, HB.bi, H.ClassName "bi-file-richtext" ] ]
+                      []
+                  ]
               ]
           ]
       , HH.div -- Editor container
@@ -298,6 +310,10 @@ editor docID = connect selectTranslator $ H.mkComponent
         H.liftEffect $ do
           Editor.redo ed
           Editor.focus ed
+
+    RenderHTML -> do
+      _ <- handleQuery (QueryEditor unit)
+      pure unit
 
     Save -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -208,32 +208,18 @@ editor docID = connect selectTranslator $ H.mkComponent
               ]
           , HH.div
               [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
-              [ makeEditorToolbarButton
-                  "" -- TODO editor_save einfügen
+              [ makeEditorToolbarButtonWithText
                   Save
                   "bi-floppy"
-              , HH.button
-                  [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px2, HB.py0, HB.m0 ]
-                  , HP.title "Render HTML" -- TODO editor_render_html einfügen
-                  , HE.onClick \_ -> RenderHTML
-                  ]
-                  [ HH.small_
-                      [ HH.text "Render" ]
-                  , HH.i
-                      [ HP.classes [ HB.ms1, HB.bi, H.ClassName "bi-file-richtext" ] ]
-                      []
-                  ]
-              , HH.button
-                  [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px2, HB.py0, HB.m0 ]
-                  , HP.title "Render HTML" -- TODO editor_render_html einfügen
-                  , HE.onClick \_ -> ShowAllComments
-                  ]
-                  [ HH.small_
-                      [ HH.text "All comments" ]
-                  , HH.i
-                      [ HP.classes [ HB.ms1, HB.bi, H.ClassName "bi-chat-square" ] ]
-                      []
-                  ]
+                  (translate (label :: _ "editor_save") state.translator)
+              , makeEditorToolbarButtonWithText
+                  RenderHTML
+                  "bi-file-richtext"
+                  (translate (label :: _ "editor_preview") state.translator)
+              , makeEditorToolbarButtonWithText
+                  ShowAllComments
+                  "bi-chat-square"
+                  (translate (label :: _ "editor_allComments") state.translator)
               ]
           ]
       , HH.div -- Editor container
@@ -757,6 +743,21 @@ makeEditorToolbarButton tooltip action biName = HH.button
   ]
   [ HH.i
       [ HP.classes [ HB.bi, H.ClassName biName ]
+      ]
+      []
+  ]
+
+-- Here, no tooltip is needed as the text is shown in the button
+makeEditorToolbarButtonWithText
+  :: forall m. Action -> String -> String -> H.ComponentHTML Action () m
+makeEditorToolbarButtonWithText action biName smallText = HH.button
+  [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px1, HB.py0, HB.m0 ]
+  , HE.onClick \_ -> action
+  ]
+  [ HH.small_
+      [ HH.text smallText ]
+  , HH.i
+      [ HP.classes [ HB.ms1, HB.bi, H.ClassName biName ]
       ]
       []
   ]

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -79,7 +79,6 @@ data Action
   | HandleEditor Editor.Output
   | HandlePreview Preview.Output
   | HandleTOC TOC.Output
-  | ForceGET
   | GET
   | POST
 
@@ -186,7 +185,6 @@ splitview docID = H.mkComponent
       [ HP.classes [ HB.bgDark, HB.overflowAuto, HB.dFlex, HB.flexRow ] ]
       [ toolbarButton "[=]" ToggleSidebar
       , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
-      , toolbarButton "ForceGETP" ForceGET
       , toolbarButton "GET" GET
       , toolbarButton "POST" POST
       , toolbarButton "All Comments" (ToggleCommentOverview true)
@@ -492,17 +490,6 @@ splitview docID = H.mkComponent
         Left _ -> pure unit -- H.liftEffect $ Console.log $ Request.printError "post" err
         Right _ -> pure unit
     -- H.liftEffect $ Console.log "Successfully posted TOC to server"
-    ForceGET -> do
-      fetchedTree <- H.liftAff
-        $ Request.getFromJSONEndpoint DT.decodeDocument
-        $ "/docs/" <> show docID <> "/tree/latest"
-      let
-        tree = case fetchedTree of
-          Nothing -> Empty
-          Just t -> documentTreeToTOCTree t
-      H.modify_ \st -> do
-        st { tocEntries = tree }
-      H.tell _toc unit (TOC.ReceiveTOCs tree)
 
     GET -> do
       -- TODO: As of now, the editor page and splitview are parametrized by the document ID
@@ -534,7 +521,7 @@ splitview docID = H.mkComponent
       -- Load the initial TOC entries into the editor
       -- TODO: Shoult use Get instead, but I (Eddy) don't understand GET
       -- or rather, we don't use commit anymore in the API
-      handleAction ForceGET
+      handleAction GET
 
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -185,8 +185,6 @@ splitview docID = H.mkComponent
       [ HP.classes [ HB.bgDark, HB.overflowAuto, HB.dFlex, HB.flexRow ] ]
       [ toolbarButton "[=]" ToggleSidebar
       , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
-      , toolbarButton "GET" GET
-      , toolbarButton "POST" POST
       , toolbarButton "All Comments" (ToggleCommentOverview true)
       , toolbarButton "Save" SaveSection
       , toolbarButton "Render HTML" RenderHTML

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -173,23 +173,7 @@ splitview docID = H.mkComponent
   render :: State -> H.ComponentHTML Action Slots m
   render state =
     HH.div_
-      [ renderToolbar, renderSplit state ]
-
-  renderToolbar :: H.ComponentHTML Action Slots m
-  renderToolbar =
-    -- First Toolbar
-    HH.div
-      [ HP.classes [ HB.bgDark, HB.overflowAuto, HB.dFlex, HB.flexRow ] ]
-      [ toolbarButton "[=]" ToggleSidebar
-      , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
-      , toolbarButton "All Comments" (ToggleCommentOverview true)
-      ]
-    where
-    toolbarButton label act = HH.button
-      [ HP.classes [ HB.btn, HB.btnSuccess, HB.btnSm ]
-      , HE.onClick $ const act
-      ]
-      [ HH.text label ]
+      [ renderSplit state ]
 
   renderSplit :: State -> H.ComponentHTML Action Slots m
   renderSplit state =
@@ -739,6 +723,8 @@ splitview docID = H.mkComponent
 
       Editor.SendingTOC tocEntry -> do
         H.tell _commentOverview unit (CommentOverview.ReceiveTOC tocEntry)
+
+      Editor.ShowAllCommentsOutput -> handleAction $ ToggleCommentOverview true
     HandlePreview _ -> pure unit
 
     HandleTOC output -> case output of

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -65,8 +65,6 @@ data Action
   | StartResize DragTarget MouseEvent
   | StopResize MouseEvent
   | HandleMouseMove MouseEvent
-  -- Toolbar buttons
-  | RenderHTML
   -- Toggle buttons
   | ToggleComment
   | ToggleCommentOverview Boolean
@@ -185,7 +183,6 @@ splitview docID = H.mkComponent
       [ toolbarButton "[=]" ToggleSidebar
       , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
       , toolbarButton "All Comments" (ToggleCommentOverview true)
-      , toolbarButton "Render HTML" RenderHTML
       ]
     where
     toolbarButton label act = HH.button
@@ -595,12 +592,6 @@ splitview docID = H.mkComponent
               }
 
         _ -> pure unit
-
-    -- Toolbar button actions
-
-    RenderHTML -> do
-      -- H.tell _editor unit Editor.SaveSection 
-      H.tell _editor unit Editor.QueryEditor
 
     -- Toggle actions
 

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -66,7 +66,6 @@ data Action
   | StopResize MouseEvent
   | HandleMouseMove MouseEvent
   -- Toolbar buttons
-  | SaveSection
   | RenderHTML
   -- Toggle buttons
   | ToggleComment
@@ -186,7 +185,6 @@ splitview docID = H.mkComponent
       [ toolbarButton "[=]" ToggleSidebar
       , HH.span [ HP.classes [ HB.textWhite, HB.px2 ] ] [ HH.text "Toolbar" ]
       , toolbarButton "All Comments" (ToggleCommentOverview true)
-      , toolbarButton "Save" SaveSection
       , toolbarButton "Render HTML" RenderHTML
       ]
     where
@@ -600,10 +598,8 @@ splitview docID = H.mkComponent
 
     -- Toolbar button actions
 
-    SaveSection -> H.tell _editor unit Editor.SaveSection
-
     RenderHTML -> do
-      H.tell _editor unit Editor.SaveSection
+      -- H.tell _editor unit Editor.SaveSection 
       H.tell _editor unit Editor.QueryEditor
 
     -- Toggle actions

--- a/frontend/src/FPO/Translations/Components/Editor.purs
+++ b/frontend/src/FPO/Translations/Components/Editor.purs
@@ -1,14 +1,20 @@
-module FPO.Translations.Components.Editor where
+module FPO.Translations.Components.Editor
+  ( deEditor
+  , enEditor
+  ) where
 
 import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord)
 
 type EditorLabels =
-  ( "editor_comment"
+  ( "editor_allComments"
+      ::: "editor_comment"
       ::: "editor_deleteComment"
       ::: "editor_fontSizeDown"
       ::: "editor_fontSizeUp"
+      ::: "editor_preview"
       ::: "editor_redo"
+      ::: "editor_save"
       ::: "editor_textBold"
       ::: "editor_textItalic"
       ::: "editor_textUnderline"
@@ -18,11 +24,14 @@ type EditorLabels =
 
 enEditor :: Translation EditorLabels
 enEditor = fromRecord
-  { editor_comment: "Comment"
+  { editor_allComments: "All comments"
+  , editor_comment: "Comment"
   , editor_deleteComment: "Delete comment"
   , editor_fontSizeDown: "Font size up"
   , editor_fontSizeUp: "Font size down"
+  , editor_preview: "Preview"
   , editor_redo: "Redo (Ctrl+Shift+Z)"
+  , editor_save: "Save"
   , editor_textBold: "Bold text (Ctrl+B)"
   , editor_textItalic: "Italic text (Ctrl+I)"
   , editor_textUnderline: "Underline text"
@@ -31,11 +40,14 @@ enEditor = fromRecord
 
 deEditor :: Translation EditorLabels
 deEditor = fromRecord
-  { editor_comment: "Kommentar"
+  { editor_allComments: "Alle Kommentare"
+  , editor_comment: "Kommentar"
   , editor_deleteComment: "Kommentar löschen"
   , editor_fontSizeDown: "Schrift vergößern"
   , editor_fontSizeUp: "Schrift verkleinern"
+  , editor_preview: "Vorschau"
   , editor_redo: "Vor (Strg+Umschalt+Z)"
+  , editor_save: "Speichern"
   , editor_textBold: "Text fett (Strg+B)"
   , editor_textItalic: "Text kursiv (Strg+I)"
   , editor_textUnderline: "Text unterstreichen"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -123,11 +123,14 @@ type Labels =
       ::: "common_userName"
 
       -- | Editor Page
+      ::: "editor_allComments"
       ::: "editor_comment"
       ::: "editor_deleteComment"
       ::: "editor_fontSizeDown"
       ::: "editor_fontSizeUp"
+      ::: "editor_preview"
       ::: "editor_redo"
+      ::: "editor_save"
       ::: "editor_textBold"
       ::: "editor_textItalic"
       ::: "editor_textUnderline"


### PR DESCRIPTION
This PR closes https://github.com/fachpruefungsordnung/fachpruefungsordnung/issues/310 and this PR closes https://github.com/fachpruefungsordnung/fachpruefungsordnung/issues/120.

I reworked the toolbar, so that all unnecessary buttons are gone and the others (save, render, comments) went into the editor toolbar. With that the toolbar is completely gone and I think it can stay that way if we dont get too much more buttons for the editor. I also think that the comments button might go into the left splitview in the future (so that you can change between TOC and comments maybe).