### PR TITLE
backend/lsd: Make LSD AST more verbose

### DIFF
--- a/backend/src/Language/Lsd/AST/Type/AppendixSection.hs
+++ b/backend/src/Language/Lsd/AST/Type/AppendixSection.hs
@@ -14,6 +14,7 @@ import Language.Lsd.AST.Format
     , IdentifierFormat
     , TocKeyFormat
     )
+import Language.Lsd.AST.SimpleRegex (Disjunction, Star)
 import Language.Lsd.AST.Type.Document (DocumentType)
 
 data AppendixSectionFormat
@@ -35,9 +36,9 @@ data AppendixElementFormat
 data AppendixSectionType
     = AppendixSectionType
         AppendixSectionFormat
-        [DocumentType]
+        (Star (Disjunction DocumentType))
 
 data PreAppendixSectionType
     = PreAppendixSectionType
         AppendixSectionFormat
-        [TypeName]
+        (Star (Disjunction TypeName))

--- a/backend/src/Language/Lsd/AST/Type/DocumentContainer.hs
+++ b/backend/src/Language/Lsd/AST/Type/DocumentContainer.hs
@@ -6,6 +6,7 @@ module Language.Lsd.AST.Type.DocumentContainer
 where
 
 import Language.Lsd.AST.Common (TypeName)
+import Language.Lsd.AST.SimpleRegex (Sequence)
 import Language.Lsd.AST.Type.AppendixSection (AppendixSectionType)
 import Language.Lsd.AST.Type.Document (DocumentType)
 
@@ -16,10 +17,10 @@ data DocumentContainerType
     = DocumentContainerType
         DocumentContainerFormat
         DocumentType
-        [AppendixSectionType]
+        (Sequence AppendixSectionType)
 
 data PreDocumentContainerType
     = PreDocumentContainerType
         DocumentContainerFormat
         TypeName
-        [TypeName]
+        (Sequence TypeName)

--- a/backend/src/Language/Lsd/AST/Type/SimpleSection.hs
+++ b/backend/src/Language/Lsd/AST/Type/SimpleSection.hs
@@ -6,6 +6,7 @@ module Language.Lsd.AST.Type.SimpleSection
 where
 
 import Language.Lsd.AST.Common (Keyword, TypeName)
+import Language.Lsd.AST.SimpleRegex (Star)
 import Language.Lsd.AST.Type.SimpleParagraph (SimpleParagraphType)
 
 data SimpleSectionFormat = SimpleSectionFormat
@@ -15,10 +16,10 @@ data SimpleSectionType
     = SimpleSectionType
         Keyword
         SimpleSectionFormat
-        SimpleParagraphType
+        (Star SimpleParagraphType)
 
 data PreSimpleSectionType
     = PreSimpleSectionType
         Keyword
         SimpleSectionFormat
-        TypeName
+        (Star TypeName)

--- a/backend/src/Language/Lsd/AST/Type/Text.hs
+++ b/backend/src/Language/Lsd/AST/Type/Text.hs
@@ -4,10 +4,12 @@ module Language.Lsd.AST.Type.Text
     )
 where
 
+import Language.Lsd.AST.SimpleRegex (Disjunction)
+
 newtype TextType enumT
     = TextType
-        [enumT]
+        (Disjunction enumT)
 
 newtype PreTextType enumT
     = PreTextType
-        [enumT]
+        (Disjunction enumT)

--- a/backend/src/Language/Lsd/Example/Fpo.hs
+++ b/backend/src/Language/Lsd/Example/Fpo.hs
@@ -27,7 +27,7 @@ fpoT =
     DocumentContainerType
         DocumentContainerFormat
         mainDocT
-        [appendixT, attachmentT]
+        (Sequence [appendixT, attachmentT])
 
 appendixT :: AppendixSectionType
 appendixT =
@@ -51,7 +51,7 @@ appendixT =
                 )
             )
         )
-        [] -- TODO
+        (Star $ Disjunction []) -- TODO
 
 attachmentT :: AppendixSectionType
 attachmentT =
