### PR TITLE
Backend: Introduce Logging

### DIFF
--- a/backend/migrations/006_logs.up.sql
+++ b/backend/migrations/006_logs.up.sql
@@ -1,0 +1,10 @@
+CREATE TYPE severity AS ENUM('info', 'warning', 'error');
+
+CREATE TABLE IF NOT EXISTS logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "severity" severity NOT NULL,
+    "timestamp" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "user" UUID REFERENCES users (id), -- NULL = system
+    scope TEXT NOT NULL,
+    content JSONB NOT NULL
+);

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -135,8 +135,8 @@ logged userID scope result = do
         Left err -> do
             _ <- DB.logMessage Info (Just userID) scope err
             --                 ^~~~ all of these errors are user errors
-            result
-        Right _ -> result
+            return $ Left err
+        Right val -> return $ Right val
 
 logMessage
     :: (HasLogMessage m, ToJSON v)

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Docs
     ( Error (..)
     , Result
     , Limit
+    , logMessage
     , createDocument
     , getDocument
     , getDocuments
@@ -18,6 +21,7 @@ module Docs
     , getComments
     , resolveComment
     , createReply
+    , getLogs
     ) where
 
 import Control.Monad (unless)
@@ -33,7 +37,9 @@ import UserManagement.DocumentPermission (Permission (..))
 import UserManagement.Group (GroupID)
 import UserManagement.User (UserID)
 
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Maybe (fromMaybe)
+import Data.OpenApi (ToSchema)
 import Docs.Comment (Comment, CommentRef (CommentRef), Message)
 import qualified Docs.Comment as Comment
 import Docs.Database
@@ -51,12 +57,14 @@ import Docs.Database
     , HasGetComments
     , HasGetDocument
     , HasGetDocumentHistory
+    , HasGetLogs
     , HasGetTextElementRevision
     , HasGetTextHistory
     , HasGetTreeHistory
     , HasGetTreeRevision
     , HasIsGroupAdmin
     , HasIsSuperAdmin
+    , HasLogMessage
     )
 import qualified Docs.Database as DB
 import Docs.Document (Document, DocumentID)
@@ -83,17 +91,29 @@ import Docs.TreeRevision
     )
 import qualified Docs.TreeRevision as TreeRevision
 import qualified Docs.UserRef as UserRef
+import GHC.Generics (Generic)
 import GHC.Int (Int64)
+import Logging.Logs (LogMessage, Severity (Info))
+import Logging.Scope (Scope)
+import qualified Logging.Scope as Scope
 
 data Error
     = NoPermission DocumentID Permission
     | NoPermissionForUser UserID
     | NoPermissionInGroup GroupID
+    | SuperAdminOnly
     | DocumentNotFound DocumentID
     | TextElementNotFound TextElementRef
     | TextRevisionNotFound TextRevisionRef
     | TreeRevisionNotFound TreeRevisionRef
     | CommentNotFound CommentRef
+    deriving (Generic)
+
+instance ToJSON Error
+
+instance FromJSON Error
+
+instance ToSchema Error
 
 type Result a = Either Error a
 
@@ -108,22 +128,51 @@ squashRevisionsWithinMinutes = 15
 enableSquashing :: Bool
 enableSquashing = False
 
+logged :: (HasLogMessage m) => UserID -> Scope -> m (Result a) -> m (Result a)
+logged userID scope result = do
+    value <- result
+    case value of
+        Left err -> do
+            _ <- DB.logMessage Info (Just userID) scope err
+            --                 ^~~~ all of these errors are user errors
+            result
+        Right _ -> result
+
+logMessage
+    :: (HasLogMessage m, ToJSON v)
+    => Severity
+    -> Maybe UserID
+    -> Scope
+    -> v
+    -> m LogMessage
+logMessage = DB.logMessage
+
+getLogs
+    :: (HasGetLogs m, HasLogMessage m)
+    => UserID
+    -> Maybe UTCTime
+    -> Int64
+    -> m (Result (Vector LogMessage))
+getLogs userID offset limit = logged userID Scope.logging $ runExceptT $ do
+    guardSuperAdmin userID
+    lift $ DB.getLogs offset limit
+
 createDocument
-    :: (HasCreateDocument m)
+    :: (HasCreateDocument m, HasLogMessage m)
     => UserID
     -> GroupID
     -> Text
     -> m (Result Document)
-createDocument userID groupID title = runExceptT $ do
+createDocument userID groupID title = logged userID Scope.docs $ runExceptT $ do
     guardGroupAdmin groupID userID
     lift $ DB.createDocument title groupID userID
 
 getDocument
-    :: (HasGetDocument m)
+    :: (HasGetDocument m, HasLogMessage m)
     => UserID
     -> DocumentID
     -> m (Result Document)
