### PR TITLE
Backend Docs: Comment Replies

### DIFF
--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -1,9 +1,17 @@
 CREATE TABLE IF NOT EXISTS doc_comments (
     id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
     text_element BIGINT NOT NULL REFERENCES doc_text_elements (id),
+    resolved_ts TIMESTAMPTZ DEFAULT NULL,
     author UUID NOT NULL REFERENCES users (id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT now(),
-    resolved_ts TIMESTAMPTZ DEFAULT NULL,
+    content TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS doc_comment_replies (
+    id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    comment BIGINT NOT NULL REFERENCES doc_comments (id),
+    author UUID NOT NULL REFERENCES users (id),
+    creation_ts TIMESTAMPTZ NOT NULL DEFAULT now(),
     content TEXT NOT NULL
 );
 

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -17,6 +17,7 @@ module Docs
     , createComment
     , getComments
     , resolveComment
+    , createReply
     ) where
 
 import Control.Monad (unless)
@@ -33,7 +34,7 @@ import UserManagement.Group (GroupID)
 import UserManagement.User (UserID)
 
 import Data.Maybe (fromMaybe)
-import Docs.Comment (Comment, CommentRef (CommentRef))
+import Docs.Comment (Comment, CommentRef (CommentRef), Message)
 import qualified Docs.Comment as Comment
 import Docs.Database
     ( HasCheckPermission
@@ -351,6 +352,17 @@ resolveComment userID ref@(CommentRef (TextElementRef docID _) commentID) = runE
     guardPermission Comment docID userID
     guardExistsComment ref
     lift $ DB.resolveComment commentID
+
+createReply
+    :: (HasCreateComment m)
+    => UserID
+    -> CommentRef
+    -> Text
+    -> m (Result Message)
+createReply userID ref@(CommentRef (TextElementRef docID _) commentID) content = runExceptT $ do
+    guardPermission Comment docID userID
+    guardExistsComment ref
+    lift $ DB.createReply userID commentID content
 
 -- guards
 

--- a/backend/src/Docs/Comment.hs
+++ b/backend/src/Docs/Comment.hs
@@ -4,6 +4,7 @@ module Docs.Comment
     ( CommentID (..)
     , Status (..)
     , Comment (..)
+    , Message (..)
     , CommentRef (..)
     , CommentAnchor (..)
     , Range (start, end)
@@ -26,6 +27,7 @@ import Data.OpenApi.Lens (HasType (..))
 import Data.Proxy (Proxy (Proxy))
 import Data.Text (Text)
 import Data.Time (UTCTime)
+import Data.Vector (Vector)
 import Docs.TextElement (TextElementRef, prettyPrintTextElementRef)
 import Docs.UserRef (UserRef)
 import GHC.Generics (Generic)
@@ -78,10 +80,9 @@ instance ToSchema Status
 
 data Comment = Comment
     { identifier :: CommentID
-    , author :: UserRef
-    , timestamp :: UTCTime
     , status :: Status
-    , content :: Text
+    , message :: Message
+    , replies :: Vector Message
     }
     deriving (Generic)
 
@@ -90,6 +91,19 @@ instance ToJSON Comment
 instance FromJSON Comment
 
 instance ToSchema Comment
+
+data Message = Message
+    { author :: UserRef
+    , timestamp :: UTCTime
+    , content :: Text
+    }
+    deriving (Generic)
+
+instance ToJSON Message
+
+instance FromJSON Message
+
+instance ToSchema Message
 
 data CommentAnchor = CommentAnchor
     { comment :: CommentID

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -30,7 +30,7 @@ import UserManagement.DocumentPermission (Permission)
 import UserManagement.Group (GroupID)
 import UserManagement.User (UserID)
 
-import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef)
+import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef, Message)
 import Docs.Document (Document, DocumentID)
 import Docs.DocumentHistory (DocumentHistory)
 import Docs.TextElement
@@ -140,3 +140,4 @@ class (HasCheckPermission m, HasExistsDocument m) => HasCreateTreeRevision m whe
 class (HasCheckPermission m, HasExistsComment m) => HasCreateComment m where
     createComment :: UserID -> TextElementID -> Text -> m Comment
     resolveComment :: CommentID -> m ()
+    createReply :: UserID -> CommentID -> Text -> m Message

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -149,3 +149,4 @@ instance HasCreateTreeRevision HasqlTransaction where
 instance HasCreateComment HasqlTransaction where
     createComment = ((HasqlTransaction .) .) . Transactions.createComment
     resolveComment = HasqlTransaction . Transactions.resolveComment
+    createReply = ((HasqlTransaction .) .) . Transactions.createReply

--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -17,6 +17,7 @@ module Docs.Hasql.Transactions
     , createComment
     , existsComment
     , resolveComment
+    , createReply
     ) where
 
 import qualified Crypto.Hash.SHA1 as SHA1
@@ -34,7 +35,7 @@ import UserManagement.User (UserID)
 import Control.Monad (guard)
 import Data.Time (UTCTime)
 import Data.Vector (Vector)
-import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef)
+import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef, Message)
 import qualified Docs.Comment as Comment
 import Docs.Document (DocumentID)
 import Docs.Hash
@@ -178,3 +179,6 @@ existsComment =
 resolveComment :: CommentID -> Transaction ()
 resolveComment =
     flip statement Statements.resolveComment
+
+createReply :: UserID -> CommentID -> Text -> Transaction Message
+createReply userID commentID = (`statement` Statements.createReply) . (userID,commentID,)

--- a/backend/src/Server/DTOs/CreateReply.hs
+++ b/backend/src/Server/DTOs/CreateReply.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Server.DTOs.CreateReply (CreateReply (..)) where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+
+newtype CreateReply = CreateReply
+    { text :: Text
+    }
+    deriving (Generic)
+
+instance ToJSON CreateReply
+
+instance FromJSON CreateReply
+
+instance ToSchema CreateReply


### PR DESCRIPTION
This PR adds replies to comments.
Replies are included in the response body of `GET /docs/{id}/text/{id}/comments`.
A reply can be created at `POST /docs/{id}/text/{id}/comments/{id}/replies`.