### PR TITLE
Backend Users Fix: Allow Current Email of User in Patch Request

### DIFF
--- a/backend/src/Server/Handlers/UserHandlers.hs
+++ b/backend/src/Server/Handlers/UserHandlers.hs
@@ -231,7 +231,9 @@ patchUserHandler (Authenticated Auth.Token {..}) userID (Auth.UserUpdate {..}) =
                 case eUser of
                     Left _ -> throwError errDatabaseAccessFailed
                     Right Nothing -> patchUser conn
-                    Right _ -> throwError errEmailAlreadyUsed
+                    Right (Just user)
+                        | User.userID user == userID -> patchUser conn
+                        | otherwise -> throwError errEmailAlreadyUsed
         else
             throwError errSuperAdminOnly
   where


### PR DESCRIPTION
When a email address is present in the request body of `PATCH /users/{userID}`, the backend checks if that email is already in use. If the specified email is already in use, the request fails. This is expected, however, the request also fails, if the specified email is the current email of the respective user. This is equivalent to not changing the email and should be allowed. With this PR, it is now allowed, to include the users current email in the request body.

Note: It might be sensible to adapt the user management code to the architecture of the new document managements code. If time permits, I might do this.