-getDocument userID docID = runExceptT $ do
+getDocument userID docID = logged userID Scope.docs $ runExceptT $ do
     guardPermission Read docID userID
     document <- lift $ DB.getDocument docID
     maybe (throwError $ DocumentNotFound docID) pure document
@@ -131,25 +180,26 @@ getDocument userID docID = runExceptT $ do
 -- | Gets all documents visible by the user
 --   OR all documents by the specified group and / or user
 getDocuments
-    :: (HasGetDocument m)
+    :: (HasGetDocument m, HasLogMessage m)
     => UserID
     -> Maybe UserID
     -> Maybe GroupID
     -> m (Result (Vector Document))
-getDocuments userID byUserID byGroupID = case (byUserID, byGroupID) of
-    (Nothing, Nothing) -> Right <$> DB.getDocuments userID
-    _ -> runExceptT $ do
-        maybe (pure ()) (guardUserRights userID) byUserID
-        maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
-        lift $ DB.getDocumentsBy byUserID byGroupID
+getDocuments userID byUserID byGroupID = logged userID Scope.docs $
+    case (byUserID, byGroupID) of
+        (Nothing, Nothing) -> Right <$> DB.getDocuments userID
+        _ -> runExceptT $ do
+            maybe (pure ()) (guardUserRights userID) byUserID
+            maybe (pure ()) (`guardGroupAdmin` userID) byGroupID
+            lift $ DB.getDocumentsBy byUserID byGroupID
 
 createTextElement
-    :: (HasCreateTextElement m)
+    :: (HasCreateTextElement m, HasLogMessage m)
     => UserID
     -> DocumentID
     -> TextElementKind
     -> m (Result TextElement)
-createTextElement userID docID kind = runExceptT $ do
+createTextElement userID docID kind = logged userID Scope.docsText $ runExceptT $ do
     guardPermission Edit docID userID
     guardExistsDocument docID
     lift $ DB.createTextElement docID kind
@@ -162,55 +212,60 @@ createTextElement userID docID kind = runExceptT $ do
 --   In case of an update, the revision id is increased nevertheless to
 --   prevent lost update scenarios.
 createTextRevision
-    :: (HasCreateTextRevision m, HasGetTextElementRevision m, HasExistsComment m)
+    :: ( HasCreateTextRevision m
+       , HasGetTextElementRevision m
+       , HasExistsComment m
+       , HasLogMessage m
+       )
     => UserID
     -> NewTextRevision
     -> m (Result ConflictStatus)
-createTextRevision userID revision = runExceptT $ do
-    let ref@(TextElementRef docID _) = newTextRevisionElement revision
-    guardPermission Edit docID userID
-    guardExistsTextElement ref
-    mapM_
-        guardExistsComment
-        (CommentRef ref . Comment.comment <$> newTextRevisionCommentAnchors revision)
-    let latestRevisionRef = TextRevisionRef ref TextRevision.Latest
-    latestElementRevision <-
-        lift $ DB.getTextElementRevision latestRevisionRef
-    let latestRevision = latestElementRevision >>= TextRevision.revision
-    let latestRevisionID =
-            latestRevision
-                <&> TextRevision.identifier . TextRevision.header
-    let parentRevisionID = newTextRevisionParent revision
-    let createRevision =
-            DB.createTextRevision
-                userID
-                ref
-                (newTextRevisionContent revision)
-                (newTextRevisionCommentAnchors revision)
-    lift $ do
-        now <- DB.now
-        case latestRevision of
-            -- first revision
-            Nothing -> createRevision <&> TextRevision.NoConflict
-            Just latest
-                -- content has not changed? -> return latest
-                | content latest == newTextRevisionContent revision ->
-                    return $ TextRevision.NoConflict latest
-                -- no conflict, and can update? -> update (squash)
-                | latestRevisionID == parentRevisionID && shouldUpdate now latest ->
-                    DB.updateTextRevision
-                        (identifier latest)
-                        (newTextRevisionContent revision)
-                        (newTextRevisionCommentAnchors revision)
-                        <&> TextRevision.NoConflict
-                -- no conflict, but can not update? -> create new
-                | latestRevisionID == parentRevisionID ->
-                    createRevision <&> TextRevision.NoConflict
-                -- conflict
-                | otherwise ->
-                    return $
-                        TextRevision.Conflict $
-                            identifier latest
+createTextRevision userID revision = logged userID Scope.docsTextRevision $
+    runExceptT $ do
+        let ref@(TextElementRef docID _) = newTextRevisionElement revision
+        guardPermission Edit docID userID
+        guardExistsTextElement ref
+        mapM_
+            guardExistsComment
+            (CommentRef ref . Comment.comment <$> newTextRevisionCommentAnchors revision)
+        let latestRevisionRef = TextRevisionRef ref TextRevision.Latest
+        latestElementRevision <-
+            lift $ DB.getTextElementRevision latestRevisionRef
+        let latestRevision = latestElementRevision >>= TextRevision.revision
+        let latestRevisionID =
+                latestRevision
+                    <&> TextRevision.identifier . TextRevision.header
+        let parentRevisionID = newTextRevisionParent revision
+        let createRevision =
+                DB.createTextRevision
+                    userID
+                    ref
+                    (newTextRevisionContent revision)
+                    (newTextRevisionCommentAnchors revision)
+        lift $ do
+            now <- DB.now
+            case latestRevision of
+                -- first revision
+                Nothing -> createRevision <&> TextRevision.NoConflict
+                Just latest
+                    -- content has not changed? -> return latest
+                    | content latest == newTextRevisionContent revision ->
+                        return $ TextRevision.NoConflict latest
+                    -- no conflict, and can update? -> update (squash)
+                    | latestRevisionID == parentRevisionID && shouldUpdate now latest ->
+                        DB.updateTextRevision
+                            (identifier latest)
+                            (newTextRevisionContent revision)
+                            (newTextRevisionCommentAnchors revision)
+                            <&> TextRevision.NoConflict
+                    -- no conflict, but can not update? -> create new
+                    | latestRevisionID == parentRevisionID ->
+                        createRevision <&> TextRevision.NoConflict
+                    -- conflict
+                    | otherwise ->
+                        return $
+                            TextRevision.Conflict $
+                                identifier latest
   where
     header = TextRevision.header
     identifier = TextRevision.identifier . header
