### PR TITLE
Backend Docs: Squash Subsequent Text Revisions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,9 +149,14 @@ jobs:
         uses: sbdchd/squawk-action@v2
         with:
           fail-on-violations: true
+          # -> require-concurrent-index-creation <-
           # We perform migrations within a transaction. Postgres does not allow
           # concurrent index creation during transactions.
-          exclude: "require-concurrent-index-creation"
+          # -> prefer-bigin-over-int <-
+          # Currently, all ID types use int32. In the future, this should be
+          # changed, but it is too much work for now and other thins have
+          # higer prio.
+          exclude: "require-concurrent-index-creation,prefer-bigint-over-int"
           files: ${{ steps.modified-migrations.outputs.FILES }}
           pg-version: "17.0"
           version: "latest"

--- a/backend/migrations/004_docs.up.sql
+++ b/backend/migrations/004_docs.up.sql
@@ -12,8 +12,10 @@ CREATE TABLE IF NOT EXISTS doc_text_elements (
     document INTEGER REFERENCES docs (id)
 );
 
+CREATE SEQUENCE doc_text_revision_seq;
+
 CREATE TABLE IF NOT EXISTS doc_text_revisions (
-    id INTEGER PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    id INTEGER PRIMARY KEY NOT NULL DEFAULT nextval('doc_text_revision_seq'),
     text_element INTEGER NOT NULL REFERENCES doc_text_elements (id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     author UUID NOT NULL REFERENCES users (id),

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -146,6 +146,8 @@ createTextElement userID docID kind = runExceptT $ do
 --   Updates the latest revision instead of creating a new one, if
 --      - the latest revision is created by the same author,
 --      - the latest revision is no older than a set threshold.
+--   In case of an update, the revision id is increased nevertheless to
+--   prevent lost update scenarios.
 createTextRevision
     :: (HasCreateTextRevision m, HasGetTextElementRevision m)
     => UserID

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -22,7 +22,7 @@ import Control.Monad.Trans.Class (lift)
 import Data.Foldable (find)
 import Data.Functor ((<&>))
 import Data.Text (Text)
-import Data.Time (UTCTime)
+import Data.Time (UTCTime, diffUTCTime)
 import Data.Vector (Vector)
 
 import UserManagement.DocumentPermission (Permission (..))
@@ -64,7 +64,6 @@ import Docs.TextRevision
     , TextElementRevision (TextElementRevision)
     , TextRevisionHistory
     , TextRevisionRef (..)
-    , newTextRevision
     )
 import qualified Docs.TextRevision as TextRevision
 import Docs.Tree (Node)
@@ -74,6 +73,7 @@ import Docs.TreeRevision
     , TreeRevisionRef (..)
     )
 import qualified Docs.TreeRevision as TreeRevision
+import qualified Docs.UserRef as UserRef
 import GHC.Int (Int32)
 
 data Error
@@ -91,6 +91,9 @@ type Limit = Int32
 
 defaultHistoryLimit :: Limit
 defaultHistoryLimit = 20
+
+squashRevisionsWithinMinutes :: Float
+squashRevisionsWithinMinutes = 15
 
 createDocument
     :: (HasCreateDocument m)
@@ -138,6 +141,11 @@ createTextElement userID docID kind = runExceptT $ do
     guardExistsDocument docID
     lift $ DB.createTextElement docID kind
 
+-- | Create a new 'TextRevision' in the Database.
+--
+--   Updates the latest revision instead of creating a new one, if
+--      - the latest revision is created by the same author,
+--      - the latest revision is no older than a set threshold.
 createTextRevision
     :: (HasCreateTextRevision m, HasGetTextElementRevision m)
     => UserID
@@ -151,12 +159,52 @@ createTextRevision userID revision = runExceptT $ do
     latestElementRevision <-
         lift $ DB.getTextElementRevision latestRevisionRef
     let latestRevision = latestElementRevision >>= TextRevision.revision
-    let createRevision = DB.createTextRevision userID ref
-    lift $
-        newTextRevision
+    let latestRevisionID =
             latestRevision
