### PR TITLE
Backend Docs: View Entire Document at a Specific Revision

### DIFF
--- a/backend/migrations/004_docs.up.sql
+++ b/backend/migrations/004_docs.up.sql
@@ -12,10 +12,10 @@ CREATE TABLE IF NOT EXISTS doc_text_elements (
     document BIGINT REFERENCES docs (id)
 );
 
-CREATE SEQUENCE doc_text_revision_seq;
+CREATE SEQUENCE doc_revision_seq;
 
 CREATE TABLE IF NOT EXISTS doc_text_revisions (
-    id BIGINT PRIMARY KEY NOT NULL DEFAULT nextval('doc_text_revision_seq'),
+    id BIGINT PRIMARY KEY NOT NULL DEFAULT nextval('doc_revision_seq'),
     text_element BIGINT NOT NULL REFERENCES doc_text_elements (id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     author UUID NOT NULL REFERENCES users (id),
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS doc_tree_edges (
 );
 
 CREATE TABLE IF NOT EXISTS doc_tree_revisions (
-    id BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    id BIGINT PRIMARY KEY NOT NULL DEFAULT nextval('doc_revision_seq'),
     document BIGINT NOT NULL REFERENCES docs (id),
     creation_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     author UUID NOT NULL REFERENCES users (id),

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -493,8 +493,8 @@ guardExistsTreeRevision allowLatestNothing ref@(TreeRevisionRef docID selector) 
     guardExistsDocument docID
     existsTreeRevision <- lift $ DB.existsTreeRevision ref
     let considerExistant = case selector of
-            TreeRevision.Latest -> existsTreeRevision || allowLatestNothing
             TreeRevision.Specific _ -> existsTreeRevision
+            _ -> existsTreeRevision || allowLatestNothing
     unless considerExistant $
         throwError (TreeRevisionNotFound ref)
 
@@ -519,8 +519,8 @@ guardExistsTextRevision allowLatestNothing ref@(TextRevisionRef elementRef selec
     guardExistsTextElement elementRef
     existsTextRevision <- lift $ DB.existsTextRevision ref
     let considerExistant = case selector of
-            TextRevision.Latest -> existsTextRevision || allowLatestNothing
             TextRevision.Specific _ -> existsTextRevision
+            _ -> existsTextRevision || allowLatestNothing
     unless considerExistant $
         throwError (TextRevisionNotFound ref)
 

--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -11,12 +11,15 @@ module Docs
     , createTextElement
     , createTextRevision
     , getTextElementRevision
+    , getDocumentRevisionText
     , getTreeRevision
+    , getDocumentRevisionTree
     , createTreeRevision
     , getTextHistory
     , getTreeHistory
     , getDocumentHistory
     , getTreeWithLatestTexts
+    , getDocumentRevision
     , createComment
     , getComments
     , resolveComment
@@ -24,7 +27,7 @@ module Docs
     , getLogs
     ) where
 
-import Control.Monad (unless)
+import Control.Monad (join, unless)
 import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.Trans.Class (lift)
 import Data.Foldable (find)
@@ -58,6 +61,7 @@ import Docs.Database
     , HasGetDocument
     , HasGetDocumentHistory
     , HasGetLogs
+    , HasGetRevisionKey
     , HasGetTextElementRevision
     , HasGetTextHistory
     , HasGetTreeHistory
@@ -69,6 +73,13 @@ import Docs.Database
 import qualified Docs.Database as DB
 import Docs.Document (Document, DocumentID)
 import Docs.DocumentHistory (DocumentHistory)
+import Docs.FullDocument (FullDocument (FullDocument))
+import qualified Docs.FullDocument as FullDocument
+import Docs.Revision
+    ( RevisionRef (RevisionRef)
+    , textRevisionRefFor
+    , treeRevisionRefFor
+    )
 import Docs.TextElement
     ( TextElement
     , TextElementID
@@ -103,6 +114,7 @@ data Error
     | NoPermissionInGroup GroupID
     | SuperAdminOnly
     | DocumentNotFound DocumentID
+    | RevisionNotFound RevisionRef
     | TextElementNotFound TextElementRef
     | TextRevisionNotFound TextRevisionRef
     | TreeRevisionNotFound TreeRevisionRef
@@ -295,6 +307,23 @@ getTextElementRevision userID ref = logged userID Scope.docsTextRevision $
         guardExistsTextRevision True ref
         lift $ DB.getTextElementRevision ref
 
+getDocumentRevisionText
+    :: (HasGetTextElementRevision m, HasGetRevisionKey m, HasLogMessage m)
+    => UserID
+    -> RevisionRef
+    -> TextElementID
+    -> m (Result (Maybe TextElementRevision))
+getDocumentRevisionText userID ref@(RevisionRef docID _) textID =
+    logged userID Scope.docsTextRevision $ runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsDocument docID
+        lift $ do
+            key <- DB.getRevisionKey ref
+            let textRef = TextElementRef docID textID
+            result <-
+                mapM (DB.getTextElementRevision . textRevisionRefFor textRef) key
+            return $ join result
+
 createTreeRevision
     :: (HasCreateTreeRevision m, HasLogMessage m)
     => UserID
@@ -317,11 +346,27 @@ getTreeRevision
     => UserID
     -> TreeRevisionRef
     -> m (Result (Maybe (TreeRevision TextElement)))
-getTreeRevision userID ref@(TreeRevisionRef docID _) = logged userID Scope.docsTreeRevision $
-    runExceptT $ do
-        guardPermission Read docID userID
-        guardExistsTreeRevision True ref
-        lift $ DB.getTreeRevision ref
+getTreeRevision userID ref@(TreeRevisionRef docID _) =
+    logged userID Scope.docsTreeRevision $
+        runExceptT $ do
+            guardPermission Read docID userID
+            guardExistsTreeRevision True ref
+            lift $ DB.getTreeRevision ref
+
+getDocumentRevisionTree
+    :: (HasGetTreeRevision m, HasGetRevisionKey m, HasLogMessage m)
+    => UserID
+    -> RevisionRef
+    -> m (Result (Maybe (TreeRevision TextElement)))
+getDocumentRevisionTree userID ref@(RevisionRef docID _) =
+    logged userID Scope.docsTreeRevision $
+        runExceptT $ do
+            guardPermission Read docID userID
+            guardExistsDocument docID
+            lift $ do
+                key <- DB.getRevisionKey ref
+                result <- mapM (DB.getTreeRevision . treeRevisionRefFor docID) key
+                return $ join result
 
 getTextHistory
     :: (HasGetTextHistory m, HasLogMessage m)
@@ -380,6 +425,46 @@ getTreeWithLatestTexts userID revision = logged userID Scope.docs $ runExceptT $
         DB.getTextElementRevision
             . (`TextRevisionRef` TextRevision.Latest)
             . TextElementRef docID
+    getter' = (<&> (>>= elementRevisionToRevision)) . getter
+    elementRevisionToRevision (TextElementRevision _ rev) = rev
+
+getDocumentRevision
+    :: ( HasGetTreeRevision m
+       , HasGetTextElementRevision m
+       , HasGetRevisionKey m
+       , HasGetDocument m
+       , HasLogMessage m
+       )
+    => UserID
+    -> RevisionRef
+    -> m (Result FullDocument)
+getDocumentRevision userID ref@(RevisionRef docID _) =
+    logged userID Scope.docs $ runExceptT $ do
+        guardPermission Read docID userID
+        guardExistsDocument docID
+        maybeDocument <- lift $ DB.getDocument docID
+        document <- maybe (throwError $ DocumentNotFound docID) pure maybeDocument
+        lift $ do
+            key <- DB.getRevisionKey ref
+            result <- mapM (DB.getTreeRevision . treeRevisionRefFor docID) key
+            let tree = join result
+            body <- mapM (TreeRevision.withTextRevisions getter') tree
+            return
+                FullDocument
+                    { FullDocument.header = document
+                    , FullDocument.body = body
+                    }
+  where
+    getter textID = do
+        key <- DB.getRevisionKey ref
+        result <-
+            mapM
+                ( DB.getTextElementRevision
+                    . textRevisionRefFor
+                        (TextElementRef docID textID)
+                )
+                key
+        return $ join result
     getter' = (<&> (>>= elementRevisionToRevision)) . getter
     elementRevisionToRevision (TextElementRevision _ rev) = rev
 

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -22,6 +22,7 @@ module Docs.Database
     , HasExistsComment (..)
     , HasGetLogs (..)
     , HasLogMessage (..)
+    , HasGetRevisionKey (..)
     ) where
 
 import Data.Text (Text)
@@ -36,6 +37,7 @@ import Data.Aeson (ToJSON)
 import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef, Message)
 import Docs.Document (Document, DocumentID)
 import Docs.DocumentHistory (DocumentHistory)
+import Docs.Revision (RevisionKey, RevisionRef)
 import Docs.TextElement
     ( TextElement
     , TextElementID
@@ -123,6 +125,9 @@ class (HasIsSuperAdmin m) => HasGetLogs m where
         -- ^ limit
         -> m (Vector LogMessage)
         -- ^ log messages
+
+class (HasExistsDocument m) => HasGetRevisionKey m where
+    getRevisionKey :: RevisionRef -> m (Maybe RevisionKey)
 
 -- create
 

--- a/backend/src/Docs/FullDocument.hs
+++ b/backend/src/Docs/FullDocument.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Docs.FullDocument (FullDocument (..)) where
+
+import Docs.Document (Document)
+import Docs.TextRevision (TextElementRevision)
+import Docs.TreeRevision (TreeRevision)
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.OpenApi (ToSchema)
+import GHC.Generics (Generic)
+
+data FullDocument = FullDocument
+    { header :: Document
+    , body :: Maybe (TreeRevision TextElementRevision)
+    }
+    deriving (Generic)
+
+instance ToJSON FullDocument
+
+instance FromJSON FullDocument
+
+instance ToSchema FullDocument

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -103,6 +103,9 @@ instance HasGetComments HasqlSession where
 instance HasGetLogs HasqlSession where
     getLogs = (HasqlSession .) . Sessions.getLogs
 
+instance HasGetRevisionKey HasqlSession where
+    getRevisionKey = HasqlSession . Sessions.getRevisionKey
+
 -- create
 
 instance HasCreateDocument HasqlSession where

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -21,6 +21,7 @@ module Docs.Hasql.Sessions
     , getComments
     , logMessage
     , getLogs
+    , getRevisionKey
     ) where
 
 import Data.Functor ((<&>))
@@ -49,6 +50,7 @@ import Docs.Hash (Hash)
 import qualified Docs.Hasql.Statements as Statements
 import qualified Docs.Hasql.Transactions as Transactions
 import Docs.Hasql.TreeEdge (TreeEdgeChild (..))
+import Docs.Revision (RevisionID, RevisionKey)
 import Docs.TextElement
     ( TextElement
     , TextElementID
@@ -216,3 +218,6 @@ getLogs
     -> Session (Vector LogMessage)
     -- ^ log messages
 getLogs = curry (`statement` Statements.getLogs)
+
+getRevisionKey :: DocumentID -> RevisionID -> Session (Maybe RevisionKey)
+getRevisionKey = curry (`statement` Statements.getRevisionKey)

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -50,7 +50,7 @@ import Docs.Hash (Hash)
 import qualified Docs.Hasql.Statements as Statements
 import qualified Docs.Hasql.Transactions as Transactions
 import Docs.Hasql.TreeEdge (TreeEdgeChild (..))
-import Docs.Revision (RevisionID, RevisionKey)
+import Docs.Revision (RevisionKey, RevisionRef (RevisionRef))
 import Docs.TextElement
     ( TextElement
     , TextElementID
@@ -219,5 +219,6 @@ getLogs
     -- ^ log messages
 getLogs = curry (`statement` Statements.getLogs)
 
-getRevisionKey :: DocumentID -> RevisionID -> Session (Maybe RevisionKey)
-getRevisionKey = curry (`statement` Statements.getRevisionKey)
+getRevisionKey :: RevisionRef -> Session (Maybe RevisionKey)
+getRevisionKey (RevisionRef docID revID) =
+    statement (docID, revID) Statements.getRevisionKey

--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -910,7 +910,7 @@ getTreeRevision =
                 where
                     tr.document = $1 :: int8
                     and ($2 :: int8? is null or tr.id = $2 :: int8?)
-                    and ($3 :: timestamptz? is null or ts.creation_ts <= $3 :: timestamptz?)
+                    and ($3 :: timestamptz? is null or tr.creation_ts <= $3 :: timestamptz?)
                 order by
                     tr.creation_ts desc
                 limit 1

--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -42,6 +42,7 @@ module Docs.Hasql.Statements
     , existsComment
     , getLogs
     , logMessage
+    , getRevisionKey
     ) where
 
 import Control.Applicative ((<|>))
@@ -92,6 +93,8 @@ import Docs.Hasql.TreeEdge
     , TreeEdgeChildRef (..)
     )
 import qualified Docs.Hasql.TreeEdge as TreeEdge
+import Docs.Revision (RevisionID (unRevisionID), RevisionKey (RevisionKey))
+import qualified Docs.Revision as Revision
 import Docs.TextElement
     ( TextElement (TextElement)
     , TextElementID (..)
@@ -106,6 +109,7 @@ import Docs.TextRevision
     , TextRevisionID (..)
     , TextRevisionRef (..)
     , TextRevisionSelector (..)
+    , latestTextRevisionAsOf
     , specificTextRevision
     )
 import qualified Docs.TextRevision as TextRevision
@@ -116,6 +120,7 @@ import Docs.TreeRevision
     , TreeRevisionHeader (TreeRevisionHeader)
     , TreeRevisionID (..)
     , TreeRevisionRef (..)
+    , latestTreeRevisionAsOf
     , specificTreeRevision
     )
 import qualified Docs.TreeRevision as TreeRevision
@@ -159,6 +164,7 @@ existsTreeRevision =
                 WHERE
                     document = $1 :: int8
                     AND ($2 :: int8? IS NULL OR id = $2 :: int8?)
+                    AND ($3 :: timestamptz? IS NULL OR creation_ts <= $3 :: timestamptz?)
             ) :: bool
         |]
 
