### PR TITLE
Cleanup home navbar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="static/profile.css">
     <link rel="stylesheet" href="static/toc.css">
     <link rel="stylesheet" href="static/toasts.css">
+    <link rel="stylesheet" href="static/home.css">
   </head>
   <body>
     <script

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -90,10 +90,6 @@ navbar = connect (selectEq identity) $ H.mkComponent
                           (translate (label :: _ "common_home") state.translator)
                           Home
                       ]
-                  -- TODO: This doesn't make sense anymore and should be removed.
-                  --       We keep this for convenience for now.
-                  , HH.li [ HP.classes [ HB.navItem ] ]
-                      [ navButton "Editor" (Editor { docID: 1 }) ]
                   ]
                     <>
                       ( if (maybe false isUserSuperadmin state.user) then
@@ -158,7 +154,7 @@ navbar = connect (selectEq identity) $ H.mkComponent
     let translator = FPOTranslator $ getTranslatorForLanguage lang
     updateStore $ Store.SetTranslator translator
   handleAction ReloadUser = do
-    userWithError <- getUser
+    userWithError <- Store.preventErrorHandlingLocally getUser
     case userWithError of
       Left _ -> H.modify_ _ { user = Nothing } -- TODO error handling
       Right user -> H.modify_ _ { user = Just user }

--- a/frontend/src/FPO/Data/AppError.purs
+++ b/frontend/src/FPO/Data/AppError.purs
@@ -4,12 +4,8 @@ import Prelude
 
 import Affjax (Error(..))
 import Effect.Aff (message)
-import Effect.Aff.Class (class MonadAff)
-import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Route (Route(..))
 import FPO.Translations.Labels (Labels)
 import Foreign (renderForeignError)
-import Halogen as H
 import Simple.I18n.Translator (Translator, label, translate)
 
 -- Add this after your imports
@@ -38,22 +34,6 @@ instance Show AppError where
       <> " (method: "
       <> method
       <> ")"
-
--- Helper function to handle app errors
-handleAppError
-  :: forall st act slots msg m
-   . MonadAff m
-  => Navigate m
-  => AppError
-  -> H.HalogenM st act slots msg m Unit
-handleAppError = case _ of
-  NetworkError _ -> pure unit -- Let component handle this
-  AuthError _ -> navigate Login
-  NotFoundError _ -> navigate Page404
-  ServerError _ -> pure unit -- Let component handle this
-  DataError _ -> pure unit -- Let component handle this
-  AccessDeniedError -> pure unit -- Let component handle this
-  MethodNotAllowedError _ _ -> pure unit -- Let component handle this
 
 -- | Prints an error message based on the type of error.
 -- | The error message is prefixed with the provided string.

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -217,6 +217,7 @@ main = HA.runHalogenAff do
       , language: defaultLang
       , toasts: []
       , totalToasts: 0
+      , handleRequestError: true
       } :: Store.Store
   rootComponent <- runAppM initialStore component
   halogenIO <- runUI rootComponent unit body

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -209,15 +209,13 @@ component =
   renderDocumentOverview state =
     HH.div [ HP.classes [ HB.container ] ]
       [ HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
-          [ HH.div [ HP.classes [ HB.col6 ] ]
-              [ addColumn
-                  state.documentNameFilter
-                  ""
-                  (translate (label :: _ "gp_searchProjects") state.translator)
-                  "bi-search"
-                  HP.InputText
-                  ChangeFilterDocumentName
-              ]
+          [ addColumn
+              state.documentNameFilter
+              ""
+              (translate (label :: _ "gp_searchProjects") state.translator)
+              "bi-search"
+              HP.InputText
+              ChangeFilterDocumentName
           , HH.div [ HP.classes [ HB.col12 ] ]
               [ renderDocumentList docs state ]
           , HH.slot _pagination unit P.component ps SetPage
@@ -551,12 +549,12 @@ component =
         "Title" ->
           TH.sortByF
             order
-            (\a b -> compare (DH.getName a) (DH.getName b))
+            (comparing DH.getName)
             state.documents
         "Last Updated" ->
           TH.sortByF
             (TH.toggleSorting order) -- The newest project should be first.
-            (\a b -> compare (DH.getLastEdited a) (DH.getLastEdited b))
+            (comparing DH.getLastEdited)
             state.documents
         _ -> state.documents -- Ignore other columns.
 

--- a/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/MemberOverview.purs
@@ -199,15 +199,13 @@ component =
   renderMemberOverview state =
     HH.div [ HP.classes [ HB.container ] ]
       [ HH.div [ HP.classes [ HB.row, HB.justifyContentCenter ] ]
-          [ HH.div [ HP.classes [ HB.col6 ] ]
-              [ addColumn
-                  state.memberNameFilter
-                  ""
-                  (translate (label :: _ "gm_searchMembers") state.translator)
-                  "bi-search"
-                  HP.InputText
-                  FilterForMember
-              ]
+          [ addColumn
+              state.memberNameFilter
+              ""
+              (translate (label :: _ "gm_searchMembers") state.translator)
+              "bi-search"
+              HP.InputText
+              FilterForMember
           , HH.div [ HP.classes [ HB.col12 ] ]
               [ renderMemberList docs state ]
           , HH.slot _pagination unit P.component ps SetPage

--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -125,11 +125,11 @@ component =
   handleAction = case _ of
     Initialize -> do
       store <- getStore
-      userWithError <- getUser
+      userWithError <- Store.preventErrorHandlingLocally getUser
       now <- liftEffect nowDateTime
       -- If the user is logged in, fetch their documents and convert them to projects.
       case userWithError of
-        Left _ -> do -- TODO correct error handling for this page
+        Left _ -> do
           H.modify_ _
             { user = Nothing
             , translator = fromFpoTranslator store.translator
@@ -169,12 +169,12 @@ component =
         "Title" ->
           TH.sortByF
             order
-            (\a b -> compare (DH.getName a) (DH.getName b))
+            (comparing DH.getName)
             state.projects
         "Last Updated" ->
           TH.sortByF
             (TH.toggleSorting order) -- The newest project should be first.
-            (\a b -> compare (getEditTimestamp a) (getEditTimestamp b))
+            (comparing getEditTimestamp)
             state.projects
         _ -> state.projects -- Ignore other columns.
 

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -185,9 +185,18 @@ type Labels =
       ::: "gp_searchProjects"
 
       -- | Home Page
+      ::: "home_basicDescription"
+      ::: "home_editing"
+      ::: "home_editingDescription"
+      ::: "home_getStarted"
+      ::: "home_learnMore"
       ::: "home_pleaseLogInA"
       ::: "home_pleaseLogInB"
+      ::: "home_teamCollaboration"
+      ::: "home_teamCollaborationDescription"
       ::: "home_toLogin"
+      ::: "home_versionControl"
+      ::: "home_versionControlDescription"
       ::: "home_yourProjects"
 
       -- | Login Page

--- a/frontend/src/FPO/Translations/Page/Home.purs
+++ b/frontend/src/FPO/Translations/Page/Home.purs
@@ -4,24 +4,59 @@ import Record.Extra (type (:::), SNil)
 import Simple.I18n.Translation (Translation, fromRecord)
 
 type HomeLabels =
-  ( "home_pleaseLogInA"
+  ( "home_basicDescription"
+      ::: "home_editing"
+      ::: "home_editingDescription"
+      ::: "home_getStarted"
+      ::: "home_learnMore"
+      ::: "home_pleaseLogInA"
       ::: "home_pleaseLogInB"
+      ::: "home_teamCollaboration"
+      ::: "home_teamCollaborationDescription"
       ::: "home_toLogin"
+      ::: "home_versionControl"
+      ::: "home_versionControlDescription"
       ::: "home_yourProjects"
       ::: SNil
   )
 
 enHome :: Translation HomeLabels
 enHome = fromRecord
-  { home_pleaseLogInA: "Please "
+  { home_basicDescription:
+      "Collaborative platform for creating and managing Fachprüfungsordnungen with version control and advanced editing tools."
+  , home_editing: "Advanced Editing"
+  , home_editingDescription:
+      "Write using a dedicated markup language with live preview."
+  , home_getStarted: "Get Started"
+  , home_learnMore: "Learn More"
+  , home_pleaseLogInA: "Please "
   , home_pleaseLogInB: " to see your projects."
+  , home_teamCollaboration: "Team Collaboration"
+  , home_teamCollaborationDescription:
+      "Create projects, manage groups, and collaborate with university personnel."
   , home_toLogin: "log in"
+  , home_versionControl: "Version Control"
+  , home_versionControlDescription:
+      "Track changes and maintain document history for all regulations."
   , home_yourProjects: "Your Projects"
   }
 
 deHome :: Translation HomeLabels
 deHome = fromRecord
-  { home_pleaseLogInA: "Bitte "
+  { home_basicDescription:
+      "Kollaborative Plattform zur Erstellung und Verwaltung von Fachprüfungsordnungen mit Versionskontrolle und erweiterten Bearbeitungswerkzeugen."
+  , home_editing: "Fortgeschrittene Bearbeitung"
+  , home_editingDescription:
+      "Schreibe mit einer dedizierten Auszeichnungssprache und Live-Vorschau."
+  , home_getStarted: "Loslegen"
+  , home_learnMore: "Mehr erfahren"
+  , home_teamCollaboration: "Teamarbeit"
+  , home_teamCollaborationDescription:
+      "Erstelle Projekte, verwalte Gruppen und arbeite mit Universitätsmitarbeitern zusammen."
+  , home_versionControl: "Versionskontrolle"
+  , home_versionControlDescription:
+      "Verfolge Änderungen und pflege die Dokumentenhistorie für alle Ordnungen."
+  , home_pleaseLogInA: "Bitte "
   , home_pleaseLogInB: ", damit Du deine Projekte sehen kannst."
   , home_toLogin: "logge Dich ein"
   , home_yourProjects: "Deine Projekte"

--- a/frontend/src/FPO/UI/SmoothScroll.js
+++ b/frontend/src/FPO/UI/SmoothScroll.js
@@ -1,0 +1,6 @@
+export const smoothScrollToElementImpl = (elementId) => () => {
+  const element = document.getElementById(elementId);
+  if (element) {
+    element.scrollIntoView({ behavior: 'smooth' });
+  }
+};

--- a/frontend/src/FPO/UI/SmoothScroll.purs
+++ b/frontend/src/FPO/UI/SmoothScroll.purs
@@ -1,0 +1,12 @@
+module FPO.UI.SmoothScroll
+  ( smoothScrollToElement
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+
+foreign import smoothScrollToElementImpl :: String -> Effect Unit
+
+smoothScrollToElement :: String -> Effect Unit
+smoothScrollToElement = smoothScrollToElementImpl

--- a/frontend/static/home.css
+++ b/frontend/static/home.css
@@ -1,0 +1,14 @@
+.hero-bg {
+  background: linear-gradient(
+    180deg, 
+    #f8f9fa 0%, 
+    #91b0e9 30%,
+    #91b0e9 60%,
+    #c8d2e2 90%
+  );
+  min-height: 100vh;
+}
+
+.slanted-bottom {
+  clip-path: polygon(0 0, 100% 0, 100% 85%, 0 100%);
+}


### PR DESCRIPTION
This PR finally removes the Editor tab from the navbar and overhauls the home view shown when not logged in (welcome screen).

This PR also fixes a bug where the user would always be redirected from Home to Login when not logged in, with an accompanying authentification error toast. 

Closes #365.