### PR TITLE
Add TOC management functionality

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="static/highlighting.css">
     <link rel="stylesheet" href="static/tooltip.css">
     <link rel="stylesheet" href="static/responsive.css">
+    <link rel="stylesheet" href="static/toc.css">
   </head>
   <body>
     <script

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -241,25 +241,7 @@ splitview = H.mkComponent
                 else
                   "display: none;"
         ]
-        [ HH.button
-            [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
-            , HP.style
-                "position: absolute; \
-                \top: 0.5rem; \
-                \right: 0.5rem; \
-                \background-color: #fdecea; \
-                \color: #b71c1c; \
-                \padding: 0.2rem 0.4rem; \
-                \font-size: 0.75rem; \
-                \line-height: 1; \
-                \border: 1px solid #f5c6cb; \
-                \border-radius: 0.2rem; \
-                \z-index: 10;"
-            , HE.onClick \_ -> ToggleSidebar
-            ]
-            [ HH.text "×" ]
-        , HH.slot _toc unit TOC.tocview state.docID HandleTOC
-        ]
+        [ HH.slot _toc unit TOC.tocview state.docID HandleTOC ]
     -- Comment
     , HH.div
         [ HP.classes [ HB.overflowAuto, HB.p1 ]

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -38,3 +38,53 @@
   background-color: var(--bs-gray-100) !important;
   color: var(--bs-body-color) !important;
 }
+
+/* ********** Small TOC buttons ********** */
+
+.toc-button {
+  padding: 0.125rem 0.375rem;
+  font-size: 0.7rem;
+  border-radius: 3px;
+  border: none;
+  background: transparent;
+  color: #6c757d;
+  transition: all 0.15s ease;
+}
+
+.toc-button:hover {
+  background: #e9ecef;
+  color: #495057;
+}
+
+.toc-button.btn-success:hover {
+  background: #d4edda;
+  color: #155724;
+}
+
+.toc-button.btn-danger:hover {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+/* ********** Drag and drop ********** */
+
+.toc-item.dragging {
+  opacity: 0.6;
+  transform: scale(0.98);
+  z-index: 1000;
+  background: #f8f9fa;
+}
+
+.drop-zone {
+  height: 2px;
+  margin: 0 0.75rem;
+  background: transparent;
+  border-radius: 1px;
+  transition: all 0.15s ease;
+}
+
+.drop-zone.active {
+  background: #0d6efd;
+  height: 2px;
+  margin: 0.25rem 0.75rem;
+}

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -1,0 +1,40 @@
+/* Hide drag handles and add buttons by default, show on hover */
+.toc-drag-handle,
+.toc-add-wrapper {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+/* Show drag handles and add buttons on hover */
+.toc-item:hover .toc-drag-handle,
+.toc-item:hover .toc-add-wrapper {
+  opacity: 1;
+}
+
+/* Always show add button in header */
+.border-bottom .toc-add-wrapper {
+  opacity: 1;
+}
+
+/* Hover effects for toc items */
+.toc-item:hover {
+  background-color: var(--bs-gray-100) !important;
+}
+
+/* Drag handle cursor */
+.toc-drag-handle {
+  cursor: grab;
+  user-select: none;
+  font-size: 0.8rem;
+  width: 16px;
+}
+
+.toc-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* Dropdown hover effects */
+.btn-link:hover {
+  background-color: var(--bs-gray-100) !important;
+  color: var(--bs-body-color) !important;
+}


### PR DESCRIPTION
This PR adds the following things to the TOC overview:
- improved styling using CSS
- (sub)section dragging and rearranging
- (sub)section deletion

The following features are still missing:
- dragging (sub)sections into _empty_ sections
- dragging (sub)sections to the very end of sections
- pretty modal text for section deletion

See #256.

It would perhaps be nice for the user to be able to add nodes at any position, not only at the end of a section. Though, the user can always add a node to the section, then rearrange as he pleases.