@@ -193,6 +199,7 @@ existsTextRevision =
                     te.document = $1 :: int8
                     AND tr.text_element = $2 :: int8
                     AND ($3 :: int8? IS NULL OR tr.id = $3 :: int8?)
+                    AND ($4 :: timestamptz? IS NULL OR tr.creation_ts <= $4 :: timestamptz?)
             ) :: bool
         |]
 
@@ -574,7 +581,7 @@ getTextRevision
         ((TextRevisionID -> m (Vector CommentAnchor)) -> m (Maybe TextRevision))
 getTextRevision =
     lmap
-        (bimap unTextElementID ((unTextRevisionID <$>) . specificTextRevision))
+        mapInput
         $ rmap
             (\row f -> mapM (`uncurryTextRevision` f) row)
             [maybeStatement|
@@ -590,10 +597,17 @@ getTextRevision =
                 where
                     tr.text_element = $1 :: int8
                     and ($2 :: int8? is null or tr.id = $2 :: int8?)
+                    and ($3 :: timestamptz? is null or tr.creation_ts <= $3 :: timestamptz?)
                 order by
                     tr.creation_ts desc
                 limit 1
             |]
+  where
+    mapInput (textID, selector) =
+        ( unTextElementID textID
+        , unTextRevisionID <$> specificTextRevision selector
+        , latestTextRevisionAsOf selector
+        )
 
 getTextRevisionHistory
     :: Statement (TextElementRef, Maybe UTCTime, Int64) (Vector TextRevisionHeader)
