### PR TITLE
Backend Anchor: Row + Col Instead of Offset From Start

### DIFF
--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -10,8 +10,9 @@ CREATE TABLE IF NOT EXISTS doc_comments (
 CREATE TABLE IF NOT EXISTS doc_comment_anchors (
     comment BIGINT NOT NULL REFERENCES doc_comments (id),
     revision BIGINT NOT NULL REFERENCES doc_text_revisions (id),
-    span_start BIGINT NOT NULL,
-    span_end BIGINT NOT NULL,
-    PRIMARY KEY (comment, revision),
-    CHECK (span_start <= span_end)
+    start_col BIGINT NOT NULL,
+    start_row BIGINT NOT NULL,
+    end_col BIGINT NOT NULL,
+    end_row BIGINT NOT NULL,
+    PRIMARY KEY (comment, revision)
 );

--- a/backend/src/Docs/Comment.hs
+++ b/backend/src/Docs/Comment.hs
@@ -7,6 +7,7 @@ module Docs.Comment
     , CommentRef (..)
     , CommentAnchor (..)
     , Range (start, end)
+    , Anchor (Anchor, row, col)
     , range
     , prettyPrintCommentRef
     ) where
@@ -102,9 +103,26 @@ instance FromJSON CommentAnchor
 
 instance ToSchema CommentAnchor
 
+data Anchor = Anchor
+    { col :: Int64
+    , row :: Int64
+    }
+    deriving (Generic, Eq)
+
+instance ToJSON Anchor
+
+instance FromJSON Anchor
+
+instance ToSchema Anchor
+
+instance Ord Anchor where
+    compare a b = case compare (row a) (row b) of
+        EQ -> compare (col a) (col b)
+        ordering -> ordering
+
 data Range = Range
-    { start :: Int64
-    , end :: Int64
+    { start :: Anchor
+    , end :: Anchor
     }
     deriving (Generic)
 
@@ -114,7 +132,7 @@ instance FromJSON Range
 
 instance ToSchema Range
 
-range :: Int64 -> Int64 -> Range
+range :: Anchor -> Anchor -> Range
 range a b
     | a <= b = Range a b
     | otherwise = Range b a

--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -183,7 +183,7 @@ data TextRevision
     = TextRevision
     { header :: TextRevisionHeader
     , content :: Text
-    , commentAchors :: Vector CommentAnchor
+    , commentAnchors :: Vector CommentAnchor
     }
     deriving (Generic)
 


### PR DESCRIPTION
This PR changes the representation of comment anchors to `(row, col)` instead of just a single character offset.
