### PR TITLE
Backend/html: Fixed spacing issues regarding styled text and enum ids

### DIFF
--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -103,7 +103,8 @@ instance ToHtmlM (Node Paragraph) where
          in do
                 childText <- local (\s -> s {currentParagraphIDHtml = paragraphIDHtml}) $ do
                     addMaybeLabelToState mLabel ParagraphRef
-                    toHtmlM textTrees
+                    -- \| Group raw text (without enums) into <div> for flex layout spacing
+                    renderGroupedTextTree textTrees
                 modify (\s -> s {currentParagraphID = currentParagraphID s + 1})
                 -- \| Reset sentence id for next paragraph
                 modify (\s -> s {currentSentenceID = 0})
@@ -132,7 +133,6 @@ instance
                 Just labelHtml -> labelWrapperFunc globalState label labelHtml
         Styled style textTrees -> do
             textTreeHtml <- toHtmlM textTrees
-            -- TODO: Adds new Html tag which leads to newline in textContainers
             return $ toHtmlStyle style <$> textTreeHtml
         Enum enum -> toHtmlM enum
         Footnote _ ->
@@ -153,8 +153,8 @@ class ToHtmlStyle style where
     toHtmlStyle :: (Monad m) => style -> (HtmlT m a -> HtmlT m a)
 
 instance ToHtmlStyle FontStyle where
-    toHtmlStyle Bold = b_
-    toHtmlStyle Italics = i_
+    toHtmlStyle Bold = span_ <#> Class.Bold
+    toHtmlStyle Italics = span_ <#> Class.Italic
     toHtmlStyle Underlined = span_ <#> Class.Underlined
 
 instance ToHtmlM Enumeration where
@@ -182,7 +182,8 @@ instance ToHtmlM (Node EnumItem) where
         enumItemHtml <- toHtmlM textTrees
         -- \| Increment enumItemID for next enumItem
         modify (\s -> s {currentEnumItemID = enumItemID + 1})
-        return $ div_ [cssClass_ Class.TextContainer, mId_ mLabel] <$> enumItemHtml
+        return $
+            div_ [cssClass_ Class.TextContainer, mId_ mLabel] . div_ <$> enumItemHtml
 
 instance (ToHtmlM a) => ToHtmlM [a] where
     toHtmlM [] = returnNow mempty
@@ -202,3 +203,24 @@ instance ToHtmlM Void where
 --   no values of type Void
 instance ToHtmlStyle Void where
     toHtmlStyle = error "toHtmlStyle for Void was called!"
+
+-------------------------------------------------------------------------------
+
+-- | Extracts enums from list and packs raw text (without enums) into <div>;
+--   E.g. result: <div> raw text </div> <enum></enum> <div> reference </div>
+renderGroupedTextTree
+    :: (ToHtmlStyle style, ToHtmlM enum, ToHtmlM special)
+    => [TextTree style enum special]
+    -> HtmlReaderState
+renderGroupedTextTree [] = return $ Now mempty
+renderGroupedTextTree (enum@(Enum _) : ts) = do
+    enumHtml <- toHtmlM enum
+    followingHtml <- renderGroupedTextTree ts
+    return $ enumHtml <> followingHtml
+renderGroupedTextTree tts =
+    let (rawText, tts') = getNextRawTextTree tts
+     in do
+            rawTextHtml <- toHtmlM rawText
+            followingHtml <- renderGroupedTextTree tts'
+            -- \| Pack raw text without enums into <div>
+            return $ (div_ <$> rawTextHtml) <> followingHtml

--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -179,11 +179,12 @@ instance ToHtmlM (Node EnumItem) where
         addMaybeLabelToState mLabel EnumItemRef
         -- \| Save current enum item id, if nested enumerations follow and reset it
         enumItemID <- gets currentEnumItemID
-        enumItemHtml <- toHtmlM textTrees
+        -- \| Render grouped raw text (without enums) to get correct flex spacing
+        enumItemHtml <- renderGroupedTextTree textTrees
         -- \| Increment enumItemID for next enumItem
         modify (\s -> s {currentEnumItemID = enumItemID + 1})
         return $
-            div_ [cssClass_ Class.TextContainer, mId_ mLabel] . div_ <$> enumItemHtml
+            div_ [cssClass_ Class.TextContainer, mId_ mLabel] <$> enumItemHtml
 
 instance (ToHtmlM a) => ToHtmlM [a] where
     toHtmlM [] = returnNow mempty

--- a/backend/src/Language/Ltml/HTML/CSS.hs
+++ b/backend/src/Language/Ltml/HTML/CSS.hs
@@ -17,4 +17,4 @@ cssClasses = map classStyle [minBound .. maxBound]
 
 -- | Builds CSS Counters and produces final main stylesheet
 mainStylesheet :: EnumStyleMap -> Css
-mainStylesheet enumStyleMap = mconcat (buildCssCounters enumStyleMap : cssClasses)
+mainStylesheet enumStyleMap = mconcat cssClasses <> buildCssCounters enumStyleMap

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -107,11 +107,9 @@ classStyle Enumeration =
             ol # byClass enumClassName |> li ? do
                 counterIncrement "item"
                 display grid
-                gridTemplateColumns [ch 3, fr 1]
-                -- TODO: Gap stays the same for 1. and aaa), instead the
-                --       size of the identifier should not be part of the gap
+                gridTemplateColumns [auto, fr 1]
                 -- \| gap between enum item id and enum text
-                gap (em 0.5)
+                gap (em 0.55)
                 marginTop (em 0)
                 marginBottom (em 0)
 

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -30,12 +30,16 @@ data Class
       ParagraphID
     | -- | Text container which spaces text with elements in it (e.g. enumerations)
       TextContainer