@@ -676,16 +690,19 @@ getTextElementRevision =
                     te.document = $1 :: int8
                     and te.id = $2 :: int8
                     and ($3 :: int8? is null or tr.id = $3 :: int8?)
+                    and ($4 :: timestamptz? is null or tr.creation_ts <= $4 :: timestamptz?)
                 order by
                     tr.creation_ts desc
                 limit 1
             |]
 
-uncurryTextRevisionRef :: TextRevisionRef -> (Int64, Int64, Maybe Int64)
+uncurryTextRevisionRef
+    :: TextRevisionRef -> (Int64, Int64, Maybe Int64, Maybe UTCTime)
 uncurryTextRevisionRef (TextRevisionRef (TextElementRef docID textID) revision) =
     ( unDocumentID docID
     , unTextElementID textID
     , unTextRevisionID <$> specificTextRevision revision
+    , latestTextRevisionAsOf revision
     )
 
 getTreeNode :: Statement Hash NodeHeader
@@ -893,14 +910,18 @@ getTreeRevision =
                 where
                     tr.document = $1 :: int8
                     and ($2 :: int8? is null or tr.id = $2 :: int8?)
+                    and ($3 :: timestamptz? is null or ts.creation_ts <= $3 :: timestamptz?)
                 order by
                     tr.creation_ts desc
                 limit 1
             |]
 
