### PR TITLE
backend/ltml: Fix mi-forest WS parsing

### DIFF
--- a/backend/src/Language/Ltml/Parser/MiTree.hs
+++ b/backend/src/Language/Ltml/Parser/MiTree.hs
@@ -91,7 +91,10 @@ miForestFrom
 miForestFrom elementPF childP lvl = go False
   where
     go :: Bool -> m [a]
-    go isBracketed = goE
+    go isBracketed = do
+        -- Permit and drop initial whitespace within brackets.
+        when isBracketed $ void $ sp >> optional (nli >> checkIndent lvl)
+        goE
       where
         -- `goX` vs. `goX'`:
         --  - The `goX` parsers must generally be used in-line; that is, not
@@ -103,9 +106,6 @@ miForestFrom elementPF childP lvl = go False
         -- Parse forest, headed by element.
         goE :: m [a]
         goE = do
-            -- Permit and drop initial whitespace within brackets.
-            when isBracketed $ void $ sp >> optional (nli >> checkIndent lvl)
-
             (cfg, e) <- elementPF (go True)
             s0 <- sp
 


### PR DESCRIPTION
This should not change anything, but removes a useless code path.

Previously, we consumed and dropped whitespace at the start of any element that is within brackets, now we only do that for the first element within brackets.

This matches the original intention of that code, but does not actually change anything because the whitespace between two elements is consumed anyways (and before our old code could get a hold of it).