@@ -229,84 +284,90 @@ createTextRevision userID revision = runExceptT $ do
                 $ timestamp latestRevision
 
 getTextElementRevision
-    :: (HasGetTextElementRevision m)
+    :: (HasGetTextElementRevision m, HasLogMessage m)
     => UserID
     -> TextRevisionRef
     -> m (Result (Maybe TextElementRevision))
-getTextElementRevision userID ref = runExceptT $ do
-    let (TextRevisionRef (TextElementRef docID _) _) = ref
-    guardPermission Read docID userID
-    guardExistsTextRevision True ref
-    lift $ DB.getTextElementRevision ref
+getTextElementRevision userID ref = logged userID Scope.docsTextRevision $
+    runExceptT $ do
+        let (TextRevisionRef (TextElementRef docID _) _) = ref
+        guardPermission Read docID userID
+        guardExistsTextRevision True ref
+        lift $ DB.getTextElementRevision ref
 
 createTreeRevision
-    :: (HasCreateTreeRevision m)
+    :: (HasCreateTreeRevision m, HasLogMessage m)
     => UserID
     -> DocumentID
     -> Node TextElementID
     -> m (Result (TreeRevision TextElementID))
-createTreeRevision userID docID root = runExceptT $ do
-    guardPermission Edit docID userID
-    guardExistsDocument docID
-    existsTextElement <- lift $ DB.existsTextElementInDocument docID
-    case firstFalse existsTextElement root of
-        Just textID -> throwError $ TextElementNotFound $ TextElementRef docID textID
-        Nothing -> lift $ DB.createTreeRevision userID docID root
+createTreeRevision userID docID root = logged userID Scope.docsTreeRevision $
+    runExceptT $ do
+        guardPermission Edit docID userID
+        guardExistsDocument docID
+        existsTextElement <- lift $ DB.existsTextElementInDocument docID
+        case firstFalse existsTextElement root of
+            Just textID -> throwError $ TextElementNotFound $ TextElementRef docID textID
+            Nothing -> lift $ DB.createTreeRevision userID docID root
   where
     firstFalse predicate = find (not . predicate)
 
 getTreeRevision
-    :: (HasGetTreeRevision m)
+    :: (HasGetTreeRevision m, HasLogMessage m)
     => UserID
     -> TreeRevisionRef
     -> m (Result (Maybe (TreeRevision TextElement)))
-getTreeRevision userID ref@(TreeRevisionRef docID _) = runExceptT $ do
-    guardPermission Read docID userID
-    guardExistsTreeRevision True ref
-    lift $ DB.getTreeRevision ref
+getTreeRevision userID ref@(TreeRevisionRef docID _) = logged userID Scope.docsTreeRevision $
+    runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsTreeRevision True ref
+        lift $ DB.getTreeRevision ref
 
 getTextHistory
-    :: (HasGetTextHistory m)
+    :: (HasGetTextHistory m, HasLogMessage m)
     => UserID
     -> TextElementRef
     -> Maybe UTCTime
     -> Maybe Limit
     -> m (Result TextRevisionHistory)