-uncurryTreeRevisionRef :: TreeRevisionRef -> (Int64, Maybe Int64)
+uncurryTreeRevisionRef :: TreeRevisionRef -> (Int64, Maybe Int64, Maybe UTCTime)
 uncurryTreeRevisionRef (TreeRevisionRef docID selector) =
-    (unDocumentID docID, unTreeRevisionID <$> specificTreeRevision selector)
+    ( unDocumentID docID
+    , unTreeRevisionID <$> specificTreeRevision selector
+    , latestTreeRevisionAsOf selector
+    )
 
 getTreeRevisionHistory
     :: Statement (DocumentID, Maybe UTCTime, Int64) (Vector TreeRevisionHeader)
@@ -998,6 +1019,45 @@ getDocumentRevisionHistory =
             |]
   where
     mapInput (docID, time, limit) = (unDocumentID docID, time, limit)
+
+uncurryRevisionKey :: (UTCTime, Int64, Maybe Int64, Int64) -> RevisionKey
+uncurryRevisionKey (timestamp, docID, maybeTextID, revID) =
+    RevisionKey
+        { Revision.timestamp = timestamp
+        , Revision.revision = maybe tree text maybeTextID
+        }
+  where
+    tree =
+        Revision.Tree $
+            TreeRevisionRef (DocumentID docID) $
+                TreeRevision.Specific $
+                    TreeRevisionID revID
+    text textID =
+        Revision.Text $
+            TextRevisionRef (TextElementRef (DocumentID docID) (TextElementID textID)) $
+                TextRevision.Specific $
+                    TextRevisionID revID
+
+getRevisionKey
+    :: Statement
+        (DocumentID, RevisionID)
+        (Maybe RevisionKey)
+getRevisionKey =
+    lmap (bimap unDocumentID unRevisionID) $
+        rmap
+            (uncurryRevisionKey <$>)
+            [maybeStatement|
+                SELECT
+                    creation_ts :: TIMESTAMPTZ,
+                    document :: int8,
+                    text_element :: int8?,
+                    id :: int8
+                FROM
+                    doc_revisions
+                WHERE
+                    document = $1 :: int8
+                    AND id = $2 :: int8
+        |]
 
 -- Natürlich schreibe ich dir einen Kommentar, der sagt, dass hier das UserManagement beginnt!
 

