### PR TITLE
Backend/html: Improve HTML structure

### DIFF
--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -75,7 +75,7 @@ instance ToHtmlM (Node Section) where
         titleHtml <- toHtmlM title
         let (sectionIDHtml, sectionTocKeyHtml) = sectionFormat sectionFormatS (currentSectionID globalState)
             headingHtml =
-                (div_ <#> Class.Heading) . headingFormat headingFormatS sectionIDHtml
+                (h2_ <#> Class.Heading) . headingFormat headingFormatS sectionIDHtml
                     <$> titleHtml
          in do
                 -- \| Add table of contents entry for section
@@ -94,7 +94,7 @@ instance ToHtmlM (Node Section) where
                 modify (\s -> s {currentParagraphID = 1})
 
                 return $
-                    div_ [cssClass_ Class.Section, id_ htmlId] <$> (headingHtml <> childrenHtml)
+                    section_ [cssClass_ Class.Section, id_ htmlId] <$> (headingHtml <> childrenHtml)
 
 instance ToHtmlM (Node Paragraph) where
     toHtmlM (Node mLabel (Paragraph format textTrees)) = do
@@ -213,7 +213,7 @@ renderGroupedTextTree
     :: (ToHtmlStyle style, ToHtmlM enum, ToHtmlM special)
     => [TextTree style enum special]
     -> HtmlReaderState
-renderGroupedTextTree [] = return $ Now mempty
+renderGroupedTextTree [] = returnNow mempty
 renderGroupedTextTree (enum@(Enum _) : ts) = do
     enumHtml <- toHtmlM enum
     followingHtml <- renderGroupedTextTree ts

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -76,6 +76,9 @@ classStyle ParagraphID =
         --       the larger paragraph will have a bigger indentation than the smaller one
         --       Might be needed to make paragraphs <li> and section <ol> and apply a
         --       custom css counter to each paragraph <li>
+        --       Actually the indentation of paragraphs should be the same across the whole Section
+        --       or Document even. Maybe it would be best to track the largest paragrapg id and then
+        --       scale all paragraphs to fit the largest one (let i = length maxid in flex 0 0 (em i))
         -- \| Gap between paragraph id and text
         paddingRight (em 0.75)
         userSelect none

--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -65,10 +65,20 @@ classStyle Heading =
         fontWeight bold
         marginTop (em 0)
         marginBottom (em 0)
+        fontSize (em 1)
 classStyle Paragraph =
     toClassSelector Paragraph ? do
         display flex
-classStyle ParagraphID = toClassSelector ParagraphID ? Flexbox.flex 0 0 (em 2)
+classStyle ParagraphID =
+    toClassSelector ParagraphID ? do
+        Flexbox.flex 0 0 auto
+        -- TODO: if some paragraph ids are larger than others (e.g. (1) and (42))
+        --       the larger paragraph will have a bigger indentation than the smaller one
+        --       Might be needed to make paragraphs <li> and section <ol> and apply a
+        --       custom css counter to each paragraph <li>
+        -- \| Gap between paragraph id and text
+        paddingRight (em 0.75)
+        userSelect none
 classStyle TextContainer =
     toClassSelector TextContainer ? do
         display flex


### PR DESCRIPTION
## HTML Strcuture
Instead of `<div>` we use `<section>` for sections and `<h2>` for section headings now. 

## CSS
Paragraph Ids now have a fixed gap to the paragraph text of `0.75 em` and are not selectable by the user. 

## Issues
The indentation of paragraphs scales with the size of their id. Which is not intended and will be fixed later. 