### PR TITLE
Fix button text cutoff threshold

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -760,7 +760,7 @@ editor = connect selectTranslator $ H.mkComponent
       -- but it works.
 
       lang <- liftEffect $ Store.loadLanguage
-      let cutoff = if lang == Just "de-DE" then 573.0 else 520.0
+      let cutoff = if lang == Just "de-DE" then 690.0 else 592.0
 
       H.modify_ _ { showButtonText = width >= cutoff }
 
@@ -1064,7 +1064,10 @@ cursorInRange lms cursor =
 makeEditorToolbarButton
   :: forall m. Boolean -> String -> Action -> String -> H.ComponentHTML Action () m
 makeEditorToolbarButton enabled tooltip action biName = HH.button
-  [ HP.classes $ [ HB.btn, HB.p0, HB.m0, HB.border0 ]
+  [ HP.classes
+      ( prependIf (not enabled) HB.opacity25
+          [ HB.btn, HB.p0, HB.m0, HB.border0 ]
+      )
   , HP.title tooltip
   , HE.onClick \_ -> action
   , HP.enabled enabled
@@ -1086,7 +1089,10 @@ makeEditorToolbarButtonWithText
   -> H.ComponentHTML Action () m
 makeEditorToolbarButtonWithText enabled asText action biName smallText = HH.button
   ( prependIf (not asText) (HP.title smallText)
-      [ HP.classes [ HB.btn, HB.btnOutlineDark, HB.px1, HB.py0, HB.m0 ]
+      [ HP.classes
+          ( prependIf (not enabled) HB.opacity25
+              [ HB.btn, HB.btnOutlineDark, HB.px1, HB.py0, HB.m0 ]
+          )
       , HP.style "white-space: nowrap;"
       , HE.onClick \_ -> action
       , HP.enabled enabled


### PR DESCRIPTION
This pull request updates the editor button UI logic to improve accessibility and visual feedback for disabled states, and adjusts layout thresholds based on language selection.

**UI improvements for disabled buttons:**

* Both `makeEditorToolbarButton` and `makeEditorToolbarButtonWithText` now add the `HB.opacity25` class when the button is disabled, making disabled buttons appear visually distinct. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1067-R1070) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1089-R1095)

**Layout adjustments:**

* The cutoff width for showing button text in the editor is increased for both German and English to account for the new PDF download button.