### PR TITLE
Toast improvement

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -42,6 +42,7 @@
             "safe-coerce",
             "simple-i18n",
             "strings",
+            "stringutils",
             "transformers",
             "tuples",
             "unsafe-coerce",
@@ -134,6 +135,7 @@
             "simple-i18n",
             "st",
             "strings",
+            "stringutils",
             "tailrec",
             "transformers",
             "tuples",
@@ -1841,6 +1843,19 @@
         "tuples",
         "unfoldable",
         "unsafe-coerce"
+      ]
+    },
+    "stringutils": {
+      "type": "registry",
+      "version": "0.0.12",
+      "integrity": "sha256-t63QWBlp49U0nRqUcFryKflSJsNKGTQAHKjn24/+ooI=",
+      "dependencies": [
+        "arrays",
+        "integers",
+        "maybe",
+        "partial",
+        "prelude",
+        "strings"
       ]
     },
     "tailrec": {

--- a/frontend/src/FPO/Components/AppToasts.purs
+++ b/frontend/src/FPO/Components/AppToasts.purs
@@ -1,4 +1,4 @@
-module FPO.Components.ErrorToasts
+module FPO.Components.AppToasts
   ( Input
   , Output
   , component

--- a/frontend/src/FPO/Data/AppError.purs
+++ b/frontend/src/FPO/Data/AppError.purs
@@ -20,6 +20,9 @@ data AppError
   | AccessDeniedError
   | MethodNotAllowedError String String
 
+type ErrorId = Int
+type AppErrorWithId = { errorId :: ErrorId, error :: AppError }
+
 derive instance Eq AppError
 instance Show AppError where
   show = case _ of

--- a/frontend/src/FPO/Data/AppToast.purs
+++ b/frontend/src/FPO/Data/AppToast.purs
@@ -1,0 +1,30 @@
+module FPO.Data.AppToast where
+
+import Prelude
+
+import FPO.Data.AppError (AppError)
+import Halogen.HTML as HH
+
+type ToastId = Int
+data AppToast
+  = Success String
+  | Error AppError
+  | Warning String
+  | Info String
+
+type AppToastWithId = { id :: ToastId, toast :: AppToast }
+
+derive instance Eq AppToast
+instance Show AppToast where
+  show = case _ of
+    Success msg -> msg
+    Error err -> show err
+    Warning msg -> msg
+    Info msg -> msg
+
+classForToast :: AppToast -> HH.ClassName
+classForToast = case _ of
+  Success _ -> HH.ClassName "fpo-toast-success"
+  Error _ -> HH.ClassName "fpo-toast-error"
+  Warning _ -> HH.ClassName "fpo-toast-warning"
+  Info _ -> HH.ClassName "fpo-toast-info"

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -14,7 +14,7 @@ import Effect.Aff (launchAff_)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class.Console (log)
 import FPO.AppM (runAppM)
-import FPO.Components.ErrorToasts as ErrorToasts
+import FPO.Components.AppToasts as AppToasts
 import FPO.Components.Navbar as Navbar
 import FPO.Data.AppToast (AppToastWithId)
 import FPO.Data.Navigate (class Navigate, navigate)
@@ -148,7 +148,7 @@ component =
         ]
     ]
     [ HH.slot_ _navbar unit Navbar.navbar unit
-    , HH.slot_ _appToasts unit ErrorToasts.component state.errors
+    , HH.slot_ _appToasts unit AppToasts.component state.errors
     , case state.route of
         Nothing -> HH.slot_ _page404 unit Page404.component unit
         Just p -> case p of

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -40,7 +40,7 @@ import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Halogen.Store.Connect (Connected, connect)
-import Halogen.Store.Monad (class MonadStore)
+import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Simple.I18n.Translator (label, translate)
 import Type.Proxy (Proxy(..))
@@ -194,6 +194,10 @@ component =
                 ) <> ": " <> (show err)
             }
         Right _ -> do
