### PR TITLE
Disable scrollbar for completele pages

### DIFF
--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -37,6 +37,7 @@ import FPO.Translations.Translator
   , detectBrowserLanguage
   , getTranslatorForLanguage
   )
+import FPO.UI.Style as Style
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -132,6 +133,7 @@ component =
         , HB.p0
         , HB.overflowYAuto
         , HB.overflowXHidden
+        , Style.disableScrollbar
         ]
     ]
     [ HH.slot_ _navbar unit Navbar.navbar unit

--- a/frontend/src/FPO/UI/Style.purs
+++ b/frontend/src/FPO/UI/Style.purs
@@ -33,3 +33,9 @@ cyanStyle = HP.classes
   , HB.textDark
   , responsiveButton
   ]
+
+-- | A class to disable scrollbars in a cross-browser compatible way.
+-- | This class can be applied to any scrollable container to hide
+-- | the scrollbar while still allowing scrolling functionality.
+disableScrollbar ∷ HH.ClassName
+disableScrollbar = HH.ClassName "disable-scrollbar"

--- a/frontend/static/home.css
+++ b/frontend/static/home.css
@@ -12,3 +12,12 @@
 .slanted-bottom {
   clip-path: polygon(0 0, 100% 0, 100% 85%, 0 100%);
 }
+
+/* Remove scroll indicator */
+.disable-scrollbar {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* IE and Edge */
+}
+.disable-scrollbar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}


### PR DESCRIPTION
This commit removes the scrollbar from the main content area (all pages) of the application. The user can still scroll, if necessary, but this is necessary to improve the visual appearance of the application (otherwise, the the scrollbar would push the navbar to the left on some pages). The scrollbar is still visible in modals and other scrollable containers (like the TOC or editor).