### PR TITLE
Docker Backend: Add `texlive`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,6 +62,10 @@ FROM base AS final
 
 WORKDIR /home
 
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends texlive
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /build/bin/backend-exe /home/bin/backend-exe
 COPY migrations/ migrations/
 COPY static/ static/


### PR DESCRIPTION
This PR installs `texlive` in the backend runtime image. 