### PR TITLE
Clean up `getUserGroups` request

### DIFF
--- a/frontend/src/FPO/Dto/GroupDto.purs
+++ b/frontend/src/FPO/Dto/GroupDto.purs
@@ -9,7 +9,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe, isJust)
 import Data.Newtype (class Newtype)
 import Data.Show.Generic (genericShow)
-import FPO.Dto.UserDto (Role, UserID)
+import FPO.Dto.UserDto (UserID)
+import FPO.Dto.UserRoleDto as UR
 
 type GroupID = Int
 
@@ -46,12 +47,6 @@ newtype GroupDto = GroupDto
   , groupName :: String
   }
 
-demoteToGroupOverview :: GroupDto -> GroupOverview
-demoteToGroupOverview (GroupDto g) = GroupOverview
-  { groupOverviewName: g.groupName
-  , groupOverviewID: g.groupID
-  }
-
 getGroupName :: GroupDto -> String
 getGroupName (GroupDto g) = g.groupName
 
@@ -77,13 +72,13 @@ newtype GroupMemberDto = GroupMemberDto
   { userInfoEmail :: String
   , userInfoID :: UserID
   , userInfoName :: String
-  , userInfoRole :: Role
+  , userInfoRole :: UR.Role
   }
 
 getUserInfoName :: GroupMemberDto -> String
 getUserInfoName (GroupMemberDto m) = m.userInfoName
 
-getUserInfoRole :: GroupMemberDto -> Role
+getUserInfoRole :: GroupMemberDto -> UR.Role
 getUserInfoRole (GroupMemberDto m) = m.userInfoRole
 
 getUserInfoID :: GroupMemberDto -> UserID
@@ -95,3 +90,18 @@ derive newtype instance decodeJsonGroupMemberDto :: DecodeJson GroupMemberDto
 derive instance genericGroupMemberDto :: Generic GroupMemberDto _
 instance showGroupMemberDto :: Show GroupMemberDto where
   show = genericShow
+
+class ToGroupOverview a where
+  toGroupOverview :: a -> GroupOverview
+
+instance toGroupOverviewGroupDto :: ToGroupOverview GroupDto where
+  toGroupOverview (GroupDto g) = GroupOverview
+    { groupOverviewName: g.groupName
+    , groupOverviewID: g.groupID
+    }
+
+instance toGroupOverviewGroupOverview :: ToGroupOverview UR.FullUserRoleDto where
+  toGroupOverview r = GroupOverview
+    { groupOverviewName: UR.getGroupName r
+    , groupOverviewID: UR.getGroupID r
+    }

--- a/frontend/src/FPO/Dto/UserRoleDto.purs
+++ b/frontend/src/FPO/Dto/UserRoleDto.purs
@@ -1,0 +1,62 @@
+module FPO.Dto.UserRoleDto where
+
+import Prelude
+
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , JsonDecodeError(..)
+  , decodeJson
+  , encodeJson
+  )
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.Show.Generic (genericShow)
+
+newtype FullUserRoleDto = FullUserRoleDto
+  { groupID :: Int
+  , groupName :: String
+  , role :: Role
+  }
+
+getGroupID :: FullUserRoleDto -> Int
+getGroupID (FullUserRoleDto r) = r.groupID
+
+getUserRole :: FullUserRoleDto -> Role
+getUserRole (FullUserRoleDto r) = r.role
+
+getGroupName :: FullUserRoleDto -> String
+getGroupName (FullUserRoleDto r) = r.groupName
+
+derive instance newtypeFullUserRoleDto :: Newtype FullUserRoleDto _
+derive newtype instance encodeJsonFullUserRoleDto :: EncodeJson FullUserRoleDto
+derive newtype instance decodeJsonFullUserRoleDto :: DecodeJson FullUserRoleDto
+derive instance genericFullUserRoleDto :: Generic FullUserRoleDto _
+instance showFullUserRoleDto :: Show FullUserRoleDto where
+  show = genericShow
+
+data Role = Admin | Member
+
+instance encodeJsonRole :: EncodeJson Role where
+  encodeJson Admin = encodeJson "Admin"
+  encodeJson Member = encodeJson "Member"
+
+instance decodeJsonRole :: DecodeJson Role where
+  decodeJson json = do
+    str <- decodeJson json
+    case str of
+      "Admin" -> Right Admin
+      "Member" -> Right Member
+      _ -> Left $ UnexpectedValue json
+
+stringToRole :: String -> Maybe Role
+stringToRole "Admin" = Just Admin
+stringToRole "Member" = Just Member
+stringToRole _ = Nothing
+
+derive instance eqRole :: Eq Role
+derive instance genericRole :: Generic Role _
+instance showRole :: Show Role where
+  show = genericShow

--- a/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
+++ b/frontend/src/FPO/Page/Admin/Group/AddMembers.purs
@@ -21,8 +21,8 @@ import FPO.Data.Request
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.GroupDto (GroupDto, GroupID, getGroupName, isUserInGroup)
-import FPO.Dto.UserDto (Role(..))
 import FPO.Dto.UserOverviewDto (getID)
+import FPO.Dto.UserRoleDto (Role(..))
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
 import FPO.UI.HTML (addError)

--- a/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
@@ -39,7 +39,8 @@ import FPO.Dto.GroupDto
   , getUserInfoRole
   , lookupUser
   )
-import FPO.Dto.UserDto (Role(..), UserID, isAdminOf, isUserSuperadmin)
+import FPO.Dto.UserDto (UserID, isAdminOf, isUserSuperadmin)
+import FPO.Dto.UserRoleDto (Role(..))
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
 import FPO.UI.HTML (addColumn)


### PR DESCRIPTION
This PR simplifies the `getUserGroups` request, used to list those groups a user is admin of (or all groups if the user is superadmin). Thanks to the changes introduced in issue #307, the request no longer requires multiple server calls to retrieve user group data — a single request is now sufficient.