### PR TITLE
backend/ltml: Remove Sequence wrapper from LTML

### DIFF
--- a/backend/src/Language/Ltml/Parser/SimpleSection.hs
+++ b/backend/src/Language/Ltml/Parser/SimpleSection.hs
@@ -26,8 +26,8 @@ simpleSectionP (SimpleSectionType kw fmt childrenT) succStartP = do
 simpleSectionSequenceP
     :: Sequence SimpleSectionType
     -> Parser ()
-    -> Parser (Sequence SimpleSection)
-simpleSectionSequenceP (Sequence ts') succStartP = Sequence <$> aux ts'
+    -> Parser [SimpleSection]
+simpleSectionSequenceP (Sequence ts') succStartP = aux ts'
   where
     aux [] = return []
     aux [t] = simpleSectionP t succStartP <:> aux []


### PR DESCRIPTION
It is meant only for LSD; in LTML, basically any list is a sequence.