+          updateStore $ Store.AddSuccess
+            ( translate (label :: _ "admin_users_successfullyCreatedUser")
+                state.translator
+            )
           H.modify_ _
             { createUserError = Nothing
             , createUserSuccess = Just

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -16,6 +16,7 @@ import Effect.Aff.Class (class MonadAff)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.UI.UserFilter as Filter
 import FPO.Components.UI.UserList as UserList
+import FPO.Data.AppError (AppError(..))
 import FPO.Data.Email as Email
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request (deleteIgnore, getUser, postString)
@@ -74,8 +75,6 @@ data Action
 type State = FPOState
   ( error :: Maybe String
   , createUserDto :: CreateUserDto
-  , createUserError :: Maybe String
-  , createUserSuccess :: Maybe String
   , requestDeleteUser :: Maybe UOD.UserOverviewDto
   -- | The ID of the user that is currently viewing the page.
   , userID :: Maybe UserID
@@ -104,8 +103,6 @@ component =
     { translator: fromFpoTranslator context
     , error: Nothing
     , createUserDto: CreateUserDto.empty
-    , createUserError: Nothing
-    , createUserSuccess: Nothing
     , requestDeleteUser: Nothing
     , userID: Nothing
     }
@@ -187,24 +184,18 @@ component =
       response <- postString "/register" (encodeJson state.createUserDto) -- could be a postIgnore
       case response of
         Left err -> do
-          H.modify_ _
-            { createUserError = Just $
-                ( translate (label :: _ "admin_users_failedToCreateUser")
-                    state.translator
-                ) <> ": " <> (show err)
-            }
+          updateStore $ Store.AddError $ ServerError
+            ( ( translate (label :: _ "admin_users_failedToCreateUser")
+                  state.translator
+              ) <> ": " <> (show err)
+            )
         Right _ -> do
           updateStore $ Store.AddSuccess
             ( translate (label :: _ "admin_users_successfullyCreatedUser")
                 state.translator
             )
           H.modify_ _
-            { createUserError = Nothing
-            , createUserSuccess = Just
-                ( translate (label :: _ "admin_users_successfullyCreatedUser")
-                    state.translator
-                )
-            , createUserDto = CreateUserDto.empty
+            { createUserDto = CreateUserDto.empty
             }
           H.tell _userlist unit UserList.ReloadUsersQ
     HandleUserList (UserList.ButtonPressed userOverviewDto effect) -> do
@@ -295,16 +286,6 @@ component =
                   (const CreateUser)
               ]
           ]
-      , case state.createUserError of
-          Just err -> HH.div
-            [ HP.classes [ HB.alert, HB.alertDanger, HB.textCenter, HB.mt3 ] ]
-            [ HH.text err ]
-          Nothing -> HH.text ""
-      , case state.createUserSuccess of
-          Just err -> HH.div
-            [ HP.classes [ HB.alert, HB.alertSuccess, HB.textCenter, HB.mt3 ] ]
-            [ HH.text err ]
-          Nothing -> HH.text ""
       ]
 
 renderDeleteModal :: forall m. State -> HH.HTML m Action

