### PR TITLE
Improve robustness of editor toolbar

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -48,6 +48,7 @@
             "web-events",
             "web-file",
             "web-html",
+            "web-resize-observer",
             "web-storage",
             "web-uievents"
           ],
@@ -148,6 +149,7 @@
             "web-file",
             "web-html",
             "web-pointerevents",
+            "web-resize-observer",
             "web-storage",
             "web-touchevents",
             "web-uievents",
@@ -2010,6 +2012,23 @@
         "prelude",
         "web-dom",
         "web-uievents"
+      ]
+    },
+    "web-resize-observer": {
+      "type": "registry",
+      "version": "2.1.0",
+      "integrity": "sha256-xKJDpJdKB3L89ooASmQm/eAjzjSuKmkApT/kyJ5MyKw=",
+      "dependencies": [
+        "arrays",
+        "control",
+        "effect",
+        "either",
+        "foldable-traversable",
+        "foreign",
+        "prelude",
+        "record",
+        "transformers",
+        "web-dom"
       ]
     },
     "web-storage": {

--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -25,6 +25,7 @@
             "halogen",
             "halogen-bootstrap5",
             "halogen-store",
+            "halogen-subscriptions",
             "http-methods",
             "integers",
             "lists",

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -44,6 +44,7 @@ package:
     - web-events
     - web-file
     - web-html
+    - web-resize-observer
     - web-storage
     - web-uievents
   test:

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -21,6 +21,7 @@ package:
     - halogen
     - halogen-bootstrap5
     - halogen-store
+    - halogen-subscriptions
     - http-methods
     - integers
     - lists

--- a/frontend/src/FPO/Util.purs
+++ b/frontend/src/FPO/Util.purs
@@ -1,0 +1,9 @@
+module FPO.Util where
+
+import Prelude
+
+import Control.Alternative (guard)
+
+-- | Prepends an element to an array if the condition is true.
+prependIf :: forall a. Boolean -> a -> Array a -> Array a
+prependIf cond x xs = (guard cond $> x) <> xs


### PR DESCRIPTION
This PR improves the dynamic layouting of the editor toolbar;
- The vertical seperators now have the correct length
- if the editor becomes too narrow, the button text is replaced by a button tooltip/title

The reason for this is that currently, if the toolbar is too narrow, the text of the three buttons on the right side would break lines and cause the button to expand vertically, screwing with the toolbar layout. Now, using a resize observer/subscription, we can determine the toolbar width and dynamically show either the button text or button tooltips (text appears when hovering), and the overall layout is much more stable. 

It would have been nice to do this with CSS instead of Halogen, but this kind of reactive behavior doesn't seem to be possible from within a flex environment(?).