--- a/backend/src/Docs/Revision.hs
+++ b/backend/src/Docs/Revision.hs
@@ -1,0 +1,23 @@
+module Docs.Revision
+    ( RevisionID (..)
+    , TextOrTree (..)
+    , RevisionKey (..)
+    ) where
+
+import Data.Time (UTCTime)
+import Docs.TextRevision (TextRevisionRef)
+import Docs.TreeRevision (TreeRevisionRef)
+import GHC.Int (Int64)
+
+newtype RevisionID = RevisionID
+    { unRevisionID :: Int64
+    }
+
+data TextOrTree
+    = Text TextRevisionRef
+    | Tree TreeRevisionRef
+
+data RevisionKey = RevisionKey
+    { timestamp :: UTCTime
+    , revision :: TextOrTree
+    }

--- a/backend/src/Docs/Revision.hs
+++ b/backend/src/Docs/Revision.hs
@@ -1,23 +1,125 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Docs.Revision
     ( RevisionID (..)
     , TextOrTree (..)
     , RevisionKey (..)
+    , RevisionRef (..)
+    , textRevisionRefFor
+    , treeRevisionRefFor
+    , prettyPrintRevisionRef
     ) where
 
+import Control.Lens ((?~))
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
+import Data.Function ((&))
+import Data.OpenApi
+    ( HasExclusiveMinimum (exclusiveMinimum)
+    , HasMinimum (minimum_)
+    , HasType (type_)
+    , OpenApiType (OpenApiInteger)
+    , ToSchema
+    )
+import Data.OpenApi.ParamSchema
+import Data.OpenApi.Schema (declareNamedSchema)
+import Data.Proxy (Proxy (Proxy))
 import Data.Time (UTCTime)
-import Docs.TextRevision (TextRevisionRef)
-import Docs.TreeRevision (TreeRevisionRef)
+import Docs.Document (DocumentID (unDocumentID))
+import Docs.TextElement (TextElementRef)
+import Docs.TextRevision (TextRevisionRef (TextRevisionRef))
+import qualified Docs.TextRevision as TextRevision
+import Docs.TreeRevision (TreeRevisionRef (TreeRevisionRef))
+import qualified Docs.TreeRevision as TreeRevision
+import GHC.Generics (Generic)
 import GHC.Int (Int64)
