### PR TITLE
Translate errors

### DIFF
--- a/frontend/src/FPO/Components/AppToasts.purs
+++ b/frontend/src/FPO/Components/AppToasts.purs
@@ -27,7 +27,6 @@ import Halogen.Themes.Bootstrap5 as HB
 
 type State = FPOState
   ( toasts :: Array AppToastWithId
-  , totalToasts :: Int
   )
 
 type Input = Unit
@@ -84,13 +83,12 @@ handleAction
 handleAction = case _ of
   HandleNewToasts { context: { toasts: newToasts, translator } } -> do
     state <- H.get
-    let previouslyUnknownToasts = getNewToasts state.toasts newToasts
     H.modify_ _
       { toasts = newToasts
-      , totalToasts = length previouslyUnknownToasts
       , translator = fromFpoTranslator translator
       }
 
+    let previouslyUnknownToasts = getNewToasts state.toasts newToasts
     traverse_
       ( \toast -> do
           let toastId = toast.id
@@ -110,7 +108,7 @@ handleAction = case _ of
 
 initialState :: Connected ToastsAndTranslator Input -> State
 initialState { context: { toasts, translator } } =
-  { toasts, totalToasts: length toasts, translator: fromFpoTranslator translator }
+  { toasts, translator: fromFpoTranslator translator }
 
 render :: forall m. State -> H.ComponentHTML ToastAction () m
 render state = do

--- a/frontend/src/FPO/Components/AppToasts.purs
+++ b/frontend/src/FPO/Components/AppToasts.purs
@@ -6,14 +6,15 @@ module FPO.Components.AppToasts
 
 import Prelude
 
-import Data.Array (any, filter, length)
+import Data.Array (any, filter)
 import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff (delay)
 import Effect.Aff.Class (class MonadAff)
-import FPO.Data.AppToast (AppToast(..), AppToastWithId, ToastId)
+import FPO.Data.AppToast (AppToast(..), AppToastWithId, ToastId, showToastText)
 import FPO.Data.Store as Store
+import FPO.Translations.Labels (Labels)
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState)
 import Halogen as H
@@ -24,6 +25,7 @@ import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Store.Select (Selector, selectEq)
 import Halogen.Themes.Bootstrap5 as HB
+import Simple.I18n.Translator (Translator)
 
 type State = FPOState
   ( toasts :: Array AppToastWithId
@@ -121,11 +123,12 @@ render state = do
         ]
     , HP.style "top: 80px; z-index: 9999;"
     ]
