### PR TITLE
Backend Docs: Comments

### DIFF
--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -1,0 +1,18 @@
+CREATE TYPE commentstatus AS ENUM('open', 'resolved', 'closed');
+
+CREATE TABLE IF NOT EXISTS doc_comments (
+    id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    text_element BIGINT NOT NULL REFERENCES doc_text_elements (id),
+    creation_ts TIMESTAMPTZ NOT NULL DEFAULT now(),
+    status commentstatus NOT NULL DEFAULT 'open',
+    content TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS doc_comment_positions (
+    comment BIGINT NOT NULL REFERENCES doc_comments (id),
+    revision BIGINT NOT NULL REFERENCES doc_text_revisions (id),
+    span_start BIGINT NOT NULL,
+    span_end BIGINT NOT NULL,
+    PRIMARY KEY (comment, revision),
+    CHECK start <= END
+);

--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -1,17 +1,17 @@
 CREATE TABLE IF NOT EXISTS doc_comments (
     id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
     text_element BIGINT NOT NULL REFERENCES doc_text_elements (id),
-    author BIGINT NOT NULL REFERENCES user(id),
+    author UUID NOT NULL REFERENCES users (id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT now(),
     resolved_ts TIMESTAMPTZ DEFAULT NULL,
     content TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS doc_comment_positions (
+CREATE TABLE IF NOT EXISTS doc_comment_anchors (
     comment BIGINT NOT NULL REFERENCES doc_comments (id),
     revision BIGINT NOT NULL REFERENCES doc_text_revisions (id),
     span_start BIGINT NOT NULL,
     span_end BIGINT NOT NULL,
     PRIMARY KEY (comment, revision),
-    CHECK start <= END
+    CHECK (span_start <= span_end)
 );

--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -1,10 +1,9 @@
-CREATE TYPE commentstatus AS ENUM('open', 'resolved', 'closed');
-
 CREATE TABLE IF NOT EXISTS doc_comments (
     id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
     text_element BIGINT NOT NULL REFERENCES doc_text_elements (id),
+    author BIGINT NOT NULL REFERENCES user(id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT now(),
-    status commentstatus NOT NULL DEFAULT 'open',
+    resolved_ts TIMESTAMPTZ DEFAULT NULL,
     content TEXT NOT NULL
 );
 

--- a/backend/src/Docs/Comment.hs
+++ b/backend/src/Docs/Comment.hs
@@ -1,22 +1,79 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Docs.Comment
     ( CommentID (..)
     , Status (..)
     , Comment (..)
-    , AnchoredComment (..)
+    , CommentRef (..)
+    , CommentAnchor (..)
     , Range (start, end)
     , range
+    , prettyPrintCommentRef
     ) where
 
+import Control.Lens ((&))
+import Control.Lens.Operators ((?~))
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
+import Data.OpenApi
+    ( HasExclusiveMinimum (exclusiveMinimum)
+    , HasMinimum (minimum_)
+    , OpenApiType (OpenApiInteger)
+    , ToParamSchema (toParamSchema)
+    , ToSchema (declareNamedSchema)
+    )
+import Data.OpenApi.Lens (HasType (..))
+import Data.Proxy (Proxy (Proxy))
 import Data.Text (Text)
 import Data.Time (UTCTime)
+import Docs.TextElement (TextElementRef, prettyPrintTextElementRef)
 import Docs.UserRef (UserRef)
+import GHC.Generics (Generic)
 import GHC.Int (Int64)
+import Servant (FromHttpApiData (parseUrlPiece))
+
+data CommentRef = CommentRef TextElementRef CommentID
+
+prettyPrintCommentRef :: CommentRef -> String
+prettyPrintCommentRef (CommentRef textElementRef id_) =
+    prettyPrintTextElementRef textElementRef ++ show id_
 
 newtype CommentID = CommentID
     { unCommentID :: Int64
     }
+    deriving (Show)
 
-data Status = Open | Resolved UTCTime
+instance ToJSON CommentID where
+    toJSON = toJSON . unCommentID
+
+instance FromJSON CommentID where
+    parseJSON = fmap CommentID . parseJSON
+
+instance ToSchema CommentID where
+    declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Int64)
+
+instance ToParamSchema CommentID where
+    toParamSchema _ =
+        mempty
+            & type_
+                ?~ OpenApiInteger
+            & minimum_
+                ?~ 0
+            & exclusiveMinimum
+                ?~ False
+
+instance FromHttpApiData CommentID where
+    parseUrlPiece = (CommentID <$>) . parseUrlPiece
+
+data Status
+    = Open
+    | Resolved UTCTime
+    deriving (Generic)
+
+instance ToJSON Status
+
+instance FromJSON Status
+
+instance ToSchema Status
 
 data Comment = Comment
     { identifier :: CommentID
@@ -25,18 +82,39 @@ data Comment = Comment
     , status :: Status
     , content :: Text
     }
+    deriving (Generic)
 
-data AnchoredComment = AnchoredComment
-    { comment :: Comment
-    , location :: Range
+instance ToJSON Comment
+
+instance FromJSON Comment
+
+instance ToSchema Comment
+
+data CommentAnchor = CommentAnchor
+    { comment :: CommentID
+    , anchor :: Range
     }
+    deriving (Generic)
+
+instance ToJSON CommentAnchor
+
+instance FromJSON CommentAnchor
+
+instance ToSchema CommentAnchor
 
 data Range = Range
     { start :: Int64
     , end :: Int64
     }
+    deriving (Generic)
 
-range :: Int64 -> Int64 -> Maybe Range
+instance ToJSON Range
+
+instance FromJSON Range
+
+instance ToSchema Range
+
+range :: Int64 -> Int64 -> Range
 range a b
-    | a <= b = Just $ Range a b
-    | otherwise = Nothing
+    | a <= b = Range a b
+    | otherwise = Range b a

--- a/backend/src/Docs/Comment.hs
+++ b/backend/src/Docs/Comment.hs
@@ -1,0 +1,42 @@
+module Docs.Comment
+    ( CommentID (..)
+    , Status (..)
+    , Comment (..)
+    , AnchoredComment (..)
+    , Range (start, end)
+    , range
+    ) where
+
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Docs.UserRef (UserRef)
+import GHC.Int (Int64)
+
+newtype CommentID = CommentID
+    { unCommentID :: Int64
+    }
+
+data Status = Open | Resolved UTCTime
+
+data Comment = Comment
+    { identifier :: CommentID
+    , author :: UserRef
+    , timestamp :: UTCTime
+    , status :: Status
+    , content :: Text
+    }
+
+data AnchoredComment = AnchoredComment
+    { comment :: Comment
+    , location :: Range
+    }
+
+data Range = Range
+    { start :: Int64
+    , end :: Int64
+    }
+
+range :: Int64 -> Int64 -> Maybe Range
+range a b
+    | a <= b = Just $ Range a b
+    | otherwise = Nothing

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -81,6 +81,9 @@ instance HasGetTreeHistory HasqlSession where
 instance HasGetDocumentHistory HasqlSession where
     getDocumentHistory = ((HasqlSession .) .) . Sessions.getDocumentRevisionHistory
 
+instance HasGetComments HasqlSession where
+    getComments = HasqlSession . Sessions.getComments
+
 -- create
 
 instance HasCreateDocument HasqlSession where
@@ -123,6 +126,9 @@ instance HasExistsTextElement HasqlTransaction where
 instance HasExistsTextRevision HasqlTransaction where
     existsTextRevision = HasqlTransaction . Transactions.existsTextRevision
 
+instance HasExistsComment HasqlTransaction where
+    existsComment = HasqlTransaction . Transactions.existsComment
+
 -- get
 
 instance HasGetTextElementRevision HasqlTransaction where
@@ -131,11 +137,15 @@ instance HasGetTextElementRevision HasqlTransaction where
 -- create
 
 instance HasCreateTextRevision HasqlTransaction where
-    updateTextRevision = (HasqlTransaction .) . Transactions.updateTextRevision
-    createTextRevision = ((HasqlTransaction .) .) . Transactions.createTextRevision
+    updateTextRevision = ((HasqlTransaction .) .) . Transactions.updateTextRevision
+    createTextRevision = (((HasqlTransaction .) .) .) . Transactions.createTextRevision
     getLatestTextRevisionID = HasqlTransaction . Transactions.getLatestTextRevisionID
 
 instance HasCreateTreeRevision HasqlTransaction where
     createTreeRevision = ((HasqlTransaction .) .) . Transactions.createTreeRevision
     existsTextElementInDocument =
         HasqlTransaction . Transactions.isTextElementInDocument
+
+instance HasCreateComment HasqlTransaction where
+    createComment = ((HasqlTransaction .) .) . Transactions.createComment
+    resolveComment = HasqlTransaction . Transactions.resolveComment

--- a/backend/src/Docs/TestDoc.hs
+++ b/backend/src/Docs/TestDoc.hs
@@ -8,6 +8,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (pack)
 import Data.UUID (fromString)
 
+import qualified Data.Vector as Vector
 import Docs
 import qualified Docs.Document as Document
 import Docs.Hasql.Database (run, runTransaction)
@@ -62,7 +63,12 @@ createTestDocument db = do
                 ]
     _ <- withDB $ runTransaction $ createTreeRevision userID docID tree
     let textElementRef = TextElementRef docID . TextElement.identifier
-    let textRevision element = NewTextRevision (textElementRef element)
+    let textRevision element revisionID text =
+            NewTextRevision
+                (textElementRef element)
+                revisionID
+                text
+                Vector.empty
     let machText = (((withDB . runTransaction . createTextRevision userID) .) .) . textRevision
     eins <- machText paragraph1 Nothing "Das hier ist ein Abschnitt."
     let parent = case eins of

--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -50,6 +50,8 @@ import Data.OpenApi
     )
 import Web.HttpApiData (FromHttpApiData (..))
 
+import Data.Vector (Vector)
+import Docs.Comment (CommentAnchor)
 import Docs.Document (DocumentID)
 import Docs.TextElement
     ( TextElement
@@ -181,6 +183,7 @@ data TextRevision
     = TextRevision
     { header :: TextRevisionHeader
     , content :: Text
+    , commentAchors :: Vector CommentAnchor
     }
     deriving (Generic)
 
@@ -240,6 +243,7 @@ data NewTextRevision = NewTextRevision
     { newTextRevisionElement :: TextElementRef
     , newTextRevisionParent :: Maybe TextRevisionID
     , newTextRevisionContent :: Text
+    , newTextRevisionCommentAnchors :: Vector CommentAnchor
     }
 
 -- | A conflict with another text revision.

--- a/backend/src/Server/DTOs/Comments.hs
+++ b/backend/src/Server/DTOs/Comments.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Server.DTOs.Comments (Comments (..)) where
+
+import GHC.Generics (Generic)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+import Data.Vector (Vector)
+import Docs.Comment (Comment)
+
+newtype Comments = Comments
+    { comments :: Vector Comment
+    }
+    deriving (Generic)
+
+instance ToJSON Comments
+
+instance FromJSON Comments
+
+instance ToSchema Comments

--- a/backend/src/Server/DTOs/CreateComment.hs
+++ b/backend/src/Server/DTOs/CreateComment.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Server.DTOs.CreateComment (CreateComment (..)) where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+
+newtype CreateComment = CreateComment
+    { text :: Text
+    }
+    deriving (Generic)
+
+instance ToJSON CreateComment
+
+instance FromJSON CreateComment
+
+instance ToSchema CreateComment

--- a/backend/src/Server/DTOs/CreateTextRevision.hs
+++ b/backend/src/Server/DTOs/CreateTextRevision.hs
@@ -1,24 +1,35 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Server.DTOs.CreateTextRevision (CreateTextRevision (..)) where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (parseJSON), ToJSON, (.!=), (.:), (.:?))
 import Data.OpenApi (ToSchema)
 import Data.Text (Text)
 
 import GHC.Generics (Generic)
 
+import Data.Aeson.Types (withObject)
+import Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import Docs.Comment (CommentAnchor)
 import Docs.TextRevision (TextRevisionID)
 
 data CreateTextRevision
     = CreateTextRevision
     { parent :: Maybe TextRevisionID
     , content :: Text
+    , commentAnchors :: Vector CommentAnchor
     }
     deriving (Generic)
 
 instance ToJSON CreateTextRevision
 
-instance FromJSON CreateTextRevision
+instance FromJSON CreateTextRevision where
+    parseJSON = withObject "CreateTextRevision" $ \o ->
+        CreateTextRevision
+            <$> o .:? "parent"
+            <*> o .: "content"
+            <*> (o .:? "commentAnchors" .!= Vector.empty)
 
 instance ToSchema CreateTextRevision

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -73,6 +73,15 @@ import Docs.TreeRevision
     , prettyPrintTreeRevisionRef
     )
 
+import Docs.Comment
+    ( Comment
+    , CommentID
+    , CommentRef (CommentRef)
+    , prettyPrintCommentRef
+    )
+import Server.DTOs.Comments (Comments (Comments))
+import Server.DTOs.CreateComment (CreateComment)
+import qualified Server.DTOs.CreateComment as CreateComment
 import Server.DTOs.CreateDocument (CreateDocument)
 import qualified Server.DTOs.CreateDocument as CreateDocument
 import Server.DTOs.CreateTextElement (CreateTextElement)
@@ -101,6 +110,9 @@ type DocsAPI =
                 :<|> GetTextHistory
                 :<|> GetTreeHistory
                 :<|> GetDocumentHistory
+                :<|> PostComment
+                :<|> GetComments
+                :<|> ResolveComment
                 :<|> RenderAPI
            )
 
@@ -194,6 +206,35 @@ type GetDocumentHistory =
         :> QueryParam "limit" Docs.Limit
         :> Get '[JSON] DocumentHistory
 
+type PostComment =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "text"
+        :> Capture "textElementID" TextElementID
+        :> "comments"
+        :> ReqBody '[JSON] CreateComment
+        :> Post '[JSON] Comment
+
+type GetComments =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "text"
+        :> Capture "textElementID" TextElementID
+        :> "comments"
+        :> Get '[JSON] Comments
+
+-- | jaja, das ist kein cleanes rest design,
+--   aber das ist mir langsam auch wirklich scheiß egal.
+type ResolveComment =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "text"
+        :> Capture "textElementID" TextElementID
+        :> "comments"
+        :> Capture "commentID" CommentID
+        :> "resolve"
+        :> Post '[JSON] ()
+
 docsServer :: Server DocsAPI
 docsServer =
     {-    -} postDocumentHandler
@@ -208,6 +249,9 @@ docsServer =
         :<|> getTextHistoryHandler
         :<|> getTreeHistoryHandler
         :<|> getDocumentHistoryHandler
+        :<|> postCommentHandler
+        :<|> getCommentsHandler
+        :<|> resolveCommentHandler
         :<|> renderServer
 
 postDocumentHandler
@@ -278,6 +322,7 @@ postTextRevisionHandler auth docID textID revision = do
                     (TextElementRef docID textID)
                     (CreateTextRevision.parent revision)
                     (CreateTextRevision.content revision)
+                    (CreateTextRevision.commentAnchors revision)
 
 getTextElementRevisionHandler
     :: AuthResult Auth.Token
@@ -358,6 +403,48 @@ getDocumentHistoryHandler
 getDocumentHistoryHandler auth docID before limit = do
     userID <- getUser auth
     withDB $ run $ Docs.getDocumentHistory userID docID before limit
+
+postCommentHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> TextElementID
+    -> CreateComment
+    -> Handler Comment
+postCommentHandler auth docID textID comment = do
+    userID <- getUser auth
+    withDB $
+        runTransaction $
+            Docs.createComment
+                userID
+                (TextElementRef docID textID)
+                (CreateComment.text comment)
+
+getCommentsHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> TextElementID
+    -> Handler Comments
+getCommentsHandler auth docID textID = do
+    userID <- getUser auth
+    comments <-
+        withDB $
+            run $
+                Docs.getComments
+                    userID
+                    (TextElementRef docID textID)
+    return $ Comments comments
+
+resolveCommentHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> TextElementID
+    -> CommentID
+    -> Handler ()
+resolveCommentHandler auth docID textID commentID = do
+    userID <- getUser auth
+    withDB $
+        runTransaction $
+            Docs.resolveComment userID (CommentRef (TextElementRef docID textID) commentID)
 
 -- utililty
 
@@ -446,5 +533,13 @@ guardDocsResult (Left err) = throwError $ mapErr err
                 LBS.pack $
                     "TreeRevision "
                         ++ prettyPrintTreeRevisionRef ref
+                        ++ " not found!\n"
+            }
+    mapErr (Docs.CommentNotFound ref) =
+        err400
+            { errBody =
+                LBS.pack $
+                    "Comment "
+                        ++ prettyPrintCommentRef ref
                         ++ " not found!\n"
             }


### PR DESCRIPTION
This PR adds support for comments for text elements and corresponding api endpoints. Namely,
- `GET /docs/{documentID}/text/{textElementID}/comments`: get all comments for a text element,
- `POST /docs/{documentID}/text/{textElementID}/comments`: create a new comment on a text element and
- `POST /docs/{documentID}/text/{textElementID}/comments/{commentID}/resolve`: mark a comment as resolved.

Further, the `TextElementRevision`s are extended by a `commentAnchors` property, which represents a mapping of text position anchors in the revisions text to comments. The `TextElementRevision` schema is part of the *existing* endpoints
- `GET /docs/{documentID}/text/{textElementID}/rev/{revision}` in the response body,
- `GET /docs/{documentID}/text/{textElementID}/rev/` in the response body and
- `POST /docs/{documentID}/text/{textElementID}/rev` in the request and response body.