@@ -77,7 +77,7 @@ attachmentT =
                 )
             )
         )
-        [] -- TODO
+        (Star $ Disjunction []) -- TODO
 
 mainDocT :: DocumentType
 mainDocT =
@@ -160,10 +160,10 @@ paragraphT =
         richTextT
 
 plainTextT :: TextType Void
-plainTextT = TextType []
+plainTextT = TextType (Disjunction [])
 
 richTextT :: TextType EnumType
-richTextT = TextType [regularEnumT, simpleEnumT]
+richTextT = TextType (Disjunction [regularEnumT, simpleEnumT])
 
 footnoteTextT :: TextType Void
 footnoteTextT = plainTextT
@@ -190,7 +190,7 @@ regularEnumT =
                         ]
                 )
         )
-        (TextType [enumTF 1, simpleEnumT])
+        (TextType (Disjunction [enumTF 1, simpleEnumT]))
   where
     enumTF :: Int -> EnumType
     enumTF depth =
@@ -208,7 +208,7 @@ regularEnumT =
                             ]
                     )
             )
-            (TextType nextEnumTs)
+            (TextType (Disjunction nextEnumTs))
       where
         nextEnumTs =
             if depth < maxRegularEnumDepth
@@ -224,7 +224,7 @@ simpleEnumT =
                 (FormatString [PlaceholderAtom Arabic])
                 (EnumItemKeyFormat $ FormatString [StringAtom "-"])
         )
-        (TextType [])
+        (TextType (Disjunction []))
 
 -- TODO: Unused.
 footnoteT :: FootnoteType

--- a/backend/src/Language/Ltml/Parser/SimpleSection.hs
+++ b/backend/src/Language/Ltml/Parser/SimpleSection.hs
@@ -6,7 +6,7 @@ where
 
 import Control.Applicative.Utils ((<:>))
 import Control.Monad (void)
-import Language.Lsd.AST.SimpleRegex (Sequence (Sequence))
+import Language.Lsd.AST.SimpleRegex (Sequence (Sequence), Star (Star))
 import Language.Lsd.AST.Type.SimpleSection
     ( SimpleSectionType (SimpleSectionType)
     )
@@ -22,7 +22,7 @@ simpleSectionP
     :: SimpleSectionType
     -> Parser ()
     -> FootnoteParser SimpleSection
-simpleSectionP (SimpleSectionType kw fmt childrenT) succStartP = do
+simpleSectionP (SimpleSectionType kw fmt (Star childrenT)) succStartP = do
     wrapParser $ nLexeme1 $ keywordP kw
     SimpleSection fmt
         <$> manyWithFootnotesTillSucc (simpleParagraphP childrenT) succStartP

--- a/backend/src/Language/Ltml/Parser/Text.hs
+++ b/backend/src/Language/Ltml/Parser/Text.hs
@@ -27,6 +27,7 @@ import qualified Data.Text as Text (singleton)
 import Data.Typography (FontStyle (..))
 import Data.Void (Void)
 import Language.Lsd.AST.Common (Keyword)
+import Language.Lsd.AST.SimpleRegex (Disjunction (Disjunction))
 import Language.Lsd.AST.Type.Enum (EnumType (EnumType))
 import Language.Lsd.AST.Type.Text (TextType (TextType))
 import Language.Ltml.AST.Label (Label)
@@ -110,8 +111,8 @@ childPF
      . (ParserWrapper m, EnumP enumType enum, SpecialP m special)
     => TextType enumType
     -> m (TextTree fnref style enum special)
-childPF (TextType enumTypes) =
-    wrapParser (Enum <$> choice (fmap enumP enumTypes))
+childPF (TextType (Disjunction enumTypes)) =
+    wrapParser (Enum <$> choice (map enumP enumTypes))
         <* postEnumP (Proxy :: Proxy special)
 
 -- TODO: Unused.


### PR DESCRIPTION
That is, use Disjunction/Star/Sequence wrappers wherever appropriate.

This is meant to:
* a) improve code readability
* b) (hopefully) ease future communication with the frontend, which is to know whether one, some, many objects are permitted.