### PR TITLE
Backend Docs Fix: Return Each Doc Only Once (by Group Query)

### DIFF
--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -276,7 +276,7 @@ getDocuments =
     rmap
         (uncurryDocument <$>)
         [vectorStatement|
-            SELECT
+            SELECT DISTINCT
                 d.id :: int4,
                 d.name :: text,
                 d."group" :: int4,
@@ -317,7 +317,7 @@ getDocumentsBy =
     rmap
         (uncurryDocument <$>)
         [vectorStatement|
-            SELECT
+            SELECT DISTINCT
                 d.id :: int4,
                 d.name :: text,
                 d."group" :: int4,


### PR DESCRIPTION
Fixes #342

Currently, querying documents by group returns each document as many times as the documents group has users. This PR fixes that.