-getTextHistory userID ref@(TextElementRef docID _) time limit = runExceptT $ do
-    guardPermission Read docID userID
-    guardExistsTextElement ref
-    lift $ DB.getTextHistory ref time $ fromMaybe defaultHistoryLimit limit
+getTextHistory userID ref@(TextElementRef docID _) time limit = logged userID Scope.docsText $
+    runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsTextElement ref
+        lift $ DB.getTextHistory ref time $ fromMaybe defaultHistoryLimit limit
 
 getTreeHistory
-    :: (HasGetTreeHistory m)
+    :: (HasGetTreeHistory m, HasLogMessage m)
     => UserID
     -> DocumentID
     -> Maybe UTCTime
     -> Maybe Limit
     -> m (Result TreeRevisionHistory)
-getTreeHistory userID docID time limit = runExceptT $ do
-    guardPermission Read docID userID
-    guardExistsDocument docID
-    lift $ DB.getTreeHistory docID time $ fromMaybe defaultHistoryLimit limit
+getTreeHistory userID docID time limit = logged userID Scope.docsTree $
+    runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsDocument docID
+        lift $ DB.getTreeHistory docID time $ fromMaybe defaultHistoryLimit limit
 
 getDocumentHistory
-    :: (HasGetDocumentHistory m)
+    :: (HasGetDocumentHistory m, HasLogMessage m)
     => UserID
     -> DocumentID
     -> Maybe UTCTime
     -> Maybe Limit
     -> m (Result DocumentHistory)
-getDocumentHistory userID docID time limit = runExceptT $ do
-    guardPermission Read docID userID
-    guardExistsDocument docID
-    lift $ DB.getDocumentHistory docID time $ fromMaybe defaultHistoryLimit limit
+getDocumentHistory userID docID time limit = logged userID Scope.docs $
+    runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsDocument docID
+        lift $ DB.getDocumentHistory docID time $ fromMaybe defaultHistoryLimit limit
 
 getTreeWithLatestTexts
-    :: (HasGetTreeRevision m, HasGetTextElementRevision m)
+    :: (HasGetTreeRevision m, HasGetTextElementRevision m, HasLogMessage m)
     => UserID
     -> TreeRevisionRef
     -> m (Result (Maybe (TreeRevision TextElementRevision)))
-getTreeWithLatestTexts userID revision = runExceptT $ do
+getTreeWithLatestTexts userID revision = logged userID Scope.docs $ runExceptT $ do
     guardPermission Read docID userID
     guardExistsDocument docID
     guardExistsTreeRevision True revision
@@ -323,46 +384,50 @@ getTreeWithLatestTexts userID revision = runExceptT $ do
     elementRevisionToRevision (TextElementRevision _ rev) = rev
 
 createComment
-    :: (HasCreateComment m)
+    :: (HasCreateComment m, HasLogMessage m)
     => UserID
     -> TextElementRef
     -> Text
     -> m (Result Comment)
-createComment userID ref@(TextElementRef docID textID) text = runExceptT $ do
-    guardPermission Comment docID userID
-    guardExistsTextElement ref
-    lift $ DB.createComment userID textID text
+createComment userID ref@(TextElementRef docID textID) text =
+    logged userID Scope.docsComment $ runExceptT $ do
+        guardPermission Comment docID userID
+        guardExistsTextElement ref
+        lift $ DB.createComment userID textID text
 
 getComments
-    :: (HasGetComments m)
+    :: (HasGetComments m, HasLogMessage m)
     => UserID
     -> TextElementRef
     -> m (Result (Vector Comment))
-getComments userID ref@(TextElementRef docID _) = runExceptT $ do
-    guardPermission Read docID userID
-    guardExistsTextElement ref
-    lift $ DB.getComments ref
+getComments userID ref@(TextElementRef docID _) = logged userID Scope.docsComment $
+    runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsTextElement ref
+        lift $ DB.getComments ref
 
 resolveComment
-    :: (HasCreateComment m)
+    :: (HasCreateComment m, HasLogMessage m)
     => UserID
     -> CommentRef
     -> m (Result ())
-resolveComment userID ref@(CommentRef (TextElementRef docID _) commentID) = runExceptT $ do
-    guardPermission Comment docID userID
-    guardExistsComment ref
-    lift $ DB.resolveComment commentID
+resolveComment userID ref@(CommentRef (TextElementRef docID _) commentID) =
+    logged userID Scope.docsComment $ runExceptT $ do
+        guardPermission Comment docID userID
+        guardExistsComment ref
+        lift $ DB.resolveComment commentID
 
 createReply
