### PR TITLE
backend/lsd/fpo: Simplify "Anhang" heading format

### DIFF
--- a/backend/src/Language/Lsd/Example/Fpo.hs
+++ b/backend/src/Language/Lsd/Example/Fpo.hs
@@ -75,8 +75,6 @@ attachmentT =
                     [ StringAtom "Anhang "
                     , PlaceholderAtom IdentifierPlaceholder
                     , StringAtom "\n"
-                    , StringAtom "(nicht Bestandteil der Satzung)"
-                    , StringAtom "\n"
                     , PlaceholderAtom HeadingTextPlaceholder
                     ]
                 )


### PR DESCRIPTION
This removes the fixed text "(nicht Bestandteil der Satzung)".

Background:

* Not all FPOs use this; maybe about half.
* When an FPO uses it, it tends to also be used in the TOC, but we
  currently do not support FormatStrings for the RHS of the TOC.
* When used in a current FPO, it tends to have different typography
  (smaller font size, not bold), and is in a new line.
    * LSD would currently only support the being in a new line.

Sidenotes:

* The formatting of "Anhang" headings is generally inconsistent, as is
  the case for many nodes; e.g., some don't
* The now removed fixed text is actually typically put below the
  heading, not above as it was configured here.  This was likely in
  error.

Given all the above, I believe it is preferable that users who want that
text should just add it to the title---in which case it would be
formatted just like the title, and not put on its own line, but that
seems not much of a downside, at least in comparison to the status quo.