+import Servant (FromHttpApiData (parseUrlPiece))
 
 newtype RevisionID = RevisionID
     { unRevisionID :: Int64
     }
+    deriving (Eq, Ord, Show)
+
+instance ToJSON RevisionID where
+    toJSON = toJSON . unRevisionID
+
+instance FromJSON RevisionID where
+    parseJSON = fmap RevisionID . parseJSON
+
+instance ToSchema RevisionID where
+    declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Int64)
+
+instance ToParamSchema RevisionID where
+    toParamSchema _ =
+        mempty
+            & type_
+                ?~ OpenApiInteger
+            & minimum_
+                ?~ 0
+            & exclusiveMinimum
+                ?~ False
+
+instance FromHttpApiData RevisionID where
+    parseUrlPiece = (RevisionID <$>) . parseUrlPiece
+
+data RevisionRef
+    = RevisionRef DocumentID RevisionID
+    deriving (Generic)
+
+instance ToJSON RevisionRef
+
+instance FromJSON RevisionRef
+
+instance ToSchema RevisionRef
+
+prettyPrintRevisionRef :: RevisionRef -> String
+prettyPrintRevisionRef (RevisionRef docID revID) =
+    show (unDocumentID docID) ++ ".rev." ++ show (unRevisionID revID)
 
 data TextOrTree
     = Text TextRevisionRef
     | Tree TreeRevisionRef
+    deriving (Generic)
+
+instance ToJSON TextOrTree
+
+instance FromJSON TextOrTree
+
+instance ToSchema TextOrTree
 
 data RevisionKey = RevisionKey
     { timestamp :: UTCTime
     , revision :: TextOrTree
     }
+    deriving (Generic)
+
+instance ToJSON RevisionKey
+
+instance FromJSON RevisionKey
+
+instance ToSchema RevisionKey
+
+textRevisionRefFor :: TextElementRef -> RevisionKey -> TextRevisionRef
+textRevisionRefFor
+    forTextRef
+    ( RevisionKey
+            { timestamp = ts
+            , revision = Text ref@(TextRevisionRef textRef _)
+            }
+        )
+        | textRef == forTextRef = ref
+        | undefined = TextRevisionRef forTextRef $ TextRevision.LatestAsOf ts
+textRevisionRefFor forTextRef (RevisionKey {timestamp = ts}) =
+    TextRevisionRef forTextRef $ TextRevision.LatestAsOf ts
+
+treeRevisionRefFor :: DocumentID -> RevisionKey -> TreeRevisionRef
+treeRevisionRefFor
+    forDocID
+    ( RevisionKey
+            { timestamp = ts
+            , revision = Tree ref@(TreeRevisionRef docID _)
+            }
+        )
+        | docID == forDocID = ref
+        | undefined = TreeRevisionRef forDocID $ TreeRevision.LatestAsOf ts
+treeRevisionRefFor forDocID (RevisionKey {timestamp = ts}) =
+    TreeRevisionRef forDocID $ TreeRevision.LatestAsOf ts

--- a/backend/src/Parse.hs
+++ b/backend/src/Parse.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Parse (parseFlexibleTime) where
+
+import Control.Applicative ((<|>))
+import Data.Time (UTCTime)
+import Data.Time.Format (defaultTimeLocale, parseTimeM)
+
+parseFlexibleTime :: String -> Maybe UTCTime
+parseFlexibleTime s =
+    let fmts =
+            [ "%Y-%m-%dT%H:%M:%SZ" -- 2025-08-24T12:34:56Z
+            , "%Y-%m-%dT%H:%M:%S" -- 2025-08-24T12:34:56
+            , "%Y-%m-%dT%H:%M" -- 2025-08-24T12:34
+            , "%Y-%m-%d" -- 2025-08-24
+            , "%H:%M:%S" -- 12:34:56
+            , "%H:%M" -- 12:34
+            ]
+     in foldr
+            (\fmt acc -> acc <|> parseTimeM True defaultTimeLocale fmt s)
+            Nothing
+            fmts

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -82,6 +82,12 @@ import Docs.Comment
     , Message
     , prettyPrintCommentRef
     )