-    :: (HasCreateComment m)
+    :: (HasCreateComment m, HasLogMessage m)
     => UserID
     -> CommentRef
     -> Text
     -> m (Result Message)
-createReply userID ref@(CommentRef (TextElementRef docID _) commentID) content = runExceptT $ do
-    guardPermission Comment docID userID
-    guardExistsComment ref
-    lift $ DB.createReply userID commentID content
+createReply userID ref@(CommentRef (TextElementRef docID _) commentID) content =
+    logged userID Scope.docsComment $ runExceptT $ do
+        guardPermission Comment docID userID
+        guardExistsComment ref
+        lift $ DB.createReply userID commentID content
 
 -- guards
 
@@ -398,6 +463,15 @@ guardUserRights userID forUserID = do
     superAdmin <- lift $ DB.isSuperAdmin userID
     unless (userID == forUserID || superAdmin) $
         throwError (NoPermissionForUser forUserID)
+
+guardSuperAdmin
+    :: (HasIsSuperAdmin m)
+    => UserID
+    -> ExceptT Error m ()
+guardSuperAdmin userID = do
+    isSuperAdmin <- lift $ DB.isSuperAdmin userID
+    unless isSuperAdmin $
+        throwError SuperAdminOnly
 
 guardExistsDocument
     :: (HasExistsDocument m)

--- a/backend/src/Docs/Comment.hs
+++ b/backend/src/Docs/Comment.hs
@@ -35,6 +35,13 @@ import GHC.Int (Int64)
 import Servant (FromHttpApiData (parseUrlPiece))
 
 data CommentRef = CommentRef TextElementRef CommentID
+    deriving (Generic)
+
+instance ToJSON CommentRef
+
+instance FromJSON CommentRef
+
+instance ToSchema CommentRef
 
 prettyPrintCommentRef :: CommentRef -> String
 prettyPrintCommentRef (CommentRef textElementRef id_) =

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -20,6 +20,8 @@ module Docs.Database
     , HasGetComments (..)
     , HasCreateComment (..)
     , HasExistsComment (..)
+    , HasGetLogs (..)
+    , HasLogMessage (..)
     ) where
 
 import Data.Text (Text)
@@ -30,6 +32,7 @@ import UserManagement.DocumentPermission (Permission)
 import UserManagement.Group (GroupID)
 import UserManagement.User (UserID)
 
+import Data.Aeson (ToJSON)
 import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef, Message)
 import Docs.Document (Document, DocumentID)
 import Docs.DocumentHistory (DocumentHistory)
@@ -49,6 +52,7 @@ import Docs.TextRevision
 import Docs.Tree (Node)
 import Docs.TreeRevision (TreeRevision, TreeRevisionHistory, TreeRevisionRef)
 import GHC.Int (Int64)
+import Logging.Logs (LogMessage, Scope, Severity)
 
 class (HasIsSuperAdmin m) => HasCheckPermission m where
     checkDocumentPermission :: UserID -> DocumentID -> Permission -> m Bool
@@ -111,6 +115,15 @@ class
     where
     getComments :: TextElementRef -> m (Vector Comment)
 
+class (HasIsSuperAdmin m) => HasGetLogs m where
+    getLogs
+        :: Maybe UTCTime
+        -- ^ offset
+        -> Int64
+        -- ^ limit
+        -> m (Vector LogMessage)
+        -- ^ log messages
+
 -- create
 
 class (HasIsGroupAdmin m) => HasCreateDocument m where
@@ -141,3 +154,12 @@ class (HasCheckPermission m, HasExistsComment m) => HasCreateComment m where
     createComment :: UserID -> TextElementID -> Text -> m Comment
     resolveComment :: CommentID -> m ()
     createReply :: UserID -> CommentID -> Text -> m Message
+
+class (Monad m) => HasLogMessage m where
+    logMessage
+        :: (ToJSON v)
+        => Severity
+        -> Maybe UserID
+        -> Scope
+        -> v
+        -> m LogMessage

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -24,6 +24,8 @@ import qualified UserManagement.Transactions as UserTransactions
 
 import qualified Docs.Hasql.Sessions as Sessions
 import qualified Docs.Hasql.Transactions as Transactions
+import Logging.Logs (Severity (..))
+import qualified Logging.Scope as Scope
 
 newtype HasqlSession a
     = HasqlSession
@@ -32,7 +34,21 @@ newtype HasqlSession a
     deriving (Functor, Applicative, Monad)
 
 run :: HasqlSession a -> Connection -> IO (Either SessionError a)
