### PR TITLE
Backend: Improved HTML Preview Styling

### DIFF
--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -110,7 +110,7 @@ instance ToHtmlM (Node Paragraph) where
                     div_ [cssClass_ Class.Paragraph, mId_ mLabel]
                         -- \| If this is the only paragraph inside this section we drop the visible paragraphID
                         <$> let idHtml = if isSingleParagraph readerState then mempty else paragraphIDHtml
-                             in return (div_ <#> Class.ParagraphID $ idHtml) <> div_ <#> Class.ParagraphText
+                             in return (div_ <#> Class.ParagraphID $ idHtml) <> div_ <#> Class.TextContainer
                                     <$> childText
 
 instance
@@ -125,7 +125,7 @@ instance
             case lookup (unLabel label) $ labels globalState of
                 -- \| Label was not found in GlobalState and a red error is emitted
                 Nothing ->
-                    b_ <#> Class.FontRed $
+                    span_ <#> Class.InlineError $
                         toHtml (("Error: Label \"" <> unLabel label <> "\" not found!") :: Text)
                 Just labelHtml -> labelWrapperFunc globalState label labelHtml
         Styled style textTrees -> do
@@ -134,7 +134,7 @@ instance
         Enum enum -> toHtmlM enum
         Footnote _ ->
             returnNow $
-                b_ <#> Class.FontRed $
+                span_ <#> Class.InlineError $
                     toHtml ("Error: FootNotes not supported yet" :: Text)
 
 -- | Increment sentence counter and add Label to GlobalState, if there is one
@@ -176,7 +176,7 @@ instance ToHtmlM (Node EnumItem) where
         enumItemHtml <- toHtmlM textTrees
         -- \| Increment enumItemID for next enumItem
         modify (\s -> s {currentEnumItemID = enumItemID + 1})
-        return $ span_ [cssClass_ Class.EnumItem, mId_ mLabel] <$> enumItemHtml
+        return $ div_ [cssClass_ Class.TextContainer, mId_ mLabel] <$> enumItemHtml
 
 instance (ToHtmlM a) => ToHtmlM [a] where
     toHtmlM [] = returnNow mempty

--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -88,6 +88,8 @@ instance ToHtmlM Heading where
     toHtmlM (Heading format textTree) = do
         headingTextHtml <- toHtmlM textTree
         readerState <- ask
+        -- TODO: replace h4 with custom css class. h4 may be styled from other
+        --       stylesheet and influence the document from outside
         return
             ( (h4_ <#> Class.Heading)
                 . headingFormat format (currentSectionIDHtml readerState)

--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -88,10 +88,8 @@ instance ToHtmlM Heading where
     toHtmlM (Heading format textTree) = do
         headingTextHtml <- toHtmlM textTree
         readerState <- ask
-        -- TODO: replace h4 with custom css class. h4 may be styled from other
-        --       stylesheet and influence the document from outside
         return
-            ( (h4_ <#> Class.Heading)
+            ( (div_ <#> Class.Heading)
                 . headingFormat format (currentSectionIDHtml readerState)
                 <$> headingTextHtml
             )

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -30,14 +30,12 @@ data Class
       Paragraph
     | -- | Class for aligning a paragraph id div inside of a paragraph div
       ParagraphID
-    | -- | Class for aligning the text inside a paragraph
-      ParagraphText
-    | -- | Class for aligning and spacing an enum item inside an enumeration
-      EnumItem
+    | -- | Text container which spaces text with elements in it (e.g. enumerations)
+      TextContainer
     | -- | Underlining basic text
       Underlined
-    | -- | Font color red
-      FontRed
+    | -- | Class which inlines a red bold error text
+      InlineError
     | -- | Enum with 1., 2., 3., ...
       EnumNum
     | -- | Enum with a), b), c), ...
@@ -57,7 +55,10 @@ classStyle Document =
         marginRight (em 2)
 classStyle Section =
     toClassSelector Section ? do
-        display block
+        display flex
+        flexDirection column
+        -- \| gap between paragraphs
+        gap (em 1)
         marginTop (em 2)
 classStyle Heading =
     toClassSelector Heading ? do
@@ -67,13 +68,21 @@ classStyle Heading =
 classStyle Paragraph =
     toClassSelector Paragraph ? do
         display flex
-        marginTop (em 1)
-        marginBottom (em 1)
 classStyle ParagraphID = toClassSelector ParagraphID ? Flexbox.flex 0 0 (em 2)
-classStyle ParagraphText = toClassSelector ParagraphText ? textAlign justify
-classStyle EnumItem = mempty
+classStyle TextContainer =
+    toClassSelector TextContainer ? do
+        display flex
+        flexDirection column
+        -- \| gap between text and enumerations
+        gap (em 0.5)
+        textAlign justify
 classStyle Underlined = toClassSelector Underlined ? textDecoration underline
-classStyle FontRed = toClassSelector FontRed ? fontColor red
+classStyle InlineError =
+    toClassSelector InlineError ? do
+        -- \| inlines content in flex environment
+        display displayContents
+        fontColor red
+        fontWeight bold
 classStyle EnumNum =
     enumCounter
         (className EnumNum)
@@ -123,7 +132,12 @@ enumCounter enumClassName counterContent = do
         marginLeft (em 0)
         paddingLeft (em 0)
         marginTop (em 0)
-        marginBottom (em 0.5)
+        marginBottom (em 0)
+        -- \| enums items are also spaced via flex environment
+        display flex
+        flexDirection column
+        -- \| gap between two enum items
+        gap (em 0.5)
 
     -- TODO: fix to much vertical space if a paragraph ends with
     --       an ol (ol and paragraph bottom margins add up)
@@ -137,8 +151,10 @@ enumCounter enumClassName counterContent = do
         counterIncrement "item"
         display grid
         gridTemplateColumns [ch 3, fr 1]
+        -- \| gap between enum item id and enum text
         gap (em 0.5)
-        marginTop (em 0.5)
+        marginTop (em 0)
+        marginBottom (em 0)
 
     ol # byClass enumClassName |> li ? before & do
         counter counterContent

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -51,6 +51,7 @@ classStyle :: Class -> Css
 classStyle Document =
     toClassSelector Document ? do
         fontFamily ["Arial"] [sansSerif]
+        lineHeight (unitless 1.5)
         marginLeft (em 2)
         marginRight (em 2)
 classStyle Section =

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -139,14 +139,6 @@ enumCounter enumClassName counterContent = do
         -- \| gap between two enum items
         gap (em 0.5)
 
-    -- TODO: fix to much vertical space if a paragraph ends with
-    --       an ol (ol and paragraph bottom margins add up)
-
-    -- This could fix it but if raw text follows the ol it does not work,
-    -- unless the text is wrapped in a span
-    -- toClassSelector ParagraphText |> ol # byClass enumClassName ? lastChild & do
-    --     marginBottom (em 0)
-
     ol # byClass enumClassName |> li ? do
         counterIncrement "item"
         display grid

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -52,6 +52,7 @@ classStyle Document =
     toClassSelector Document ? do
         fontFamily ["Arial"] [sansSerif]
         lineHeight (unitless 1.5)
+        marginTop (em 2)
         marginLeft (em 2)
         marginRight (em 2)
 classStyle Section =
@@ -60,11 +61,11 @@ classStyle Section =
         flexDirection column
         -- \| gap between paragraphs
         gap (em 1)
-        marginTop (em 2)
 classStyle Heading =
     toClassSelector Heading ? do
         textAlign center
         fontWeight bold
+        marginTop (em 0)
         marginBottom (em 0)
 classStyle Paragraph =
     toClassSelector Paragraph ? do

--- a/backend/src/Language/Ltml/HTML/CSS/CustomClay.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/CustomClay.hs
@@ -9,6 +9,7 @@ module Language.Ltml.HTML.CSS.CustomClay
     , counterReset
     , counterIncrement
     , alignRight
+    , displayContents
     , gap
     ) where
 
@@ -45,6 +46,9 @@ instance Semigroup Counter where
 
 alignRight :: TextAlign
 alignRight = other "right"
+
+displayContents :: Display
+displayContents = other "contents"
 
 -------------------------------------------------------------------------------
 

--- a/backend/src/Language/Ltml/HTML/Pipeline.hs
+++ b/backend/src/Language/Ltml/HTML/Pipeline.hs
@@ -8,6 +8,7 @@ import Data.Text (Text)
 import Language.Lsd.Example.Fpo (sectionT)
 import Language.Ltml.HTML (aToHtml)
 import Language.Ltml.HTML.CSS (mainStylesheet)
+import qualified Language.Ltml.HTML.CSS.Classes as Class
 import Language.Ltml.HTML.CSS.Util
 import Language.Ltml.Parser.Section (sectionP)
 import Lucid
@@ -17,12 +18,19 @@ import Text.Megaparsec (runParser)
 htmlPipeline :: Text -> ByteString
 htmlPipeline input =
     case runParser (sectionP sectionT empty) "" input of
-        Left _ -> renderBS errorHtml
+        Left err -> renderBS $ errorHtml (show err)
         Right nodeSection ->
             let body = aToHtml nodeSection
              in renderBS $ addInlineCssHeader mainStylesheet body
 
-errorHtml :: Html ()
-errorHtml = doctypehtml_ $ do
+-------------------------------------------------------------------------------
+
+-- | Takes error message and generates error html
+errorHtml :: String -> Html ()
+errorHtml err = doctypehtml_ $ do
+    -- head_ $
+    --     style_ (toStrict $ render (Class.classStyle Class.Document))
     body_ $ do
-        h3_ "Parsing failed!"
+        div_ <#> Class.Document $ do
+            h3_ "Parsing failed!"
+            p_ $ toHtml err

--- a/backend/src/Language/Ltml/HTML/References.hs
+++ b/backend/src/Language/Ltml/HTML/References.hs
@@ -38,7 +38,7 @@ genReference ref = do
              in case mParagraphIDText of
                     Nothing ->
                         return $
-                            b_ <#> Class.FontRed $
+                            span_ <#> Class.InlineError $
                                 "Error: Labeled paragraph does not have any identifier!"
                     Just paragraphIDHtml -> do
                         return paragraphIDHtml
@@ -54,7 +54,7 @@ genReference ref = do
                         (Class.enumLevel (enumNestingLvl - 1))
                         (currentEnumItemID globalState)
 
--- TODO: define Trie Map in GlobalState to track label references
+-- TODO: Maybe? define Trie Map in GlobalState to track label references
 
 -- | If (Just label): generates reference String as Html and adds (Label, Html) pair to GlobalState;
 --   else: does nothing;


### PR DESCRIPTION
This PR improves the overall styling of the document:
- line height set to 1.5
- parsing errors are shown in error HTML
- replaced `<h4>` by `<div>` to prevent inheriting styling from parent site

It also fixes a bug regarding the spacing of paragraphs. Previously, the gap between two paragraphs could become too large if the first paragraph ended with an enumeration, because the bottom margins of the enumeration and the paragraph would add up. This no longer occurs, as all vertical stacking is now managed via `flex` layouts using the `gap` property.