+import Docs.FullDocument (FullDocument)
+import Docs.Revision
+    ( RevisionID
+    , RevisionRef (RevisionRef)
+    , prettyPrintRevisionRef
+    )
 import Server.DTOs.Comments (Comments (Comments))
 import Server.DTOs.CreateComment (CreateComment)
 import qualified Server.DTOs.CreateComment as CreateComment
@@ -119,6 +125,9 @@ type DocsAPI =
                 :<|> GetComments
                 :<|> ResolveComment
                 :<|> PostReply
+                :<|> GetDocumentRevision
+                :<|> GetDocumentRevisionTree
+                :<|> GetDocumentRevisionText
                 :<|> RenderAPI
            )
 
@@ -252,6 +261,30 @@ type PostReply =
         :> ReqBody '[JSON] CreateReply
         :> Post '[JSON] Message
 
+type GetDocumentRevision =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "rev"
+        :> Capture "revisionID" RevisionID
+        :> Get '[JSON] FullDocument
+
+type GetDocumentRevisionTree =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "rev"
+        :> Capture "revisionID" RevisionID
+        :> "tree"
+        :> Get '[JSON] (Maybe (TreeRevision TextElement))
+
+type GetDocumentRevisionText =
+    Auth AuthMethod Auth.Token
+        :> Capture "documentID" DocumentID
+        :> "rev"
+        :> Capture "revisionID" RevisionID
+        :> "text"
+        :> Capture "textElementID" TextElementID
+        :> Get '[JSON] (Maybe TextElementRevision)
+
 docsServer :: Server DocsAPI
 docsServer =
     {-    -} postDocumentHandler
@@ -270,6 +303,9 @@ docsServer =
         :<|> getCommentsHandler
         :<|> resolveCommentHandler
         :<|> createReplyHandler
+        :<|> getDocumentRevisionHandler
+        :<|> getDocumentRevisionTreeHandler
+        :<|> getDocumentRevisionTextHandler
         :<|> renderServer
 
 postDocumentHandler
@@ -481,6 +517,39 @@ createReplyHandler auth docID textID commentID bodyDTO = do
         $ CreateReply.text
             bodyDTO
 
+getDocumentRevisionHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> RevisionID
+    -> Handler FullDocument
+getDocumentRevisionHandler auth docID revID = do
+    userID <- getUser auth
+    withDB $ run $ Docs.getDocumentRevision userID (RevisionRef docID revID)
+
+getDocumentRevisionTreeHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> RevisionID
+    -> Handler (Maybe (TreeRevision TextElement))
+getDocumentRevisionTreeHandler auth docID revID = do
+    userID <- getUser auth
+    withDB $ run $ Docs.getDocumentRevisionTree userID (RevisionRef docID revID)
+
+getDocumentRevisionTextHandler
+    :: AuthResult Auth.Token
+    -> DocumentID
+    -> RevisionID
+    -> TextElementID
+    -> Handler (Maybe TextElementRevision)
+getDocumentRevisionTextHandler auth docID revID textID = do
+    userID <- getUser auth
+    withDB $
+        run $
+            Docs.getDocumentRevisionText
+                userID
+                (RevisionRef docID revID)
+                textID
+
 -- utililty
 
 getUser :: AuthResult Auth.Token -> Handler UserID
@@ -558,6 +627,14 @@ guardDocsResult (Left err) = throwError $ mapErr err
                 LBS.pack $
                     "TextElement "
                         ++ prettyPrintTextElementRef ref
+                        ++ " not found!\n"
+            }
+    mapErr (Docs.RevisionNotFound ref) =
+        err400
+            { errBody =
+                LBS.pack $
+                    "TextRevision "
+                        ++ prettyPrintRevisionRef ref
                         ++ " not found!\n"
             }
     mapErr (Docs.TextRevisionNotFound ref) =


### PR DESCRIPTION
This PR adds endpoints to view the whole document at a specific revision.

# New Enpoints

- `GET /api/docs/{documentID}/rev/{revisionID}`: obtains the whole document at the specified revision.
- `GET /api/docs/{documentID}/rev/{revisionID}/tree`: obtains the tree at the specified revision.
- `GET /api/docs/{documentID}/rev/{revisionID}/text/{textElementID}`: obtains the text at the specified revision.

# Internal

Therefore, text and tree revision ids are now generated from the same sequence. Thus, an id uniquely identifies a revision without the additional knowledge of whether it is a text or tree revision id.