-run = Session.run . unHasqlSession
+run session conn = do
+    result <- runUnlogged session conn
+    case result of
+        Left err -> do
+            -- If something went wrong here, its fucked up anyway :)
+            -- We could cache the result and insert it into the db as soon as the
+            -- problem is solved, but i think this is currently not required.
+            Right _ <-
+                flip runUnlogged conn $
+                    logMessage Error Nothing Scope.database $
+                        show err
+            return result
+        Right _ -> return result
+  where
+    runUnlogged = Session.run . unHasqlSession
 
 -- access rights
 
@@ -84,6 +100,9 @@ instance HasGetDocumentHistory HasqlSession where
 instance HasGetComments HasqlSession where
     getComments = HasqlSession . Sessions.getComments
 
+instance HasGetLogs HasqlSession where
+    getLogs = (HasqlSession .) . Sessions.getLogs
+
 -- create
 
 instance HasCreateDocument HasqlSession where
@@ -92,6 +111,9 @@ instance HasCreateDocument HasqlSession where
 instance HasCreateTextElement HasqlSession where
     createTextElement = (HasqlSession .) . Sessions.createTextElement
 
+instance HasLogMessage HasqlSession where
+    logMessage = (((HasqlSession .) .) .) . Sessions.logMessage
+
 newtype HasqlTransaction a
     = HasqlTransaction
     { unHasqlTransaction :: Transaction a
@@ -99,7 +121,23 @@ newtype HasqlTransaction a
     deriving (Functor, Applicative, Monad)
 
 runTransaction :: HasqlTransaction a -> Connection -> IO (Either SessionError a)
-runTransaction = (Session.run . transaction Serializable Write) . unHasqlTransaction
+runTransaction tx conn = do
+    result <- runUnlogged tx conn
+    case result of
+        Left err -> do
+            -- If something went wrong here, its fucked up anyway :)
+            -- We could cache the result and insert it into the db as soon as the
+            -- problem is solved, but i think this is currently not required.
+            Right _ <-
+                flip runUnlogged conn $
+                    logMessage Error Nothing Scope.database $
+                        show err
+            return result
+        Right _ -> return result
+  where
+    runUnlogged =
+        (Session.run . transaction Serializable Write)
+            . unHasqlTransaction
 
 -- access rights
 
@@ -150,3 +188,6 @@ instance HasCreateComment HasqlTransaction where
     createComment = ((HasqlTransaction .) .) . Transactions.createComment
     resolveComment = HasqlTransaction . Transactions.resolveComment
     createReply = ((HasqlTransaction .) .) . Transactions.createReply
+
+instance HasLogMessage HasqlTransaction where
+    logMessage = (((HasqlTransaction .) .) .) . Transactions.logMessage

--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -65,6 +65,13 @@ data TextRevisionRef
     = TextRevisionRef
         TextElementRef
         TextRevisionSelector
+    deriving (Generic)
+
+instance ToJSON TextRevisionRef
+
+instance FromJSON TextRevisionRef
+
+instance ToSchema TextRevisionRef
 
 prettyPrintTextRevisionRef :: TextRevisionRef -> String
 prettyPrintTextRevisionRef (TextRevisionRef textElementRef selector) =

--- a/backend/src/Docs/TreeRevision.hs
+++ b/backend/src/Docs/TreeRevision.hs
@@ -66,6 +66,13 @@ data TreeRevisionRef
     = TreeRevisionRef
         DocumentID
         TreeRevisionSelector
+    deriving (Generic)
+
+instance ToJSON TreeRevisionRef
+
+instance FromJSON TreeRevisionRef
+
+instance ToSchema TreeRevisionRef
 
 prettyPrintTreeRevisionRef :: TreeRevisionRef -> String
 prettyPrintTreeRevisionRef (TreeRevisionRef treeElementRef selector) =

--- a/backend/src/Lib.hs
+++ b/backend/src/Lib.hs
@@ -4,13 +4,20 @@ module Lib
 where
 
 import Database (getConnection, migrate)
+import Docs (logMessage)
+import Docs.Hasql.Database (run)
 import Docs.TestDoc (createTestDocument)
+import Logging.Logs (Severity (Info))
+import qualified Logging.Scope as Scope
 import Server
 
 someFunc :: IO ()
 someFunc = do
     Right connection <- getConnection
     Right _ <- migrate connection
+    Right _ <-
+        flip run connection $
+            logMessage Info Nothing Scope.server "Starting Server..."
     -- Datenbank zumüllen :))
     createTestDocument connection
     runServer