-    | -- | Underlining basic text
-      Underlined
-    | -- | Class which inlines a red bold error text
-      InlineError
     | -- | General class for all enumerations
       Enumeration
+    | -- | Underlined inlined basic text
+      Underlined
+    | -- | Bold inlined basic text
+      Bold
+    | -- | Italic inlined basic text
+      Italic
+    | -- | Class which inlines a red bold error text
+      InlineError
     deriving (Show, Eq, Enum, Bounded)
 
 -- | maps Class to its css style definition
@@ -47,6 +51,8 @@ classStyle Document =
         marginTop (em 2)
         marginLeft (em 2)
         marginRight (em 2)
+        -- \| make Document scrollable past its end
+        paddingBottom (em 10)
 classStyle Section =
     toClassSelector Section ? do
         display flex
@@ -70,11 +76,17 @@ classStyle TextContainer =
         -- \| gap between text and enumerations
         gap (em 0.5)
         textAlign justify
-classStyle Underlined = toClassSelector Underlined ? textDecoration underline
+classStyle Underlined = do
+    toClassSelector Underlined ? do
+        textDecoration underline
+classStyle Bold =
+    toClassSelector Bold ? do
+        fontWeight bold
+classStyle Italic =
+    toClassSelector Italic ? do
+        fontStyle italic
 classStyle InlineError =
     toClassSelector InlineError ? do
-        -- \| inlines content in flex environment
-        display displayContents
         fontColor red
         fontWeight bold
 classStyle Enumeration =
@@ -96,6 +108,8 @@ classStyle Enumeration =
                 counterIncrement "item"
                 display grid
                 gridTemplateColumns [ch 3, fr 1]
+                -- TODO: Gap stays the same for 1. and aaa), instead the
+                --       size of the identifier should not be part of the gap
                 -- \| gap between enum item id and enum text
                 gap (em 0.5)
                 marginTop (em 0)

--- a/backend/src/Language/Ltml/HTML/Common.hs
+++ b/backend/src/Language/Ltml/HTML/Common.hs
@@ -138,6 +138,8 @@ addTocEntry key title mLabel = do
 
 -------------------------------------------------------------------------------
 
+-- | Maps EnumFormat to css class name which implements the counter:
+--   Is used for reusing already existing classes, if the same EnumFormat occurs again
 type EnumStyleMap = [(EnumFormat, Text)]
 
 -------------------------------------------------------------------------------

--- a/backend/src/Language/Ltml/HTML/Test.hs
+++ b/backend/src/Language/Ltml/HTML/Test.hs
@@ -31,7 +31,7 @@ import System.Directory (removeDirectoryRecursive)
 import Text.Megaparsec (runParser)
 import Prelude hiding (Enum, Word, readFile)
 
-testDoc = readFile "src/Language/Ltml/HTML/Test/studienaufbau_master.txt"
+testDoc = readFile "src/Language/Ltml/HTML/Test/test.txt"
 
 parseTest :: IO ()
 parseTest = do

--- a/backend/src/Language/Ltml/HTML/Test.hs
+++ b/backend/src/Language/Ltml/HTML/Test.hs
@@ -31,7 +31,7 @@ import System.Directory (removeDirectoryRecursive)
 import Text.Megaparsec (runParser)
 import Prelude hiding (Enum, Word, readFile)
 
-testDoc = readFile "src/Language/Ltml/HTML/Test/test.txt"
+testDoc = readFile "src/Language/Ltml/HTML/Test/studienaufbau_master.txt"
 
 parseTest :: IO ()
 parseTest = do

--- a/backend/src/Language/Ltml/HTML/Util.hs
+++ b/backend/src/Language/Ltml/HTML/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Ltml.HTML.Util
@@ -9,11 +10,13 @@ module Language.Ltml.HTML.Util
     , convertNewLine
     , mId_
     , anchorLink
+    , getNextRawTextTree
     ) where
 
 import Data.Char (chr)
 import Data.Text (cons)
 import Language.Ltml.AST.Label (Label (..))
+import Language.Ltml.AST.Text (TextTree (..))
 import Lucid
 
 -- | Converts Int to corresponding lowercase letter in the alphabet.
@@ -70,3 +73,16 @@ mId_ (Just label) = id_ $ unLabel label
 -- | Converts Label into <a href = "#<label>"> for jumping to a HTML id
 anchorLink :: Label -> Html () -> Html ()
 anchorLink label = a_ [href_ (cons '#' $ unLabel label)]
+
+-------------------------------------------------------------------------------
+
+-- | Splits list into raw text part until next enumeration (raw is everything except enums)
+getNextRawTextTree
+    :: [TextTree style enum special]
+    -> ([TextTree style enum special], [TextTree style enum special])
+getNextRawTextTree =
+    break
+        ( \case
+            Enum _ -> True
+            _ -> False
+        )


### PR DESCRIPTION
## Styled Text Problems
Previously, styled text (bold, italic and underlined) caused the flex layout to add new rows into the text. 
Also `SentenceStart` labels added additional vertical space inside the flex layout. 

This is now fixed by grouping raw text with styles and labels into `<div>`s.

## Enum Item IDs
Increasingly longer enum item Ids (e.g. `aaa)`) could previously fill the gap between enum item id and enum item text.
Now the gap has a fixed size of `0.55 em` (slight increase from `0.5 em`), regardless of the enum item ids size. 

## Parsing Errors
Parsing errors are now pretty printed and styled with the document class.