--- a/frontend/static/toasts.css
+++ b/frontend/static/toasts.css
@@ -1,149 +1,22 @@
-.fpo-toast-container {
-  position: fixed;
-  top: 80px;
-  right: 20px;
-  z-index: 9999;
-  max-width: 400px;
+/* Custom animations for toast progress bar */
+.fpo-progress-animate {
+  width: 100%;
+  animation: shrinkProgress 5s linear forwards;
+  animation-delay: 0.3s;
+}
+
+/* Toast slide-in animation */
+.animate-slide-in {
+  animation: slideInRight 0.3s ease-out;
+}
+
+.toast-container {
   pointer-events: none;
 }
 
-.fpo-toast {
-  background: #f8d7da;
-  border: 1px solid #f5c6cb;
-  border-radius: 6px;
-  color: #721c24;
-  margin-bottom: 10px;
-  padding: 12px 16px 0;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  min-width: 300px;
+.toast {
   pointer-events: auto;
-  opacity: 1;
-  display: block;
-  position: relative;
-  overflow: hidden;
-}
-
-.fpo-toast-error {
-  background: #f8d7da;
-  border-color: #f5c6cb;
-  color: #721c24;
-}
-
-.fpo-toast-content {
-  padding-bottom: 12px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.fpo-toast-message {
-  flex: 1;
-  margin-right: 12px;
-}
-
-.fpo-toast-close {
-  background: none;
-  border: none;
-  color: #721c24;
-  cursor: pointer;
-  font-size: 20px;
-  font-weight: bold;
-  width: 20px;
-  height: 20px;
-}
-
-.fpo-toast-success {
-  background: #d1eddf;
-  border-color: #c3e6cb;
-  color: #155724;
-}
-
-.fpo-toast-success .fpo-toast-close {
-  color: #155724;
-}
-
-.fpo-toast-success .fpo-toast-progress {
-  background: rgba(21, 87, 36, 0.2);
-}
-
-.fpo-toast-success .fpo-toast-progress-bar {
-  background: #155724;
-}
-
-.fpo-toast-warning {
-  background: #fff3cd;
-  border-color: #ffeaa7;
-  color: #856404;
-}
-
-.fpo-toast-warning .fpo-toast-close {
-  color: #856404;
-}
-
-.fpo-toast-warning .fpo-toast-progress {
-  background: rgba(133, 100, 4, 0.2);
-}
-
-.fpo-toast-warning .fpo-toast-progress-bar {
-  background: #856404;
-}
-
-.fpo-toast-info {
-  background: #d1ecf1;
-  border-color: #bee5eb;
-  color: #0c5460;
-}
-
-.fpo-toast-info .fpo-toast-close {
-  color: #0c5460;
-}
-
-.fpo-toast-info .fpo-toast-progress {
-  background: rgba(12, 84, 96, 0.2);
-}
-
-.fpo-toast-info .fpo-toast-progress-bar {
-  background: #0c5460;
-}
-
-.fpo-toast-close:hover {
-  opacity: 0.7;
-}
-
-.fpo-toast-progress {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  /* Remove: background: rgba(114, 28, 36, 0.2); */
-}
-
-.fpo-toast-progress-bar {
-  height: 100%;
-  /* Remove: background: #721c24; */
-  width: 100%;
-  animation: shrinkProgress 5s linear forwards;
-}
-
-/* Add error variant styles */
-.fpo-toast-error .fpo-toast-progress {
-  background: rgba(114, 28, 36, 0.2);
-}
-
-.fpo-toast-error .fpo-toast-progress-bar {
-  background: #721c24;
-}
-
-.animate-slide-in {
-  animation: 
-    slideInRight 0.3s ease-out
-    slideOutRight 0.3s ease-out 5s;
-}
-
-.animate-slide-in .fpo-toast-progress-bar {
-  animation: shrinkProgress 5s linear forwards;
-  animation-delay: 0.3s; /* Start after slide-in completes */
+  min-width: 300px;
 }
 
 @keyframes slideInRight {
@@ -154,15 +27,6 @@
   to {
     transform: translateX(0);
     opacity: 1;
-  }
-}
-
-@keyframes slideOutRight {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
   }
 }
 

--- a/frontend/static/toasts.css
+++ b/frontend/static/toasts.css
@@ -52,6 +52,60 @@
   height: 20px;
 }
 
+.fpo-toast-success {
+  background: #d1eddf;
+  border-color: #c3e6cb;
+  color: #155724;
+}
+
+.fpo-toast-success .fpo-toast-close {
+  color: #155724;
+}
+
+.fpo-toast-success .fpo-toast-progress {
+  background: rgba(21, 87, 36, 0.2);
+}
+
+.fpo-toast-success .fpo-toast-progress-bar {
+  background: #155724;
+}
+
+.fpo-toast-warning {
+  background: #fff3cd;
+  border-color: #ffeaa7;
+  color: #856404;
+}
+
+.fpo-toast-warning .fpo-toast-close {
+  color: #856404;
+}
+
+.fpo-toast-warning .fpo-toast-progress {
+  background: rgba(133, 100, 4, 0.2);
+}
+
+.fpo-toast-warning .fpo-toast-progress-bar {
+  background: #856404;
+}
+
+.fpo-toast-info {
+  background: #d1ecf1;
+  border-color: #bee5eb;
+  color: #0c5460;
+}
+
+.fpo-toast-info .fpo-toast-close {
+  color: #0c5460;
+}
+
+.fpo-toast-info .fpo-toast-progress {
+  background: rgba(12, 84, 96, 0.2);
+}
+
+.fpo-toast-info .fpo-toast-progress-bar {
+  background: #0c5460;
+}
+
 .fpo-toast-close:hover {
   opacity: 0.7;
 }
@@ -62,14 +116,23 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: rgba(114, 28, 36, 0.2);
+  /* Remove: background: rgba(114, 28, 36, 0.2); */
 }
 
 .fpo-toast-progress-bar {
   height: 100%;
-  background: #721c24;
+  /* Remove: background: #721c24; */
   width: 100%;
   animation: shrinkProgress 5s linear forwards;
+}
+
+/* Add error variant styles */
+.fpo-toast-error .fpo-toast-progress {
+  background: rgba(114, 28, 36, 0.2);
+}
+
+.fpo-toast-error .fpo-toast-progress-bar {
+  background: #721c24;
 }
 
 .animate-slide-in {


### PR DESCRIPTION
This pull request refactors the error and notification system in the frontend from a dedicated error toast component to a unified toast system that supports multiple toast types (error, success, warning, info). It introduces a new `AppToast` type and updates the global store, main application component, and usage throughout the codebase to use this new toast system. The changes improve consistency, flexibility, and code maintainability for user notifications.

**Toast System Unification and Store Refactor:**

* Removed the old `ErrorToasts` component and replaced it with a new, unified `AppToasts` component that supports multiple toast types and auto-dismissal. (`frontend/src/FPO/Components/ErrorToasts.purs`, `frontend/src/FPO/Components/AppToasts.purs`) [[1]](diffhunk://#diff-6416b91d9b0a0326a1bb7d4424afd46b871821fc88c99aa4898a33ee0b20c2c6L1-L135) [[2]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cR1-R182)
* Refactored the global store: replaced `errors` and `totalErrors` fields with `toasts` and `totalToasts`, and updated all store actions and reducers to support the new toast types (`AddError`, `AddSuccess`, `AddWarning`, `AddInfo`, `SetToasts`). (`frontend/src/FPO/Data/Store.purs`) [[1]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bL11-R32) [[2]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bL45-R44) [[3]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR63-R82)

**Type and Data Structure Updates:**

* Introduced new types: `AppToast`, `AppToastWithId`, and `ToastId`, and updated the error types to remove `AppErrorWithId` and `ErrorId` in favor of the new toast system. (`frontend/src/FPO/Data/AppToast.purs`, `frontend/src/FPO/Data/AppError.purs`) [[1]](diffhunk://#diff-c62a965f0ee23c776699a2f12e68bca92989cfdd05da45ced33edf04cf010627R1-R30) [[2]](diffhunk://#diff-1ec6931e4fa7e5df5bbab733eeb00a3da6729d14a77b76e71e8405af34689e58R23-R25)

**Main Application Component Migration:**

* Updated the main application component to use the new `AppToasts` system, removing all references to error toasts and adapting slot and state management accordingly. (`frontend/src/FPO/Main.purs`) [[1]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2R11-R22) [[2]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L44-L46) [[3]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L72-L78) [[4]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L93-R91) [[5]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L108-L137) [[6]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L150-R138) [[7]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L181) [[8]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2L233-R221)

**Usage Migration Example:**

* Updated usage in the admin users page to use the new toast actions (`AddError`, `AddSuccess`) for user creation feedback, removing local state for success/error and using the global toast system instead. (`frontend/src/FPO/Page/Admin/Users.purs`) [[1]](diffhunk://#diff-c19fd96f3062f0823db555946c3a0f165987a5c4cb055f2edf4297a347612319R19) [[2]](diffhunk://#diff-c19fd96f3062f0823db555946c3a0f165987a5c4cb055f2edf4297a347612319L43-R44) [[3]](diffhunk://#diff-c19fd96f3062f0823db555946c3a0f165987a5c4cb055f2edf4297a347612319L77-L78) [[4]](diffhunk://#diff-c19fd96f3062f0823db555946c3a0f165987a5c4cb055f2edf4297a347612319L107-L108) [[5]](diffhunk://#diff-c19fd96f3062f0823db555946c3a0f165987a5c4cb055f2edf4297a347612319L190-R198)