--- a/backend/src/Logging/Logs.hs
+++ b/backend/src/Logging/Logs.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Logging.Logs (Source (..), Severity (..), LogMessage (..), Scope) where
+
+import qualified Data.Aeson as Aeson
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
+
+import Docs.UserRef (UserRef)
+
+import Control.Lens ((&), (.~), (?~))
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.HashMap.Strict.InsOrd as InsOrd
+import Data.OpenApi
+    ( HasAdditionalProperties (additionalProperties)
+    , HasProperties (..)
+    , NamedSchema (NamedSchema)
+    , OpenApiType (OpenApiObject)
+    , Referenced (Inline)
+    , ToSchema
+    , declareSchemaRef
+    )
+import qualified Data.OpenApi as OpenApi
+import Data.OpenApi.Lens (HasType (..))
+import Data.OpenApi.Schema (ToSchema (..))
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Logging.Scope (Scope)
+
+data Severity = Info | Warning | Error deriving (Generic)
+
+instance ToJSON Severity
+
+instance FromJSON Severity
+
+instance ToSchema Severity
+
+data Source = User UserRef | System deriving (Generic)
+
+instance ToJSON Source
+
+instance FromJSON Source
+
+instance ToSchema Source
+
+data LogMessage = LogMessage
+    { identifier :: UUID
+    , severity :: Severity
+    , timestamp :: UTCTime
+    , source :: Source
+    , scope :: Scope
+    , content :: Aeson.Value
+    }
+    deriving (Generic)
+
+instance ToJSON LogMessage
+
+instance FromJSON LogMessage
+
+instance ToSchema LogMessage where
+    declareNamedSchema _ = do
+        idSchema <- declareSchemaRef (Proxy :: Proxy UUID)
+        severitySchmema <- declareSchemaRef (Proxy :: Proxy Severity)
+        timestampSchema <- declareSchemaRef (Proxy :: Proxy UTCTime)
+        sourceSchema <- declareSchemaRef (Proxy :: Proxy Source)
+        scopeSchema <- declareSchemaRef (Proxy :: Proxy Text)
+        let contentSchema =
+                mempty
+                    & type_ ?~ OpenApiObject
+                    & additionalProperties ?~ OpenApi.AdditionalPropertiesAllowed True
+        return $
+            NamedSchema (Just "LogMessage") $
+                mempty
+                    & type_
+                        ?~ OpenApiObject
+                    & properties
+                        .~ InsOrd.fromList
+                            [ ("identifier", idSchema)
+                            , ("severity", severitySchmema)
+                            , ("timestamp", timestampSchema)
+                            , ("source", sourceSchema)
+                            , ("scope", scopeSchema)
+                            , ("content", Inline contentSchema)
+                            ]

--- a/backend/src/Logging/Scope.hs
+++ b/backend/src/Logging/Scope.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Logging.Scope
+    ( Scope (..)
+    , server
+    , database
+    , logging
+    , docs
+    , docsText
+    , docsTextRevision
+    , docsTree
+    , docsTreeRevision
+    , docsComment
+    , userManagement
+    ) where
+
+import Data.Text (Text)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+import GHC.Generics (Generic)
+
+newtype Scope = Scope
+    { unScope :: Text
+    }
+    deriving (Generic)
+
+instance ToJSON Scope
+
+instance FromJSON Scope
+
+instance ToSchema Scope
+
+server :: Scope
+server = Scope "server"
+
+database :: Scope
+database = Scope "database"
+
+logging :: Scope
+logging = Scope "logging"
+
+docs :: Scope
+docs = Scope "docs"
+
+docsText :: Scope
+docsText = Scope "docs.text"
+
+docsTextRevision :: Scope
+docsTextRevision = Scope "docs.text.revision"
+
+docsTree :: Scope
+docsTree = Scope "docs.tree"
+
+docsTreeRevision :: Scope
+docsTreeRevision = Scope "docs.tree.revision"
+
+docsComment :: Scope
+docsComment = Scope "docs.comment"
+
+userManagement :: Scope
+userManagement = Scope "user-management"

--- a/backend/src/Server.hs
+++ b/backend/src/Server.hs
@@ -13,6 +13,7 @@ import Control.Lens
 import Control.Monad.IO.Class
 import Crypto.JOSE.JWK (JWK)
 import Data.ByteString.Lazy (readFile)
+import Data.Maybe (fromMaybe)
 import Data.OpenApi
     ( OpenApi
     , description
@@ -22,15 +23,21 @@ import Data.OpenApi
     , title
     , version
     )
+import Data.Time (UTCTime)
 import Data.UUID (toString)
+import qualified Docs
+import qualified Docs.Hasql.Database as DB
+import GHC.Int (Int64)
 import Network.Wai.Handler.Warp (run)
 import Servant
 import Servant.Auth.Server
 import Servant.OpenApi (HasOpenApi (toOpenApi))
 import Server.Auth (AuthMethod)
 import qualified Server.Auth as Auth
+import Server.DTOs.Logs (Logs (Logs))
+import qualified Server.DTOs.Logs as Logs
 import Server.Handlers.AuthHandlers
