### PR TITLE
Drag preview v2

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -32,7 +32,6 @@ import Effect (Effect)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class as EC
-import Effect.Console (log)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import FPO.Components.Editor.Keybindings
@@ -795,8 +794,6 @@ editor = connect selectTranslator $ H.mkComponent
       lang <- liftEffect $ Store.loadLanguage
       let cutoff = if lang == Just "de-DE" then 690.0 else 592.0
       let noButtonsCutoff = 350.0
-
-      H.liftEffect $ log $ show width
 
       H.modify_ _
         { showButtonText = width >= cutoff, showButtons = width >= noButtonsCutoff }

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -32,7 +32,7 @@ import Effect (Effect)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class as EC
--- import Effect.Console (log)
+import Effect.Console (log)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import FPO.Components.Editor.Keybindings
@@ -102,6 +102,7 @@ type State = FPOState
   , resizeObserver :: Maybe RO.ResizeObserver
   , resizeSubscription :: Maybe SubscriptionId
   , showButtonText :: Boolean
+  , showButtons :: Boolean
   -- for saving when closing window
   , mDirtyRef :: Maybe (Ref Boolean)
   , mBeforeUnloadL :: Maybe EventListener
@@ -221,6 +222,7 @@ editor = connect selectTranslator $ H.mkComponent
     , resizeObserver: Nothing
     , resizeSubscription: Nothing
     , showButtonText: true
+    , showButtons: true
     , mDirtyRef: Nothing
     , mBeforeUnloadL: Nothing
     , showSavedIcon: false
@@ -236,94 +238,106 @@ editor = connect selectTranslator $ H.mkComponent
       [ HE.onClick $ const SelectComment
       , HP.classes [ HB.dFlex, HB.flexColumn, HB.flexGrow1 ]
       ]
