### PR TITLE
Backend Docs: `RevisionSelector` For Document Revisions

### DIFF
--- a/backend/src/Docs/Revision.hs
+++ b/backend/src/Docs/Revision.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Docs.Revision
     ( RevisionID (..)
     , TextOrTree (..)
     , RevisionKey (..)
     , RevisionRef (..)
+    , RevisionSelector (..)
+    , specificRevision
+    , latestRevisionAsOf
     , textRevisionRefFor
     , treeRevisionRefFor
     , prettyPrintRevisionRef
@@ -12,17 +16,27 @@ module Docs.Revision
 
 import Control.Lens ((?~))
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
+import qualified Data.Aeson as Aeson
 import Data.Function ((&))
 import Data.OpenApi
-    ( HasExclusiveMinimum (exclusiveMinimum)
+    ( HasEnum (enum_)
+    , HasExclusiveMinimum (exclusiveMinimum)
+    , HasFormat (format)
     , HasMinimum (minimum_)
+    , HasOneOf (oneOf)
     , HasType (type_)
-    , OpenApiType (OpenApiInteger)
+    , NamedSchema (NamedSchema)
+    , OpenApiType (OpenApiInteger, OpenApiString)
+    , Referenced (Inline)
     , ToSchema
+    , declareSchemaRef
     )
 import Data.OpenApi.ParamSchema
 import Data.OpenApi.Schema (declareNamedSchema)
 import Data.Proxy (Proxy (Proxy))
+import Data.Scientific (toBoundedInteger)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time (UTCTime)
 import Docs.Document (DocumentID (unDocumentID))
 import Docs.TextElement (TextElementRef)
@@ -32,7 +46,9 @@ import Docs.TreeRevision (TreeRevisionRef (TreeRevisionRef))
 import qualified Docs.TreeRevision as TreeRevision
 import GHC.Generics (Generic)
 import GHC.Int (Int64)
+import Parse (parseFlexibleTime)
 import Servant (FromHttpApiData (parseUrlPiece))
+import Text.Read (readMaybe)
 
 newtype RevisionID = RevisionID
     { unRevisionID :: Int64
@@ -61,8 +77,80 @@ instance ToParamSchema RevisionID where
 instance FromHttpApiData RevisionID where
     parseUrlPiece = (RevisionID <$>) . parseUrlPiece
 
+-- | Selector for a revision
+data RevisionSelector
+    = Latest
+    | LatestAsOf UTCTime
+    | Specific RevisionID
+    deriving (Show)
+
+instance ToJSON RevisionSelector where
+    toJSON Latest = toJSON ("latest" :: Text)
+    toJSON (LatestAsOf ts) = toJSON ts
+    toJSON (Specific id_) = toJSON id_
+
+instance FromJSON RevisionSelector where
+    parseJSON v = case v of
+        Aeson.String "latest" -> pure Latest
+        Aeson.String _ -> LatestAsOf <$> parseJSON v -- TODO: parseFlexibleTime?
+        Aeson.Number n -> case toBoundedInteger n of
+            Just i -> pure $ Specific $ RevisionID i
+            Nothing -> fail "Invalid number for Int64"
+        _ -> fail "RevisionSelector must be either a string \"latest\" or an integer"
+
+instance ToSchema RevisionSelector where
+    declareNamedSchema _ = do
+        intSchema <- declareSchemaRef (Proxy :: Proxy Int64)
+        timestampSchema <- declareSchemaRef (Proxy :: Proxy UTCTime)
+        let latestSchema =
+                Inline $
+                    mempty
+                        & type_ ?~ OpenApiString
+                        & enum_ ?~ ["latest"]
+        return $
+            NamedSchema (Just "RevisionSelector") $
+                mempty & oneOf ?~ [latestSchema, intSchema, timestampSchema]
+
+instance ToParamSchema RevisionSelector where
+    toParamSchema _ =
+        mempty
+            & oneOf
+                ?~ [ Inline $
+                        mempty
+                            & type_ ?~ OpenApiString
+                            & enum_ ?~ ["latest"]
+                   , Inline $
+                        mempty
+                            & type_ ?~ OpenApiString
+                            & format ?~ "date-time"
+                   , Inline $
+                        mempty
+                            & type_ ?~ OpenApiInteger
+                            & minimum_ ?~ 0
+                            & exclusiveMinimum ?~ False
+                   ]
+
+instance FromHttpApiData RevisionSelector where
+    parseUrlPiece txt
+        | Text.toLower txt == "latest" = Right Latest
+        | otherwise =
+            case readMaybe (Text.unpack txt) of
+                Just i -> Right $ Specific $ RevisionID i
+                Nothing ->
+                    case parseFlexibleTime (Text.unpack txt) of
+                        Just ts -> Right $ LatestAsOf ts
+                        Nothing -> Left $ "Invalid RevisionSelector: " <> txt
+
+specificRevision :: RevisionSelector -> Maybe RevisionID
+specificRevision (Specific id_) = Just id_
+specificRevision _ = Nothing
+
+latestRevisionAsOf :: RevisionSelector -> Maybe UTCTime
+latestRevisionAsOf (LatestAsOf ts) = Just ts
+latestRevisionAsOf _ = Nothing
+
 data RevisionRef
-    = RevisionRef DocumentID RevisionID
+    = RevisionRef DocumentID RevisionSelector
     deriving (Generic)
 
 instance ToJSON RevisionRef
@@ -72,8 +160,8 @@ instance FromJSON RevisionRef
 instance ToSchema RevisionRef
 
 prettyPrintRevisionRef :: RevisionRef -> String
-prettyPrintRevisionRef (RevisionRef docID revID) =
-    show (unDocumentID docID) ++ ".rev." ++ show (unRevisionID revID)
+prettyPrintRevisionRef (RevisionRef docID revSelector) =
+    show (unDocumentID docID) ++ ".rev." ++ show revSelector
 
 data TextOrTree
     = Text TextRevisionRef

--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -177,7 +177,7 @@ instance FromHttpApiData TextRevisionSelector where
                 Nothing ->
                     case parseFlexibleTime (Text.unpack txt) of
                         Just ts -> Right $ LatestAsOf ts
-                        Nothing -> Left $ "Invalid TreeRevisionSelector: " <> txt
+                        Nothing -> Left $ "Invalid TextRevisionSelector: " <> txt
 
 specificTextRevision :: TextRevisionSelector -> Maybe TextRevisionID
 specificTextRevision (Specific id_) = Just id_

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -84,8 +84,8 @@ import Docs.Comment
     )
 import Docs.FullDocument (FullDocument)
 import Docs.Revision
-    ( RevisionID
-    , RevisionRef (RevisionRef)
+    ( RevisionRef (RevisionRef)
+    , RevisionSelector
     , prettyPrintRevisionRef
     )
 import Server.DTOs.Comments (Comments (Comments))
@@ -265,14 +265,14 @@ type GetDocumentRevision =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> Get '[JSON] FullDocument
 
 type GetDocumentRevisionTree =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> "tree"
         :> Get '[JSON] (Maybe (TreeRevision TextElement))
 
@@ -280,7 +280,7 @@ type GetDocumentRevisionText =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> "text"
         :> Capture "textElementID" TextElementID
         :> Get '[JSON] (Maybe TextElementRevision)
@@ -520,34 +520,34 @@ createReplyHandler auth docID textID commentID bodyDTO = do
 getDocumentRevisionHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> Handler FullDocument
-getDocumentRevisionHandler auth docID revID = do
+getDocumentRevisionHandler auth docID rev = do
     userID <- getUser auth
-    withDB $ run $ Docs.getDocumentRevision userID (RevisionRef docID revID)
+    withDB $ run $ Docs.getDocumentRevision userID (RevisionRef docID rev)
 
 getDocumentRevisionTreeHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> Handler (Maybe (TreeRevision TextElement))
-getDocumentRevisionTreeHandler auth docID revID = do
+getDocumentRevisionTreeHandler auth docID rev = do
     userID <- getUser auth
-    withDB $ run $ Docs.getDocumentRevisionTree userID (RevisionRef docID revID)
+    withDB $ run $ Docs.getDocumentRevisionTree userID (RevisionRef docID rev)
 
 getDocumentRevisionTextHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> TextElementID
     -> Handler (Maybe TextElementRevision)
-getDocumentRevisionTextHandler auth docID revID textID = do
+getDocumentRevisionTextHandler auth docID rev textID = do
     userID <- getUser auth
     withDB $
         run $
             Docs.getDocumentRevisionText
                 userID
-                (RevisionRef docID revID)
+                (RevisionRef docID rev)
                 textID
 
 -- utililty


### PR DESCRIPTION
With this PR, all endpoints starting with `/api/docs/{documentID}/rev/{revision}` now also accept date-times or `latest` as `revision`. Previosly, only specific revision ids where allowed.