### PR TITLE
Improve toc UI

### DIFF
--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -297,7 +297,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
     Node { title, children } ->
       let
         innerDivClasses =
-          [ HB.dFlex, HB.alignItemsCenter, HB.py2, HB.positionRelative ]
+          [ HB.dFlex, HB.alignItemsCenter, HB.py1, HB.positionRelative ]
         titleClasses =
           [ HB.textTruncate, HB.flexGrow1, HB.fwBold, HB.fs5 ]
       in
@@ -337,7 +337,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
             ] <> dragProps
           )
         innerDivBaseClasses =
-          [ HB.dFlex, HB.alignItemsCenter, HB.py2, HB.positionRelative ]
+          [ HB.dFlex, HB.alignItemsCenter, HB.py1, HB.positionRelative ]
         innerDivProps =
           [ HP.classes innerDivBaseClasses
           , HP.style "cursor: pointer;"

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -1,10 +1,11 @@
 module FPO.Dto.DocumentDto.TreeDto
-  ( Tree(..)
-  , Edge(..)
+  ( Edge(..)
   , RootTree(..)
+  , Tree(..)
   , TreeHeader(..)
   , findRootTree
   , findTitleRootTree
+  , getEdgeTree
   , replaceNodeRootTree
   ) where
 
@@ -36,6 +37,9 @@ data Tree a
   | Leaf { title :: String, node :: a }
 
 data Edge a = Edge (Tree a)
+
+getEdgeTree :: forall a. Edge a -> Tree a
+getEdgeTree (Edge tree) = tree
 
 -- automatically derive instances for Functor
 

--- a/frontend/src/FPO/Translations/Components/TOC.purs
+++ b/frontend/src/FPO/Translations/Components/TOC.purs
@@ -1,0 +1,19 @@
+module FPO.Translations.Components.TOC where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type TocLabels =
+  ( "toc_end_dropzone"
+      ::: SNil
+  )
+
+enTOC :: Translation TocLabels
+enTOC = fromRecord
+  { toc_end_dropzone: "Drop here to add to end of section"
+  }
+
+deTOC :: Translation TocLabels
+deTOC = fromRecord
+  { toc_end_dropzone: "Am Ende einfügen"
+  }

--- a/frontend/src/FPO/Translations/Components/TOC.purs
+++ b/frontend/src/FPO/Translations/Components/TOC.purs
@@ -5,15 +5,21 @@ import Simple.I18n.Translation (Translation, fromRecord)
 
 type TocLabels =
   ( "toc_end_dropzone"
+      ::: "toc_paragraph"
+      ::: "toc_section"
       ::: SNil
   )
 
 enTOC :: Translation TocLabels
 enTOC = fromRecord
   { toc_end_dropzone: "Drop here to add to end of section"
+  , toc_paragraph: "Paragraph"
+  , toc_section: "Section"
   }
 
 deTOC :: Translation TocLabels
 deTOC = fromRecord
   { toc_end_dropzone: "Am Ende einfügen"
+  , toc_paragraph: "den Paragraphen"
+  , toc_section: "den Abschnitt"
   }

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -4,6 +4,7 @@ import Data.Function (($))
 import FPO.Translations.Common (deCommon, enCommon)
 import FPO.Translations.Components.Editor (deEditor, enEditor)
 import FPO.Translations.Components.Navbar (deNavbar, enNavbar)
+import FPO.Translations.Components.TOC (deTOC, enTOC)
 import FPO.Translations.Page.Admin.AddMembers (deAddMembersPage, enAddMembersPage)
 import FPO.Translations.Page.Admin.GroupMembers (deGroupMemberPage, enGroupMemberPage)
 import FPO.Translations.Page.Admin.GroupProjects
@@ -24,6 +25,7 @@ import Simple.I18n.Translation (Translation, fromRecord, toRecord)
 
 en :: Translation Labels
 en = fromRecord
+  $ merge (toRecord enTOC)
   $ merge (toRecord enAdminPanel)
   $ merge (toRecord enAdminGroupPage)
   $ merge (toRecord enAdminUserPage)
@@ -42,6 +44,7 @@ en = fromRecord
 
 de :: Translation Labels
 de = fromRecord
+  $ merge (toRecord deTOC)
   $ merge (toRecord deAdminPanel)
   $ merge (toRecord deAdminGroupPage)
   $ merge (toRecord deAdminUserPage)
@@ -194,6 +197,8 @@ type Labels =
       ::: "rp_PasswordConfirm"
       ::: "rp_PasswordNew"
       ::: "rp_RequestCode"
+
+      ::: "toc_end_dropzone"
 
       ::: SNil
   )

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -198,7 +198,10 @@ type Labels =
       ::: "rp_PasswordNew"
       ::: "rp_RequestCode"
 
+      -- | Table of Contents (TOC)
       ::: "toc_end_dropzone"
+      ::: "toc_paragraph"
+      ::: "toc_section"
 
       ::: SNil
   )

