### PR TITLE
Fix splitview height offset

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -195,9 +195,8 @@ splitview = H.mkComponent
     let
       navbarHeight :: Int
       navbarHeight = 56 -- px, height of the navbar
-
-      toolbarHeight :: Int
-      toolbarHeight = 31 -- px, height of the toolbar
+    -- toolbarHeight :: Int
+    -- toolbarHeight = 31 -- px, height of the toolbar
     in
       HH.div
         [ HE.onMouseMove HandleMouseMove
@@ -205,7 +204,7 @@ splitview = H.mkComponent
         , HE.onMouseLeave StopResize
         , HP.classes [ HB.dFlex, HB.overflowHidden ]
         , HP.style
-            ( "height: calc(100vh - " <> show (navbarHeight + toolbarHeight) <>
+            ( "height: calc(100vh - " <> show navbarHeight <>
                 "px); max-height: 100%;"
             )
         ]


### PR DESCRIPTION
Since the toolbar has been moved into the editor section of the split view (and no longer spans its full width), the height offset calculation needed to be updated. This adjustment removes the unnecessary white bar below the split view, freeing up wasted space.