-            createRevision
-            revision
+                <&> TextRevision.identifier . TextRevision.header
+    let parentRevisionID = newTextRevisionParent revision
+    let createRevision =
+            DB.createTextRevision
+                userID
+                ref
+                (newTextRevisionContent revision)
+    lift $ do
+        now <- DB.now
+        case latestRevision of
+            -- first revision
+            Nothing -> createRevision <&> TextRevision.NoConflict
+            Just latest
+                -- content has not changed? -> return latest
+                | content latest == newTextRevisionContent revision ->
+                    return $ TextRevision.NoConflict latest
+                -- no conflict, and can update? -> update
+                | latestRevisionID == parentRevisionID && shouldUpdate now latest ->
+                    DB.updateTextRevision
+                        (identifier latest)
+                        (newTextRevisionContent revision)
+                        <&> TextRevision.NoConflict
+                -- no conflict, but can not update? -> create new
+                | latestRevisionID == parentRevisionID ->
+                    createRevision <&> TextRevision.NoConflict
+                -- conflict
+                | otherwise ->
+                    return $
+                        TextRevision.Conflict $
+                            identifier latest
+  where
+    header = TextRevision.header
+    identifier = TextRevision.identifier . header
+    content = TextRevision.content
+    timestamp = TextRevision.timestamp . header
+    author = TextRevision.author . header
+    authorID = UserRef.identifier . author
+    shouldUpdate tz latestRevision =
+        userID == authorID latestRevision && diff < squashRevisionsWithinMinutes
+      where
+        diff =
+            ((/ 60) . realToFrac)
+                . diffUTCTime tz
+                $ timestamp latestRevision
 
 getTextElementRevision
     :: (HasGetTextElementRevision m)

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -1,5 +1,6 @@
 module Docs.Database
-    ( HasCheckPermission (..)
+    ( HasNow (..)
+    , HasCheckPermission (..)
     , HasIsGroupAdmin (..)
     , HasIsSuperAdmin (..)
     , HasExistsDocument (..)
@@ -54,6 +55,9 @@ class (HasIsSuperAdmin m) => HasIsGroupAdmin m where
 class (Monad m) => HasIsSuperAdmin m where
     isSuperAdmin :: UserID -> m Bool
 
+class (Monad m) => HasNow m where
+    now :: m UTCTime
+
 -- exists
 
 class (Monad m) => HasExistsDocument m where
@@ -102,7 +106,11 @@ class (HasIsGroupAdmin m) => HasCreateDocument m where
 class (HasCheckPermission m, HasExistsDocument m) => HasCreateTextElement m where
     createTextElement :: DocumentID -> TextElementKind -> m TextElement
 
-class (HasCheckPermission m, HasExistsTextElement m) => HasCreateTextRevision m where
+class
+    (HasCheckPermission m, HasExistsTextElement m, HasNow m) =>
+    HasCreateTextRevision m
+    where
+    updateTextRevision :: TextRevisionID -> Text -> m TextRevision
     createTextRevision :: UserID -> TextElementRef -> Text -> m TextRevision
     getLatestTextRevisionID :: TextElementRef -> m (Maybe TextRevisionID)
 

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -109,6 +109,9 @@ instance HasIsGroupAdmin HasqlTransaction where
 instance HasIsSuperAdmin HasqlTransaction where
     isSuperAdmin = HasqlTransaction . UserTransactions.checkSuperadmin
 
+instance HasNow HasqlTransaction where
+    now = HasqlTransaction Transactions.now
+
 -- exists
 
 instance HasExistsDocument HasqlTransaction where
@@ -128,6 +131,7 @@ instance HasGetTextElementRevision HasqlTransaction where
 -- create
 
 instance HasCreateTextRevision HasqlTransaction where
+    updateTextRevision = (HasqlTransaction .) . Transactions.updateTextRevision
     createTextRevision = ((HasqlTransaction .) .) . Transactions.createTextRevision
     getLatestTextRevisionID = HasqlTransaction . Transactions.getLatestTextRevisionID
 

--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE TupleSections #-}
 
 module Docs.Hasql.Transactions
-    ( getTextElementRevision
+    ( now
+    , getTextElementRevision
     , existsTextRevision
+    , updateTextRevision
     , createTextRevision
     , putTree
     , createTreeRevision
@@ -27,6 +29,7 @@ import UserManagement.Group (GroupID)
 import UserManagement.User (UserID)
 
 import Control.Monad (guard)
+import Data.Time (UTCTime)
 import Docs.Document (DocumentID)
 import qualified Docs.Hasql.Statements as Statements
 import Docs.Hasql.TreeEdge (TreeEdge (TreeEdge), TreeEdgeChildRef (..))
@@ -46,6 +49,9 @@ import DocumentManagement.Hash
     , Hashable (..)
     )
 
+now :: Transaction UTCTime
+now = statement () Statements.now
+
 getTextElementRevision
     :: TextRevisionRef
     -> Transaction (Maybe TextElementRevision)
@@ -62,6 +68,9 @@ existsTextElement = flip statement Statements.existsTextElement
 
 getLatestTextRevisionID :: TextElementRef -> Transaction (Maybe TextRevisionID)
 getLatestTextRevisionID = (`statement` Statements.getLatestTextRevisionID)
+
+updateTextRevision :: TextRevisionID -> Text -> Transaction TextRevision
+updateTextRevision = curry (`statement` Statements.updateTextRevision)
 
 createTextRevision
     :: UserID


### PR DESCRIPTION
With this PR, subsequent text revisions by the same author are squashed within a time frame of 15 minutes. This means that instead of creating a new revision, the content and last edited timestamp of the latest revision are update. The `RevisionID` is increased nevertheless in order to prevent lost updates.