-      [ HH.div -- Second toolbar
-
+      [ HH.div
+          -- toolbar
           [ HP.classes [ HB.dFlex, HB.justifyContentBetween ] ]
-          [ HH.div
-              [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
-              [ makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_textBold") state.translator)
-                  Bold
-                  "bi-type-bold"
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_textItalic") state.translator)
-                  Italic
-                  "bi-type-italic"
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_textUnderline") state.translator)
-                  Underline
-                  "bi-type-underline"
+          if (not state.showButtons) then
+            -- keep the toolbar even though there is not space, so that the screen doesnt pop higher
+            [ HH.div
+                [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
+                [ HH.div
+                    [ HP.style
+                        "visibility: hidden; height: 1.5rem; min-height: 1.5rem;"
+                    ]
+                    []
+                ]
+            ]
+          else
+            [ HH.div
+                [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ] ]
+                [ makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_textBold") state.translator)
+                    Bold
+                    "bi-type-bold"
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_textItalic") state.translator)
+                    Italic
+                    "bi-type-italic"
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_textUnderline") state.translator)
+                    Underline
+                    "bi-type-underline"
 
-              , buttonDivisor
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_fontSizeUp") state.translator)
-                  FontSizeUp
-                  "bi-plus-square"
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_fontSizeDown") state.translator)
-                  FontSizeDown
-                  "bi-dash-square"
+                , buttonDivisor
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_fontSizeUp") state.translator)
+                    FontSizeUp
+                    "bi-plus-square"
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_fontSizeDown") state.translator)
+                    FontSizeDown
+                    "bi-dash-square"
 
-              , buttonDivisor
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_undo") state.translator)
-                  Undo
-                  "bi-arrow-counterclockwise"
-              , makeEditorToolbarButton
-                  true
-                  (translate (label :: _ "editor_redo") state.translator)
-                  Redo
-                  "bi-arrow-clockwise"
+                , buttonDivisor
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_undo") state.translator)
+                    Undo
+                    "bi-arrow-counterclockwise"
+                , makeEditorToolbarButton
+                    true
+                    (translate (label :: _ "editor_redo") state.translator)
+                    Redo
+                    "bi-arrow-clockwise"
 
-              , buttonDivisor
-              , makeEditorToolbarButton
-                  fullFeatures
-                  (translate (label :: _ "editor_comment") state.translator)
-                  Comment
-                  "bi-chat-square-text"
-              , makeEditorToolbarButton
-                  fullFeatures
-                  (translate (label :: _ "editor_deleteComment") state.translator)
-                  DeleteComment
-                  "bi-chat-square-text-fill"
+                , buttonDivisor
+                , makeEditorToolbarButton
+                    fullFeatures
+                    (translate (label :: _ "editor_comment") state.translator)
+                    Comment
+                    "bi-chat-square-text"
+                , makeEditorToolbarButton
+                    fullFeatures
+                    (translate (label :: _ "editor_deleteComment") state.translator)
+                    DeleteComment
+                    "bi-chat-square-text-fill"
 
-              ]
-          , HH.div
-              [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ]
-              , HP.style "min-width: 0;"
-              ]
-              [ makeEditorToolbarButtonWithText
-                  true
-                  state.showButtonText
-                  Save
-                  "bi-floppy"
-                  (translate (label :: _ "editor_save") state.translator)
-              , makeEditorToolbarButtonWithText
-                  true
-                  state.showButtonText
-                  RenderHTML
-                  "bi-file-richtext"
-                  (translate (label :: _ "editor_preview") state.translator)
-              , makeEditorToolbarButtonWithText
-                  true
-                  state.showButtonText
-                  PDF
-                  "bi-filetype-pdf"
-                  (translate (label :: _ "editor_pdf") state.translator)
-              , makeEditorToolbarButtonWithText
-                  fullFeatures
-                  state.showButtonText
-                  ShowAllComments
-                  "bi-chat-square"
-                  (translate (label :: _ "editor_allComments") state.translator)
-              ]
-          ]
+                ]
+            , HH.div
+                [ HP.classes [ HB.m1, HB.dFlex, HB.alignItemsCenter, HB.gap1 ]
+                , HP.style "min-width: 0;"
+                ]
+                [ makeEditorToolbarButtonWithText
+                    true
+                    state.showButtonText
+                    Save
+                    "bi-floppy"
+                    (translate (label :: _ "editor_save") state.translator)
+                , makeEditorToolbarButtonWithText
+                    true
+                    state.showButtonText
+                    RenderHTML
+                    "bi-file-richtext"
+                    (translate (label :: _ "editor_preview") state.translator)
+                , makeEditorToolbarButtonWithText
+                    true
+                    state.showButtonText
+                    PDF
+                    "bi-filetype-pdf"
+                    (translate (label :: _ "editor_pdf") state.translator)
+                , makeEditorToolbarButtonWithText
+                    fullFeatures
+                    state.showButtonText
+                    ShowAllComments
+                    "bi-chat-square"
+                    (translate (label :: _ "editor_allComments") state.translator)
+                ]
+            ]
       , HH.div -- Editor container
 
           [ HP.ref (H.RefLabel "container")
@@ -780,8 +794,12 @@ editor = connect selectTranslator $ H.mkComponent
 
       lang <- liftEffect $ Store.loadLanguage
       let cutoff = if lang == Just "de-DE" then 690.0 else 592.0
+      let noButtonsCutoff = 350.0
 
-      H.modify_ _ { showButtonText = width >= cutoff }
+      H.liftEffect $ log $ show width
+
+      H.modify_ _
+        { showButtonText = width >= cutoff, showButtons = width >= noButtonsCutoff }
 
     Finalize -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Preview.purs
+++ b/frontend/src/FPO/Components/Preview.purs
@@ -75,8 +75,8 @@ preview = H.mkComponent
             Nothing -> pure unit
         Nothing -> pure unit
 
-    Receive { renderedHtml } -> do
-      H.modify_ _ { renderedHtml = renderedHtml }
+    Receive { renderedHtml, isDragging } -> do
+      H.modify_ _ { renderedHtml = renderedHtml, isDragging = isDragging }
 -- htmlElementRef <- getHTMLElementRef (RefLabel "injectHtml")
 -- case htmlElementRef of
 --   Just ref -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -621,7 +621,6 @@ splitview = H.mkComponent
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
     StartResize which mouse -> do
-      H.liftEffect $ log "Start resizing"
       case which of
         ResizeLeft -> H.modify_ \st -> st { sidebarShown = true }
         ResizeRight -> H.modify_ \st -> st { previewShown = true }
@@ -641,7 +640,6 @@ splitview = H.mkComponent
 
     -- Stop resizing, when mouse is released (is detected by browser)
     StopResize _ -> do
-      state <- H.get
       H.modify_ \st -> st { mDragTarget = Nothing }
 
     -- While mouse is hold down, resizer move to position of mouse
@@ -670,7 +668,6 @@ splitview = H.mkComponent
             rawSidebarRatio = s + (ratioX - mx)
             newSidebar = clamp minRatio 0.2 rawSidebarRatio
           when (newSidebar >= minRatio && newSidebar <= maxRatio) do
-            -- H.liftEffect $ log "Still resizing"
             H.modify_ \st -> st
               { sidebarRatio = newSidebar
               , lastExpandedSidebarRatio =
@@ -688,20 +685,12 @@ splitview = H.mkComponent
             maxPreview = 1.0 - s - minRatio
             newPreview = clamp minRatio maxPreview rawPreview
 
-          -- H.liftEffect $ log $ "Raw preview: " <> show rawPreview
-          -- H.liftEffect $ log $ "Max preview: " <> show maxPreview
-          -- H.liftEffect $ log $ "New preview: " <> show newPreview
-          if rawPreview >= minRatio && rawPreview <= maxPreview then do
-            -- H.liftEffect $ log "Still resizing"
+          when (rawPreview >= minRatio && rawPreview <= maxPreview) do
             H.modify_ \st -> st
               { previewRatio = newPreview
               , lastExpandedPreviewRatio =
                   if newPreview > minRatio then newPreview
                   else st.lastExpandedPreviewRatio
-              }
-          else
-            H.modify_ _
-              { mDragTarget = Nothing
               }
 
         _ -> pure unit

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -117,7 +117,6 @@ data Action
 type State =
   { docID :: DocumentID
   , mDragTarget :: Maybe DragTarget
-  , isDragging :: Boolean
 
   -- Store the width values as ratios of the total width
   -- TODO: Using the ratios to keep the ratio, when resizing the window
@@ -190,7 +189,6 @@ splitview
 splitview = H.mkComponent
   { initialState: \docID ->
       { mDragTarget: Nothing
-      , isDragging: false
       , startMouseRatio: 0.0
       , startSidebarRatio: 0.0
       , startPreviewRatio: 0.0
@@ -518,7 +516,7 @@ splitview = H.mkComponent
               ]
           , HH.slot _preview unit Preview.preview
               { renderedHtml: state.renderedHtml
-              , isDragging: state.isDragging
+              , isDragging: state.mDragTarget /= Nothing
               }
               HandlePreview
           ]
@@ -623,9 +621,10 @@ splitview = H.mkComponent
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
     StartResize which mouse -> do
+      H.liftEffect $ log "Start resizing"
       case which of
-        ResizeLeft -> H.modify_ \st -> st { sidebarShown = true, isDragging = true }
-        ResizeRight -> H.modify_ \st -> st { previewShown = true, isDragging = true }
+        ResizeLeft -> H.modify_ \st -> st { sidebarShown = true }
+        ResizeRight -> H.modify_ \st -> st { previewShown = true }
       win <- H.liftEffect Web.HTML.window
       intWidth <- H.liftEffect $ Web.HTML.Window.innerWidth win
       let
@@ -641,8 +640,9 @@ splitview = H.mkComponent
       handleAction $ HandleMouseMove mouse
 
     -- Stop resizing, when mouse is released (is detected by browser)
-    StopResize _ ->
-      H.modify_ \st -> st { mDragTarget = Nothing, isDragging = false }
+    StopResize _ -> do
+      state <- H.get
+      H.modify_ \st -> st { mDragTarget = Nothing }
 
     -- While mouse is hold down, resizer move to position of mouse
     -- (with certain rules)
@@ -670,6 +670,7 @@ splitview = H.mkComponent
             rawSidebarRatio = s + (ratioX - mx)
             newSidebar = clamp minRatio 0.2 rawSidebarRatio
           when (newSidebar >= minRatio && newSidebar <= maxRatio) do
+            -- H.liftEffect $ log "Still resizing"
             H.modify_ \st -> st
               { sidebarRatio = newSidebar
               , lastExpandedSidebarRatio =
@@ -687,12 +688,20 @@ splitview = H.mkComponent
             maxPreview = 1.0 - s - minRatio
             newPreview = clamp minRatio maxPreview rawPreview
 
-          when (newPreview >= minRatio && newPreview <= maxPreview) do
+          -- H.liftEffect $ log $ "Raw preview: " <> show rawPreview
+          -- H.liftEffect $ log $ "Max preview: " <> show maxPreview
+          -- H.liftEffect $ log $ "New preview: " <> show newPreview
+          if rawPreview >= minRatio && rawPreview <= maxPreview then do
+            -- H.liftEffect $ log "Still resizing"
             H.modify_ \st -> st
               { previewRatio = newPreview
               , lastExpandedPreviewRatio =
                   if newPreview > minRatio then newPreview
                   else st.lastExpandedPreviewRatio
+              }
+          else
+            H.modify_ _
+              { mDragTarget = Nothing
               }
 
         _ -> pure unit

--- a/frontend/src/FPO/Page/Profile.purs
+++ b/frontend/src/FPO/Page/Profile.purs
@@ -18,7 +18,6 @@ import Data.String (length, take, toUpper)
 import Data.String.Regex (regex, split)
 import Data.String.Regex.Flags (noFlags)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import FPO.Data.AppError (AppError)
 import FPO.Data.Navigate (class Navigate)
 import FPO.Data.Request (getUser, getUserWithId, patchString)
@@ -669,5 +668,4 @@ handleAppError
   => AppError
   -> H.HalogenM State act slots msg m Unit
 handleAppError appError = do
-  H.liftEffect $ log (show appError)
   updateStore $ Store.AddError appError


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the editor and splitview components, primarily focused on responsive UI behavior and drag state handling. The most important changes include adding a new state to control toolbar button visibility based on screen width, simplifying drag state management in the splitview, and cleaning up unused logging code.

**Editor toolbar responsiveness:**
* Added a new `showButtons` state property to `Editor.purs`, and updated toolbar rendering logic to hide or show buttons based on screen width, ensuring consistent layout even when buttons are hidden. The cutoff for hiding buttons is set to 350px. (`frontend/src/FPO/Components/Editor/Editor.purs`) [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR104) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR224) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL239-R254) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR796-R799)

**Splitview drag state refactor:**
* Removed the `isDragging` property from `Splitview.purs` state and replaced its usage with a check on `mDragTarget`, simplifying drag state management and propagation to child components. (`frontend/src/FPO/Components/Splitview.purs`) [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL120) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL193) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL521-R519) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL627-R626) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL644-R643)

**Preview component updates:**
* Updated the `Preview.purs` component to receive and store the `isDragging` state from splitview, ensuring correct drag feedback during resizing. (`frontend/src/FPO/Components/Preview.purs`)

**Code cleanup:**
* Removed unused `Effect.Console (log)` imports and related logging statements from `Editor.purs` and `Profile.purs` for cleaner code. (`frontend/src/FPO/Components/Editor/Editor.purs`, `frontend/src/FPO/Page/Profile.purs`) [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL35) [[2]](diffhunk://#diff-7b14da34b53f47ce781e315e360122601a9bd29d8c74dd7bace6b041c9d7ed61L21) [[3]](diffhunk://#diff-7b14da34b53f47ce781e315e360122601a9bd29d8c74dd7bace6b041c9d7ed61L672)

**Minor logic fix:**
* Corrected the preview resizing logic in splitview to use the raw preview value for clamping, ensuring correct boundary checks during resize. (`frontend/src/FPO/Components/Splitview.purs`)