--- a/frontend/src/FPO/Util.purs
+++ b/frontend/src/FPO/Util.purs
@@ -3,7 +3,19 @@ module FPO.Util where
 import Prelude
 
 import Control.Alternative (guard)
+import Data.Array (length, take)
 
 -- | Prepends an element to an array if the condition is true.
 prependIf :: forall a. Boolean -> a -> Array a -> Array a
 prependIf cond x xs = (guard cond $> x) <> xs
+
+isPrefixOf :: forall a. Eq a => Array a -> Array a -> Boolean
+isPrefixOf prefix arr =
+  take (length prefix) arr == prefix
+
+isRealPrefixOf :: forall a. Eq a => Array a -> Array a -> Boolean
+isRealPrefixOf prefix arr =
+  let
+    len = length prefix
+  in
+    len > 0 && isPrefixOf prefix arr && length arr > len

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -5,6 +5,11 @@
   transition: opacity 0.15s ease;
 }
 
+.toc-item {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
 /* Show drag handles and add buttons on hover */
 .toc-item:hover .toc-drag-handle,
 .toc-item:hover .toc-add-wrapper {
@@ -43,12 +48,17 @@
 
 .toc-button {
   padding: 0.125rem 0.375rem;
-  font-size: 0.7rem;
+  font-size: 1.1rem;
   border-radius: 3px;
   border: none;
   background: transparent;
-  color: #6c757d;
+  color: #8995a1;
   transition: all 0.15s ease;
+  aspect-ratio: 1 / 1;
+  height: 1.3em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .toc-button:hover {

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -98,3 +98,9 @@
   height: 2px;
   margin: 0.25rem 0.75rem;
 }
+
+.drop-zone.blocked {
+  background: #aaaaaa;
+  height: 2px;
+  margin: 0.25rem 0.75rem;
+}

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -104,3 +104,54 @@
   height: 2px;
   margin: 0.25rem 0.75rem;
 }
+
+/* Drop zone at the end of sections */
+
+.drop-zone-end {
+  transition: height 0.2s ease, margin 0.2s ease;
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  margin: 0 0.75rem;
+  border: none;
+}
+
+.drop-zone-end.preview {
+  height: 18px;
+  background-color: rgba(168, 214, 255, 0.1);
+  margin: 1px 0.75rem;
+  border: 1px dashed #c6e4ff;
+  border-radius: 3px;
+}
+
+.drop-zone-end.active {
+  height: 32px;
+  background-color: rgba(0, 123, 255, 0.1);
+  margin: 2px 0.75rem;
+  border: 1px dashed #007bff;
+  border-radius: 3px;
+}
+
+.drop-zone-end::after {
+  content: attr(data-drop-text);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 10px;
+  color: #6c757d;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.drop-zone-end.preview::after {
+  opacity: 1;
+  color: #4c94e0;
+}
+
+.drop-zone-end.active::after {
+  opacity: 1;
+  color: #007bff;
+}


### PR DESCRIPTION
Things to be done/fixed:

- [x] Bug: A section can currently be dragged into itself, which of course shouldn't be possible. One way to fix this is to simply disable all _drop zones_ whose associated paths have the selected entity's path as a prefix.
- [x] Dragging (sub)sections into empty sections is not possible. 
- [x] Dragging (sub)sections to the very end of sections is not possible.
- [x] Prettify the modal text for section deletion. Right now, some translations are missing and instead of the section's name, the section's path is printed. Helpful for debugging, but not convenient for users.
- [x] Allow renaming of sections.
- [x] Tweak "+" and "-" button sizes.
- [x] remove the label in paragraph names of shape `§{<label>:} title`

Closes #256.