-    [ HH.div_ (map renderToast state.toasts)
+    [ HH.div_ (map (renderToast state.translator) state.toasts)
     ]
 
-renderToast :: forall m. AppToastWithId -> H.ComponentHTML ToastAction () m
-renderToast toast =
+renderToast
+  :: forall m. Translator Labels -> AppToastWithId -> H.ComponentHTML ToastAction () m
+renderToast translator toast =
   HH.div
     [ HP.classes
         [ HB.toast
@@ -145,7 +148,7 @@ renderToast toast =
         [ HP.classes
             [ HB.toastBody, HB.dFlex, HB.justifyContentBetween, HB.alignItemsCenter ]
         ]
-        [ HH.text (show toast.toast)
+        [ HH.text (showToastText toast.toast translator)
         , HH.button
             [ HP.classes
                 [ HB.btnClose

--- a/frontend/src/FPO/Data/AppError.purs
+++ b/frontend/src/FPO/Data/AppError.purs
@@ -7,8 +7,10 @@ import Effect.Aff (message)
 import Effect.Aff.Class (class MonadAff)
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
+import FPO.Translations.Labels (Labels)
 import Foreign (renderForeignError)
 import Halogen as H
+import Simple.I18n.Translator (Translator, label, translate)
 
 -- Add this after your imports
 data AppError
@@ -67,3 +69,18 @@ printAjaxError str = case _ of
     str <> ": request failed"
   XHROtherError err ->
     str <> ": " <> message err
+
+showToastError :: AppError -> Translator Labels -> String
+showToastError err translator = case err of
+  NetworkError msg -> (translate (label :: _ "error_networkError") translator) <> msg
+  AuthError msg -> (translate (label :: _ "error_authError") translator) <> msg
+  NotFoundError resource -> (translate (label :: _ "error_notFoundError") translator)
+    <> resource
+  ServerError msg -> (translate (label :: _ "error_serverError") translator) <> msg
+  DataError msg -> (translate (label :: _ "error_dataError") translator) <> msg
+  AccessDeniedError -> translate (label :: _ "error_accessDeniedError") translator
+  MethodNotAllowedError resource method ->
+    (translate (label :: _ "error_methodNotAllowedError") translator) <> resource
+      <> " (method: "
+      <> method
+      <> ")"

--- a/frontend/src/FPO/Data/AppToast.purs
+++ b/frontend/src/FPO/Data/AppToast.purs
@@ -2,8 +2,10 @@ module FPO.Data.AppToast where
 
 import Prelude
 
-import FPO.Data.AppError (AppError)
+import FPO.Data.AppError (AppError, showToastError)
+import FPO.Translations.Labels (Labels)
 import Halogen.HTML as HH
+import Simple.I18n.Translator (Translator)
 
 type ToastId = Int
 data AppToast
@@ -28,3 +30,10 @@ classForToast = case _ of
   Error _ -> HH.ClassName "fpo-toast-error"
   Warning _ -> HH.ClassName "fpo-toast-warning"
   Info _ -> HH.ClassName "fpo-toast-info"
+
+showToastText :: AppToast -> Translator Labels -> String
+showToastText toast translator = case toast of
+  Success msg -> msg
+  Error err -> showToastError err translator
+  Warning msg -> msg
+  Info msg -> msg

--- a/frontend/src/FPO/Translations/Errors.purs
+++ b/frontend/src/FPO/Translations/Errors.purs
@@ -9,11 +9,14 @@ import Simple.I18n.Translation (Translation, fromRecord)
 type ErrorLabels =
   ( "error_accessDeniedError"
       ::: "error_authError"
+      ::: "error_connectionFailed"
       ::: "error_dataError"
+      ::: "error_invalidCredentials"
       ::: "error_methodNotAllowedError"
       ::: "error_networkError"
       ::: "error_notFoundError"
       ::: "error_serverError"
+      ::: "error_sessionExpired"
       ::: SNil
   )
 
@@ -21,20 +24,26 @@ enErrors :: Translation ErrorLabels
 enErrors = fromRecord
   { error_accessDeniedError: "Access denied"
   , error_authError: "Authentication error: "
+  , error_connectionFailed: "Connection failed"
   , error_dataError: "Data error: "
   , error_methodNotAllowedError: "Method not allowed: "
+  , error_invalidCredentials: "Invalid credentials"
   , error_networkError: "Network error: "
   , error_notFoundError: "Not found: "
   , error_serverError: "Server error: "
+  , error_sessionExpired: "Session expired"
   }
 
 deErrors :: Translation ErrorLabels
 deErrors = fromRecord
   { error_accessDeniedError: "Zugriff verweigert"
   , error_authError: "Authentifizierungsfehler: "
+  , error_connectionFailed: "Verbindungsfehler"
   , error_dataError: "Datenfehler: "
   , error_methodNotAllowedError: "Methode nicht erlaubt: "
+  , error_invalidCredentials: "Ungültige Anmeldedaten"
   , error_networkError: "Netzwerkfehler: "
   , error_notFoundError: "Nicht gefunden: "
   , error_serverError: "Serverfehler: "
+  , error_sessionExpired: "Sitzung abgelaufen"
   }

--- a/frontend/src/FPO/Translations/Errors.purs
+++ b/frontend/src/FPO/Translations/Errors.purs
@@ -1,0 +1,40 @@
+module FPO.Translations.Errors
+  ( deErrors
+  , enErrors
+  ) where
+
+import Record.Extra (type (:::), SNil)
+import Simple.I18n.Translation (Translation, fromRecord)
+
+type ErrorLabels =
+  ( "error_accessDeniedError"
+      ::: "error_authError"
+      ::: "error_dataError"
+      ::: "error_methodNotAllowedError"
+      ::: "error_networkError"
+      ::: "error_notFoundError"
+      ::: "error_serverError"
+      ::: SNil
+  )
+
+enErrors :: Translation ErrorLabels
+enErrors = fromRecord
+  { error_accessDeniedError: "Access denied"
+  , error_authError: "Authentication error: "
+  , error_dataError: "Data error: "
+  , error_methodNotAllowedError: "Method not allowed: "
+  , error_networkError: "Network error: "
+  , error_notFoundError: "Not found: "
+  , error_serverError: "Server error: "
+  }
+
+deErrors :: Translation ErrorLabels
+deErrors = fromRecord
+  { error_accessDeniedError: "Zugriff verweigert"
+  , error_authError: "Authentifizierungsfehler: "
+  , error_dataError: "Datenfehler: "
+  , error_methodNotAllowedError: "Methode nicht erlaubt: "
+  , error_networkError: "Netzwerkfehler: "
+  , error_notFoundError: "Nicht gefunden: "
+  , error_serverError: "Serverfehler: "
+  }

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -5,6 +5,7 @@ import FPO.Translations.Common (deCommon, enCommon)
 import FPO.Translations.Components.Editor (deEditor, enEditor)
 import FPO.Translations.Components.Navbar (deNavbar, enNavbar)
 import FPO.Translations.Components.TOC (deTOC, enTOC)
+import FPO.Translations.Errors (deErrors, enErrors)
 import FPO.Translations.Page.Admin.AddMembers (deAddMembersPage, enAddMembersPage)
 import FPO.Translations.Page.Admin.GroupMembers (deGroupMemberPage, enGroupMemberPage)
 import FPO.Translations.Page.Admin.GroupProjects
@@ -32,6 +33,7 @@ en = fromRecord
   $ merge (toRecord enAddMembersPage)
   $ merge (toRecord enCommon)
   $ merge (toRecord enEditor)
+  $ merge (toRecord enErrors)
   $ merge (toRecord enNavbar)
   $ merge (toRecord enHome)
   $ merge (toRecord enLogin)
@@ -51,6 +53,7 @@ de = fromRecord
   $ merge (toRecord deAddMembersPage)
   $ merge (toRecord deCommon)
   $ merge (toRecord deEditor)
+  $ merge (toRecord deErrors)
   $ merge (toRecord deNavbar)
   $ merge (toRecord deHome)
   $ merge (toRecord deLogin)
@@ -141,6 +144,15 @@ type Labels =
       ::: "editor_textItalic"
       ::: "editor_textUnderline"
       ::: "editor_undo"
+
+      -- | Errors 
+      ::: "error_accessDeniedError"
+      ::: "error_authError"
+      ::: "error_dataError"
+      ::: "error_methodNotAllowedError"
+      ::: "error_networkError"
+      ::: "error_notFoundError"
+      ::: "error_serverError"
 
       -- | Group Members Page
       ::: "gm_addMember"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -148,11 +148,14 @@ type Labels =
       -- | Errors 
       ::: "error_accessDeniedError"
       ::: "error_authError"
+      ::: "error_connectionFailed"
       ::: "error_dataError"
+      ::: "error_invalidCredentials"
       ::: "error_methodNotAllowedError"
       ::: "error_networkError"
       ::: "error_notFoundError"
       ::: "error_serverError"
+      ::: "error_sessionExpired"
 
       -- | Group Members Page
       ::: "gm_addMember"


### PR DESCRIPTION
This pull request adds internationalization (i18n) support for toast and error messages throughout the application, making error handling and user notifications translatable based on the user's language. The changes update toast rendering and error handling to use translation labels, and introduce new translation keys and files for error messages.

### Internationalization support for error and toast messages

* Updated `AppToasts` component and related types to include a translator in state, select it from the store, and pass it to toast rendering functions, enabling translation of toast messages. (`frontend/src/FPO/Components/AppToasts.purs`) [[1]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL9-R19) [[2]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cR28-R43) [[3]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL69-R76) [[4]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL79-R93) [[5]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL101-R113) [[6]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL115-R131) [[7]](diffhunk://#diff-ada9bdcf23c6fb036ca98a64fa90706385501582395a017ce414e9bdd88b945cL139-R151)
* Modified toast and error rendering logic to use translation functions and new error label keys, ensuring all error messages shown to the user are localized. (`frontend/src/FPO/Data/AppError.purs`, `frontend/src/FPO/Data/AppToast.purs`, `frontend/src/FPO/Data/Request.purs`) [[1]](diffhunk://#diff-1ec6931e4fa7e5df5bbab733eeb00a3da6729d14a77b76e71e8405af34689e58R10-R13) [[2]](diffhunk://#diff-1ec6931e4fa7e5df5bbab733eeb00a3da6729d14a77b76e71e8405af34689e58R72-R86) [[3]](diffhunk://#diff-c62a965f0ee23c776699a2f12e68bca92989cfdd05da45ced33edf04cf010627L5-R8) [[4]](diffhunk://#diff-c62a965f0ee23c776699a2f12e68bca92989cfdd05da45ced33edf04cf010627R33-R39) [[5]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R81-R84) [[6]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R128-L137)

### Addition of new translation resources

* Added a new module for error message translations with English and German variants. (`frontend/src/FPO/Translations/Errors.purs`)
* Integrated error translation resources into the main translation label set and updated the `Labels` type to include all error keys. (`frontend/src/FPO/Translations/Labels.purs`) [[1]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR8) [[2]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR36) [[3]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR56) [[4]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR148-R159)