-import Server.Handlers.DocsHandlers (DocsAPI, docsServer)
+import Server.Handlers.DocsHandlers (DocsAPI, docsServer, getUser, withDB)
 import Server.Handlers.GroupHandlers
 import Server.Handlers.RenderHandlers
 import Server.Handlers.RoleHandlers
@@ -51,10 +58,34 @@ type ProtectedAPI =
         :<|> RoleAPI
         :<|> DocsAPI
         :<|> RenderAPI
+        :<|> LogsAPI
 
 type SwaggerAPI = "swagger.json" :> Get '[JSON] OpenApi
 
 type DocumentedAPI = SwaggerAPI :<|> PublicAPI :<|> ProtectedAPI
+
+type LogsAPI =
+    Auth AuthMethod Auth.Token
+        :> "/logs"
+        :> QueryParam "before" UTCTime
+        :> QueryParam "limit" Int64
+        :> Get '[JSON] Logs
+
+logsHandler
+    :: AuthResult Auth.Token
+    -> Maybe UTCTime
+    -> Maybe Int64
+    -> Handler Logs
+logsHandler auth offset limit = do
+    userID <- getUser auth
+    let limit' = fromMaybe 20 limit
+    messages <- withDB $ DB.run $ Docs.getLogs userID offset limit'
+    return $
+        Logs
+            { Logs.messages = messages
+            , Logs.limit = limit'
+            , Logs.offset = offset
+            }
 
 pingHandler :: Handler String
 pingHandler = return "pong"
@@ -99,6 +130,7 @@ server cookieSett jwtSett =
                 :<|> roleServer
                 :<|> docsServer
                 :<|> renderServer
+                :<|> logsHandler
              )
 
 documentedAPI :: Proxy DocumentedAPI

--- a/backend/src/Server.hs
+++ b/backend/src/Server.hs
@@ -66,7 +66,7 @@ type DocumentedAPI = SwaggerAPI :<|> PublicAPI :<|> ProtectedAPI
 
 type LogsAPI =
     Auth AuthMethod Auth.Token
-        :> "/logs"
+        :> "logs"
         :> QueryParam "before" UTCTime
         :> QueryParam "limit" Int64
         :> Get '[JSON] Logs

--- a/backend/src/Server/DTOs/Logs.hs
+++ b/backend/src/Server/DTOs/Logs.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Server.DTOs.Logs (Logs (..)) where
+
+import GHC.Generics (Generic)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+import Data.Time (UTCTime)
+import Data.Vector (Vector)
+import GHC.Int (Int64)
+import Logging.Logs (LogMessage)
+
+data Logs = Logs
+    { messages :: Vector LogMessage
+    , offset :: Maybe UTCTime
+    , limit :: Int64
+    }
+    deriving (Generic)
+
+instance ToJSON Logs
+
+instance FromJSON Logs
+
+instance ToSchema Logs

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -10,6 +10,8 @@
 module Server.Handlers.DocsHandlers
     ( DocsAPI
     , docsServer
+    , getUser
+    , withDB
     ) where
 
 import Data.Time (UTCTime)
@@ -535,6 +537,12 @@ guardDocsResult (Left err) = throwError $ mapErr err
                     "You are not an admin in group "
                         ++ show groupID
                         ++ "!\n"
+            }
+    mapErr Docs.SuperAdminOnly =
+        err403
+            { errBody =
+                LBS.pack
+                    "This feature is only for super admins!\n"
             }
     mapErr (Docs.DocumentNotFound docID) =
         err400

--- a/scripts/test_api.py
+++ b/scripts/test_api.py
@@ -40,6 +40,12 @@ class Client:
         else:
             print(f"Error: {response.status_code}")
 
+    def logs(self, offset:str|None=None, limit:int|None=None) -> str:
+        return self.get_json(with_query("logs",
+            before=offset,
+            limit=limit
+        ))
+
     def documents(self, user_id: int|None=None, group_id: int|None=None) -> str:
         return self.get_json(with_query(
             f"docs",
@@ -118,4 +124,5 @@ if __name__ == "__main__":
     # print(client.document_tree_full(1, "latest"))
     # print(client.document_history(1, limit=5))
     # print(client.document_text_revision(1, 1, "latest"))
-    print(client.documents(group_id=1))
+    # print(client.documents(group_id=1))
+    print(client.logs())


### PR DESCRIPTION
This PR introduces very simple logging, currently mainly for the docs module.
All logging messages are just dumped into the database and can be accessed via `GET /api/logs`.
<img width="142" height="142" alt="grafik" src="https://github.com/user-attachments/assets/02cde4c0-26de-4b29-908e-614abcab24d4" />
