### PR TITLE
backend/ltml: Export unused function

### DIFF
--- a/backend/src/Language/Ltml/Parser/Text.hs
+++ b/backend/src/Language/Ltml/Parser/Text.hs
@@ -9,6 +9,7 @@
 module Language.Ltml.Parser.Text
     ( ParagraphParser
     , textForestP
+    , hangingTextP
     , lHangingTextP
     , mlHangingTextP
     )


### PR DESCRIPTION
The hangingTextP function is unused, but kept for future use (by external modules).  The exporting makes the latter clear (and avoids the annoying GHC warning).