### PR TITLE
Backend User Management: Resetti Passworti

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,6 +198,13 @@ jobs:
     needs: [tests-pass]
     if: ${{ github.ref == 'refs/heads/main' }}
     timeout-minutes: 60
+    env:
+      MAIL_HOST: ${{ secrets.MAIL_HOST }}
+      MAIL_PORT: ${{ secrets.MAIL_PORT }}
+      MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USER }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      SERVER_HOST: ${{ secrets.SERVER_HOST }}
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.0
@@ -206,6 +213,7 @@ jobs:
           username: ${{ secrets.REMOTE_USER }}
           password: ${{ secrets.REMOTE_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
+          envs: MAIL_HOST,MAIL_PORT,MAIL_ADDRESS,MAIL_USERNAME,MAIL_PASSWORD,SERVER_HOST
           command_timeout: 200m
           script: |
             cd ${{ vars.REPO_PATH }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:bookworm-slim AS base
 
 # install dependencies needed by both build and final
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends libpq5 locales
+    apt-get install -y --no-install-recommends libpq5 locales ca-certificates
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN locale-gen de_DE.UTF-8 && update-locale
 
@@ -19,14 +19,14 @@ FROM base AS build
 # install build tools
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-  g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git \
-  gnupg curl libexpat-dev libpq-dev ca-certificates
+    g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git \
+    gnupg curl libexpat-dev libpq-dev ca-certificates
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install stack
 RUN curl -sSL https://get.haskellstack.org/stable/linux-x86_64.tar.gz | \
-  tar -xz --wildcards --strip-components=1 -C \
-  /usr/local/bin 'stack-*-linux-x86_64/stack'
+    tar -xz --wildcards --strip-components=1 -C \
+    /usr/local/bin 'stack-*-linux-x86_64/stack'
 
 WORKDIR /build
 
@@ -38,10 +38,10 @@ COPY *.cabal ./
 
 # build dependencies
 RUN --mount=type=cache,target=/root/.stack/ \
-  --mount=type=cache,target=/build/.stack-work/ \
-  stack setup && stack build --only-dependencies \
-  --extra-include-dirs=/usr/include/postgresql \
-  --extra-lib-dirs=/usr/lib/x86_64-linux-gnu
+    --mount=type=cache,target=/build/.stack-work/ \
+    stack setup && stack build --only-dependencies \
+    --extra-include-dirs=/usr/include/postgresql \
+    --extra-lib-dirs=/usr/lib/x86_64-linux-gnu
 
 # copy source files
 COPY src/ src/
@@ -49,10 +49,10 @@ COPY app/ app/
 
 # build project
 RUN --mount=type=cache,target=/root/.stack/ \
---mount=type=cache,target=/build/.stack-work/ \
-stack build --copy-bins --local-bin-path /build/bin\
-  --extra-include-dirs=/usr/include/postgresql \
-  --extra-lib-dirs=/usr/lib/x86_64-linux-gnu
+    --mount=type=cache,target=/build/.stack-work/ \
+    stack build --copy-bins --local-bin-path /build/bin\
+    --extra-include-dirs=/usr/include/postgresql \
+    --extra-lib-dirs=/usr/lib/x86_64-linux-gnu
 
 # +------------------------------+
 # |            FINAL             |

--- a/backend/migrations/001_init.up.sql
+++ b/backend/migrations/001_init.up.sql
@@ -10,8 +10,8 @@ INSERT INTO
 VALUES
     (
         '7f59659a-9a46-4ba0-a911-09698107a6ea',
-        'test',
-        'test@test.com',
+        'Merlin',
+        'stu235271@mail.uni-kiel.de',
         '$argon2id$v=19$m=65536,t=2,p=1$07P6YJS1ZkVWh7aA5nBB4A$nhMV4SKqiZp8KqMvKnU1kPwAApPLkrOHcDXUdNA+2eQ'
     );
 

--- a/backend/migrations/007_password_reset.up.sql
+++ b/backend/migrations/007_password_reset.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    used_at TIMESTAMP WITH TIME ZONE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token_hash ON password_reset_tokens (token_hash);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens (user_id);

--- a/backend/package.yaml
+++ b/backend/package.yaml
@@ -24,6 +24,9 @@ dependencies:
   - base >= 4.7 && < 5
   - insert-ordered-containers
   - scientific
+  - smtp-mail
+  - mime-mail
+  - network
   - tuple
   - lens
   - profunctors

--- a/backend/src/Docs/Revision.hs
+++ b/backend/src/Docs/Revision.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Docs.Revision
     ( RevisionID (..)
     , TextOrTree (..)
     , RevisionKey (..)
     , RevisionRef (..)
+    , RevisionSelector (..)
+    , specificRevision
+    , latestRevisionAsOf
     , textRevisionRefFor
     , treeRevisionRefFor
     , prettyPrintRevisionRef
@@ -12,17 +16,27 @@ module Docs.Revision
 
 import Control.Lens ((?~))
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
+import qualified Data.Aeson as Aeson
 import Data.Function ((&))
 import Data.OpenApi
-    ( HasExclusiveMinimum (exclusiveMinimum)
+    ( HasEnum (enum_)
+    , HasExclusiveMinimum (exclusiveMinimum)
+    , HasFormat (format)
     , HasMinimum (minimum_)
+    , HasOneOf (oneOf)
     , HasType (type_)
-    , OpenApiType (OpenApiInteger)
+    , NamedSchema (NamedSchema)
+    , OpenApiType (OpenApiInteger, OpenApiString)
+    , Referenced (Inline)
     , ToSchema
+    , declareSchemaRef
     )
 import Data.OpenApi.ParamSchema
 import Data.OpenApi.Schema (declareNamedSchema)
 import Data.Proxy (Proxy (Proxy))
+import Data.Scientific (toBoundedInteger)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time (UTCTime)
 import Docs.Document (DocumentID (unDocumentID))
 import Docs.TextElement (TextElementRef)
@@ -32,7 +46,9 @@ import Docs.TreeRevision (TreeRevisionRef (TreeRevisionRef))
 import qualified Docs.TreeRevision as TreeRevision
 import GHC.Generics (Generic)
 import GHC.Int (Int64)
+import Parse (parseFlexibleTime)
 import Servant (FromHttpApiData (parseUrlPiece))
+import Text.Read (readMaybe)
 
 newtype RevisionID = RevisionID
     { unRevisionID :: Int64
@@ -61,8 +77,80 @@ instance ToParamSchema RevisionID where
 instance FromHttpApiData RevisionID where
     parseUrlPiece = (RevisionID <$>) . parseUrlPiece
 
+-- | Selector for a revision
+data RevisionSelector
+    = Latest
+    | LatestAsOf UTCTime
+    | Specific RevisionID
+    deriving (Show)
+
+instance ToJSON RevisionSelector where
+    toJSON Latest = toJSON ("latest" :: Text)
+    toJSON (LatestAsOf ts) = toJSON ts
+    toJSON (Specific id_) = toJSON id_
+
+instance FromJSON RevisionSelector where
+    parseJSON v = case v of
+        Aeson.String "latest" -> pure Latest
+        Aeson.String _ -> LatestAsOf <$> parseJSON v -- TODO: parseFlexibleTime?
+        Aeson.Number n -> case toBoundedInteger n of
+            Just i -> pure $ Specific $ RevisionID i
+            Nothing -> fail "Invalid number for Int64"
+        _ -> fail "RevisionSelector must be either a string \"latest\" or an integer"
+
+instance ToSchema RevisionSelector where
+    declareNamedSchema _ = do
+        intSchema <- declareSchemaRef (Proxy :: Proxy Int64)
+        timestampSchema <- declareSchemaRef (Proxy :: Proxy UTCTime)
+        let latestSchema =
+                Inline $
+                    mempty
+                        & type_ ?~ OpenApiString
+                        & enum_ ?~ ["latest"]
+        return $
+            NamedSchema (Just "RevisionSelector") $
+                mempty & oneOf ?~ [latestSchema, intSchema, timestampSchema]
+
+instance ToParamSchema RevisionSelector where
+    toParamSchema _ =
+        mempty
+            & oneOf
+                ?~ [ Inline $
+                        mempty
+                            & type_ ?~ OpenApiString
+                            & enum_ ?~ ["latest"]
+                   , Inline $
+                        mempty
+                            & type_ ?~ OpenApiString
+                            & format ?~ "date-time"
+                   , Inline $
+                        mempty
+                            & type_ ?~ OpenApiInteger
+                            & minimum_ ?~ 0
+                            & exclusiveMinimum ?~ False
+                   ]
+
+instance FromHttpApiData RevisionSelector where
+    parseUrlPiece txt
+        | Text.toLower txt == "latest" = Right Latest
+        | otherwise =
+            case readMaybe (Text.unpack txt) of
+                Just i -> Right $ Specific $ RevisionID i
+                Nothing ->
+                    case parseFlexibleTime (Text.unpack txt) of
+                        Just ts -> Right $ LatestAsOf ts
+                        Nothing -> Left $ "Invalid RevisionSelector: " <> txt
+
+specificRevision :: RevisionSelector -> Maybe RevisionID
+specificRevision (Specific id_) = Just id_
+specificRevision _ = Nothing
+
+latestRevisionAsOf :: RevisionSelector -> Maybe UTCTime
+latestRevisionAsOf (LatestAsOf ts) = Just ts
+latestRevisionAsOf _ = Nothing
+
 data RevisionRef
-    = RevisionRef DocumentID RevisionID
+    = RevisionRef DocumentID RevisionSelector
     deriving (Generic)
 
 instance ToJSON RevisionRef
@@ -72,8 +160,8 @@ instance FromJSON RevisionRef
 instance ToSchema RevisionRef
 
 prettyPrintRevisionRef :: RevisionRef -> String
-prettyPrintRevisionRef (RevisionRef docID revID) =
-    show (unDocumentID docID) ++ ".rev." ++ show (unRevisionID revID)
+prettyPrintRevisionRef (RevisionRef docID revSelector) =
+    show (unDocumentID docID) ++ ".rev." ++ show revSelector
 
 data TextOrTree
     = Text TextRevisionRef

--- a/backend/src/Docs/TextRevision.hs
+++ b/backend/src/Docs/TextRevision.hs
@@ -177,7 +177,7 @@ instance FromHttpApiData TextRevisionSelector where
                 Nothing ->
                     case parseFlexibleTime (Text.unpack txt) of
                         Just ts -> Right $ LatestAsOf ts
-                        Nothing -> Left $ "Invalid TreeRevisionSelector: " <> txt
+                        Nothing -> Left $ "Invalid TextRevisionSelector: " <> txt
 
 specificTextRevision :: TextRevisionSelector -> Maybe TextRevisionID
 specificTextRevision (Specific id_) = Just id_

--- a/backend/src/Lib.hs
+++ b/backend/src/Lib.hs
@@ -9,6 +9,7 @@ import Docs.Hasql.Database (run)
 import Docs.TestDoc (createTestDocument)
 import Logging.Logs (Severity (Info))
 import qualified Logging.Scope as Scope
+import Mail (testMail)
 import Server
 
 someFunc :: IO ()
@@ -19,6 +20,7 @@ someFunc = do
         flip run connection $
             logMessage Info Nothing Scope.server "Starting Server..."
     -- Datenbank zumüllen :))
+    testMail
     createTestDocument connection
     runServer
     return ()

--- a/backend/src/Mail.hs
+++ b/backend/src/Mail.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Mail (testMail, Mail(..), MailSettings(..), sendMailTo, sendMailTo') where
+module Mail (testMail, Mail (..), MailSettings (..), sendMailTo, sendMailTo') where
 
 import Data.Functor ((<&>))
 import Data.Text (Text)

--- a/backend/src/Mail.hs
+++ b/backend/src/Mail.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Mail (testMail) where
+
+import Data.Functor ((<&>))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Network.Mail.Mime (Part, htmlPart, plainPart)
+import Network.Mail.SMTP
+    ( Address (Address)
+    , sendMailWithLoginTLS'
+    , simpleMail
+    )
+import Network.Socket (PortNumber)
+import System.Environment (getEnv)
+
+data MailSettings = MailSettings
+    { host :: String
+    , port :: PortNumber
+    , username :: String
+    , address :: Text
+    , password :: String
+    }
+    deriving (Show)
+
+data Mail = Mail
+    { receiver :: Address
+    , subject :: Text
+    , body :: [Part]
+    }
+    deriving (Show)
+
+testMail :: IO ()
+testMail =
+    sendMailTo
+        Mail
+            { receiver = Address (Just "Fick Anyhow") "finn.evers@outlook.de"
+            , subject = "Hallo, kennen Sie thiserror?"
+            , body = [plainPart "email body", htmlPart "<h1>HTML</h1>"]
+            }
+
+sendMailTo :: Mail -> IO ()
+sendMailTo mail = do
+    settings <- envSettings
+    sendMailTo' settings mail
+
+sendMailTo' :: MailSettings -> Mail -> IO ()
+sendMailTo' settings mail = do
+    print settings
+    print mail
+    sendMailWithLoginTLS'
+        (host settings)
+        (port settings)
+        (username settings)
+        (password settings)
+        mail'
+  where
+    from = Address (Just "Der Fachprüfungsordner") (address settings)
+    to = [receiver mail]
+    -- body = plainPart "email body"
+    -- html = htmlPart "<h1>HTML</h1>"
+    mail' = simpleMail from to [] [] (subject mail) (body mail)
+
+envSettings :: IO MailSettings
+envSettings = do
+    host' <- getEnv "MAIL_HOST"
+    port' <- getEnv "MAIL_PORT" <&> read
+    address' <- getEnv "MAIL_ADDRESS"
+    username' <- getEnv "MAIL_USERNAME"
+    password' <- getEnv "MAIL_PASSWORD"
+    return $
+        MailSettings
+            { host = host'
+            , port = port'
+            , username = username'
+            , address = Text.pack address'
+            , password = password'
+            }

--- a/backend/src/Mail.hs
+++ b/backend/src/Mail.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Mail (testMail) where
+module Mail (testMail, Mail(..), MailSettings(..), sendMailTo, sendMailTo') where
 
 import Data.Functor ((<&>))
 import Data.Text (Text)

--- a/backend/src/Server.hs
+++ b/backend/src/Server.hs
@@ -39,10 +39,10 @@ import qualified Server.DTOs.Logs as Logs
 import Server.Handlers.AuthHandlers
 import Server.Handlers.DocsHandlers (DocsAPI, docsServer, getUser, withDB)
 import Server.Handlers.GroupHandlers
+import Server.Handlers.PasswordResetHandlers
 import Server.Handlers.RenderHandlers
 import Server.Handlers.RoleHandlers
 import Server.Handlers.UserHandlers
-import Server.Handlers.PasswordResetHandlers
 import Prelude hiding (readFile)
 
 type PublicAPI =

--- a/backend/src/Server.hs
+++ b/backend/src/Server.hs
@@ -42,12 +42,14 @@ import Server.Handlers.GroupHandlers
 import Server.Handlers.RenderHandlers
 import Server.Handlers.RoleHandlers
 import Server.Handlers.UserHandlers
+import Server.Handlers.PasswordResetHandlers
 import Prelude hiding (readFile)
 
 type PublicAPI =
     "ping" :> Get '[JSON] String
         :<|> "document" :> Get '[PDF] PDFByteString
         :<|> AuthAPI
+        :<|> PasswordResetAPI
 
 type ProtectedAPI =
     Auth AuthMethod Auth.Token
@@ -123,6 +125,7 @@ server cookieSett jwtSett =
         :<|> ( pingHandler
                 :<|> documentHandler
                 :<|> authServer cookieSett jwtSett
+                :<|> passwordResetServer
              )
         :<|> ( protectedHandler
                 :<|> userServer

--- a/backend/src/Server/Auth/PasswordReset.hs
+++ b/backend/src/Server/Auth/PasswordReset.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Server.Auth.PasswordReset
+    ( PasswordResetRequest (..)
+    , PasswordResetConfirm (..)
+    , PasswordResetToken (..)
+    , PasswordResetAPI
+    ) where
+
+import Data.Aeson (FromJSON)
+import Data.OpenApi (ToSchema)
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
+import GHC.Generics (Generic)
+import Servant.API
+import UserManagement.User (UserID)
+
+-- | Request data for initiating a password reset
+newtype PasswordResetRequest = PasswordResetRequest
+    { resetRequestEmail :: Text
+    }
+    deriving (Generic, FromJSON, ToSchema)
+
+-- | Data for confirming a password reset with token
+data PasswordResetConfirm = PasswordResetConfirm
+    { resetConfirmToken :: Text
+    , resetConfirmNewPassword :: Text
+    }
+    deriving (Generic, FromJSON, ToSchema)
+
+-- | Internal representation of a password reset token
+data PasswordResetToken = PasswordResetToken
+    { tokenId :: UUID
+    , tokenUserId :: UserID
+    , tokenHash :: Text
+    , tokenExpiresAt :: UTCTime
+    , tokenCreatedAt :: UTCTime
+    , tokenUsedAt :: Maybe UTCTime
+    }
+    deriving (Generic, Show, Eq)
+
+-- | API definition for password reset endpoints
+type PasswordResetAPI =
+    "password-reset"
+        :> ( "request" :> ReqBody '[JSON] PasswordResetRequest :> Post '[JSON] NoContent
+                :<|> "confirm" :> ReqBody '[JSON] PasswordResetConfirm :> Post '[JSON] NoContent
+           )

--- a/backend/src/Server/Auth/PasswordReset.hs
+++ b/backend/src/Server/Auth/PasswordReset.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Server.Auth.PasswordReset

--- a/backend/src/Server/Auth/PasswordResetUtil.hs
+++ b/backend/src/Server/Auth/PasswordResetUtil.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Server.Auth.PasswordResetUtil
+    ( generateResetToken
+    , hashToken
+    , validateTokenFormat
+    , createResetUrl
+    , sendPasswordResetEmail
+    , getTokenExpirationTime
+    , TokenValidationResult (..)
+    ) where
+
+import Crypto.Hash.SHA1 (hash)
+import qualified Data.ByteString as BS
+import Data.ByteString.Base64 (decode, encode)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as LT
+import Data.Time
+    ( UTCTime
+    , addUTCTime
+    , defaultTimeLocale
+    , formatTime
+    , getCurrentTime
+    )
+import qualified Mail
+import Network.Mail.Mime (Address (..), htmlPart, plainPart)
+
+-- | Result of token validation
+data TokenValidationResult
+    = TokenValid
+    | TokenInvalid
+    | TokenExpired
+    | TokenAlreadyUsed
+    deriving (Eq, Show)
+
+-- | Generate a cryptographically secure random token
+generateResetToken :: IO Text
+generateResetToken = do
+    -- Generate 32 random bytes (256 bits of entropy) using current time as seed
+    now <- getCurrentTime
+    let timeStr = formatTime defaultTimeLocale "%s%q" now
+    let tokenData = Text.encodeUtf8 $ Text.pack $ "reset_" <> timeStr <> "_token"
+    return $ Text.decodeUtf8 $ encode tokenData
+
+-- | Hash a token for secure storage
+hashToken :: Text -> Text
+hashToken token =
+    let bytes = Text.encodeUtf8 token
+        hashedBytes = hash bytes
+     in Text.decodeUtf8 $ encode hashedBytes
+
+-- | Validate token format (base64 encoded, appropriate length)
+validateTokenFormat :: Text -> Bool
+validateTokenFormat token =
+    case decode (Text.encodeUtf8 token) of
+        Left _ -> False
+        Right decoded -> BS.length decoded > 10 && BS.length decoded < 200
+
+-- | Create a password reset URL with the given token
+createResetUrl :: Text -> Text -> Text
+createResetUrl baseUrl token =
+    baseUrl <> "/reset-password?token=" <> token
+
+-- | Send password reset email to user
+sendPasswordResetEmail :: Text -> Text -> Text -> IO ()
+sendPasswordResetEmail userEmail userName resetUrl = do
+    let mail =
+            Mail.Mail
+                { Mail.receiver = Address (Just userName) userEmail
+                , Mail.subject = "Password Reset - Fachprüfungsordnung"
+                , Mail.body =
+                    [ plainPart (LT.fromStrict plainBody)
+                    , htmlPart (LT.fromStrict htmlBody)
+                    ]
+                }
+    Mail.sendMailTo mail
+  where
+    plainBody =
+        Text.unlines
+            [ "Hello " <> userName <> ","
+            , ""
+            , "You have requested a password reset for your Fachprüfungsordnung account."
+            , ""
+            , "Please click on the following link to reset your password:"
+            , resetUrl
+            , ""
+            , "This link will expire in 1 hour for security reasons."
+            , ""
+            , "If you did not request this password reset, please ignore this email."
+            , "Your password will remain unchanged."
+            , ""
+            , "Best regards,"
+            , "The Fachprüfungsordnung Team"
+            ]
+
+    htmlBody =
+        Text.unlines
+            [ "<html><body>"
+            , "<h2>Password Reset Request</h2>"
+            , "<p>Hello <strong>" <> userName <> "</strong>,</p>"
+            , "<p>You have requested a password reset for your Fachprüfungsordnung account.</p>"
+            , "<p>Please click on the button below to reset your password:</p>"
+            , "<div style='margin: 20px 0;'>"
+            , "  <a href='"
+                <> resetUrl
+                <> "' style='background-color: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;'>Reset Password</a>"
+            , "</div>"
+            , "<p>Or copy and paste this link into your browser:</p>"
+            , "<p><a href='" <> resetUrl <> "'>" <> resetUrl <> "</a></p>"
+            , "<p><strong>Important:</strong> This link will expire in 1 hour for security reasons.</p>"
+            , "<p>If you did not request this password reset, please ignore this email. Your password will remain unchanged.</p>"
+            , "<hr>"
+            , "<p><small>Best regards,<br>The Fachprüfungsordnung Team</small></p>"
+            , "</body></html>"
+            ]
+
+-- | Calculate token expiration time (1 hour from now)
+getTokenExpirationTime :: IO UTCTime
+getTokenExpirationTime = do addUTCTime (60 * 60) <$> getCurrentTime

--- a/backend/src/Server/HandlerUtil.hs
+++ b/backend/src/Server/HandlerUtil.hs
@@ -136,50 +136,50 @@ getGroupOfDocument conn docID = do
 
 -- Specific errors
 errDatabaseConnectionFailed :: ServerError
-errDatabaseConnectionFailed = err500 {errBody = "\"Connection to database failed!\"\n"}
+errDatabaseConnectionFailed = err500 {errBody = "Connection to database failed!"}
 
 errDatabaseAccessFailed :: ServerError
-errDatabaseAccessFailed = err500 {errBody = "\"Database access failed!\"\n"}
+errDatabaseAccessFailed = err500 {errBody = "Database access failed!"}
 
 errFailedToSetRole :: ServerError
-errFailedToSetRole = err500 {errBody = "\"Failed to set role in Database!\"\n"}
+errFailedToSetRole = err500 {errBody = "Failed to set role in Database!"}
 
 errNoMemberOfThisGroup :: ServerError
 errNoMemberOfThisGroup =
     err403
-        { errBody = "\"You have to be Member of the group to perform this action!\"\n"
+        { errBody = "You have to be Member of the group to perform this action!"
         }
 
 errNoAdminOfThisGroup :: ServerError
 errNoAdminOfThisGroup =
     err403
-        { errBody = "\"You have to be Admin of the group to perform this action!\"\n"
+        { errBody = "You have to be Admin of the group to perform this action!"
         }
 
 errNoAdminInAnyGroup :: ServerError
-errNoAdminInAnyGroup = err403 {errBody = "\"You have to be an Admin to perform this action!\"\n"}
+errNoAdminInAnyGroup = err403 {errBody = "You have to be an Admin to perform this action!"}
 
 errSuperAdminOnly :: ServerError
 errSuperAdminOnly =
-    err403 {errBody = "\"You have to be Superadmin to perform this action!\"\n"}
+    err403 {errBody = "You have to be Superadmin to perform this action!"}
 
 errNotLoggedIn :: ServerError
 errNotLoggedIn =
     err401
-        { errBody = "\"Not allowed! You need to be logged in to perform this action.\"\n"
+        { errBody = "Not allowed! You need to be logged in to perform this action."
         }
 
 errUserCreationFailed :: ServerError
-errUserCreationFailed = err500 {errBody = "\"User creation failed!\"\n"}
+errUserCreationFailed = err500 {errBody = "User creation failed!"}
 
 errUserNotFound :: ServerError
-errUserNotFound = err404 {errBody = "\"User not member of this group.\"\n"}
+errUserNotFound = err404 {errBody = "User not member of this group."}
 
 errEmailAlreadyUsed :: ServerError
-errEmailAlreadyUsed = err409 {errBody = "\"Email is already in use.\"\n"}
+errEmailAlreadyUsed = err409 {errBody = "Email is already in use."}
 
 errDocumentDoesNotExist :: ServerError
-errDocumentDoesNotExist = err404 {errBody = "\"Document not found.\"\n"}
+errDocumentDoesNotExist = err404 {errBody = "Document not found."}
 
 errNoPermission :: ServerError
-errNoPermission = err403 {errBody = "\"Insufficient permission to perform this action.\"\n"}
+errNoPermission = err403 {errBody = "Insufficient permission to perform this action."}

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -84,8 +84,8 @@ import Docs.Comment
     )
 import Docs.FullDocument (FullDocument)
 import Docs.Revision
-    ( RevisionID
-    , RevisionRef (RevisionRef)
+    ( RevisionRef (RevisionRef)
+    , RevisionSelector
     , prettyPrintRevisionRef
     )
 import Server.DTOs.Comments (Comments (Comments))
@@ -265,14 +265,14 @@ type GetDocumentRevision =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> Get '[JSON] FullDocument
 
 type GetDocumentRevisionTree =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> "tree"
         :> Get '[JSON] (Maybe (TreeRevision TextElement))
 
@@ -280,7 +280,7 @@ type GetDocumentRevisionText =
     Auth AuthMethod Auth.Token
         :> Capture "documentID" DocumentID
         :> "rev"
-        :> Capture "revisionID" RevisionID
+        :> Capture "revision" RevisionSelector
         :> "text"
         :> Capture "textElementID" TextElementID
         :> Get '[JSON] (Maybe TextElementRevision)
@@ -520,34 +520,34 @@ createReplyHandler auth docID textID commentID bodyDTO = do
 getDocumentRevisionHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> Handler FullDocument
-getDocumentRevisionHandler auth docID revID = do
+getDocumentRevisionHandler auth docID rev = do
     userID <- getUser auth
-    withDB $ run $ Docs.getDocumentRevision userID (RevisionRef docID revID)
+    withDB $ run $ Docs.getDocumentRevision userID (RevisionRef docID rev)
 
 getDocumentRevisionTreeHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> Handler (Maybe (TreeRevision TextElement))
-getDocumentRevisionTreeHandler auth docID revID = do
+getDocumentRevisionTreeHandler auth docID rev = do
     userID <- getUser auth
-    withDB $ run $ Docs.getDocumentRevisionTree userID (RevisionRef docID revID)
+    withDB $ run $ Docs.getDocumentRevisionTree userID (RevisionRef docID rev)
 
 getDocumentRevisionTextHandler
     :: AuthResult Auth.Token
     -> DocumentID
-    -> RevisionID
+    -> RevisionSelector
     -> TextElementID
     -> Handler (Maybe TextElementRevision)
-getDocumentRevisionTextHandler auth docID revID textID = do
+getDocumentRevisionTextHandler auth docID rev textID = do
     userID <- getUser auth
     withDB $
         run $
             Docs.getDocumentRevisionText
                 userID
-                (RevisionRef docID revID)
+                (RevisionRef docID rev)
                 textID
 
 -- utililty

--- a/backend/src/Server/Handlers/PasswordResetHandlers.hs
+++ b/backend/src/Server/Handlers/PasswordResetHandlers.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Server.Handlers.PasswordResetHandlers
+    ( PasswordResetAPI
+    , passwordResetServer
+    , requestPasswordResetHandler
+    , confirmPasswordResetHandler
+    ) where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Password.Argon2
+    ( PasswordHash (unPasswordHash)
+    , hashPassword
+    , mkPassword
+    )
+import Data.Time (getCurrentTime)
+import qualified Hasql.Session as Session
+import Servant
+import Server.Auth.PasswordReset
+import Server.Auth.PasswordResetUtil (getTokenExpirationTime)
+import qualified Server.Auth.PasswordResetUtil as Util
+import Server.HandlerUtil
+import qualified UserManagement.Sessions as Sessions
+import qualified UserManagement.User as User
+
+-- | Server implementation for password reset API
+passwordResetServer :: Server PasswordResetAPI
+passwordResetServer = requestPasswordResetHandler :<|> confirmPasswordResetHandler
+
+-- | Handler for password reset requests
+requestPasswordResetHandler :: PasswordResetRequest -> Handler NoContent
+requestPasswordResetHandler PasswordResetRequest {..} = do
+    conn <- tryGetDBConnection
+
+    -- Check if user exists
+    eUser <- liftIO $ Session.run (Sessions.getUserByEmail resetRequestEmail) conn
+    case eUser of
+        Right (Just user) -> do
+            -- Generate reset token
+            token <- liftIO Util.generateResetToken
+            let tokenHash = Util.hashToken token
+
+            expiresAt <- liftIO getTokenExpirationTime
+
+            -- Store token in database
+            eTokenId <-
+                liftIO $
+                    Session.run
+                        (Sessions.createPasswordResetToken (User.userID user) tokenHash expiresAt)
+                        conn
+
+            case eTokenId of
+                Right _ -> do
+                    -- Create reset URL (you might want to make this configurable)
+                    let resetUrl = Util.createResetUrl "https://batailley.informatik.uni-kiel.de" token
+
+                    -- Send email
+                    liftIO $
+                        Util.sendPasswordResetEmail
+                            (User.userEmail user)
+                            (User.userName user)
+                            resetUrl
+
+                    return NoContent
+                Left _ -> throwError errDatabaseAccessFailed
+        Right Nothing ->
+            -- For security, don't reveal whether email exists
+            -- Just return success but don't send email
+            return NoContent
+        Left _ -> throwError errDatabaseAccessFailed
+
+-- | Handler for password reset confirmation
+confirmPasswordResetHandler :: PasswordResetConfirm -> Handler NoContent
+confirmPasswordResetHandler PasswordResetConfirm {..} = do
+    -- Validate token format
+    if not (Util.validateTokenFormat resetConfirmToken)
+        then throwError $ err400 {errBody = "Invalid token format"}
+        else do
+            conn <- tryGetDBConnection
+            let tokenHash = Util.hashToken resetConfirmToken
+
+            -- Look up token in database
+            eToken <- liftIO $ Session.run (Sessions.getPasswordResetToken tokenHash) conn
+            case eToken of
+                Right (Just (_, userId, _, expiresAt, _, usedAt)) -> do
+                    -- Check if token is already used
+                    case usedAt of
+                        Just _ -> throwError $ err400 {errBody = "Token has already been used"}
+                        Nothing -> do
+                            -- Check if token is expired (redundant with DB query, but good for clarity)
+                            now <- liftIO getCurrentTime
+                            if now > expiresAt
+                                then throwError $ err400 {errBody = "Token has expired"}
+                                else do
+                                    -- Hash new password
+                                    hashedPassword <- liftIO $ hashPassword (mkPassword resetConfirmNewPassword)
+
+                                    -- Update user's password
+                                    eUpdateResult <-
+                                        liftIO $
+                                            Session.run
+                                                (Sessions.updateUserPWHash userId (unPasswordHash hashedPassword))
+                                                conn
+
+                                    case eUpdateResult of
+                                        Right _ -> do
+                                            -- Mark token as used
+                                            _ <-
+                                                liftIO $
+                                                    Session.run
+                                                        (Sessions.markPasswordResetTokenUsed tokenHash)
+                                                        conn
+
+                                            -- Clean up expired tokens (best effort, don't fail if it doesn't work)
+                                            _ <- liftIO $ Session.run Sessions.cleanupExpiredTokens conn
+
+                                            return NoContent
+                                        Left _ -> throwError errDatabaseAccessFailed
+                Right Nothing ->
+                    throwError $ err400 {errBody = "Invalid or expired token"}
+                Left _ -> throwError errDatabaseAccessFailed

--- a/backend/src/UserManagement/Sessions.hs
+++ b/backend/src/UserManagement/Sessions.hs
@@ -31,11 +31,17 @@ module UserManagement.Sessions
     , addExternalPermission
     , updateExternalPermission
     , deleteExternalPermission
+    , createPasswordResetToken
+    , getPasswordResetToken
+    , markPasswordResetTokenUsed
+    , cleanupExpiredTokens
     )
 where
 
 import qualified Data.Bifunctor (second)
 import Data.Text (Text)
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
 import qualified Docs.Document as Document
 import Hasql.Session (Session, statement)
 import qualified UserManagement.DocumentPermission as Permission
@@ -158,3 +164,19 @@ updateExternalPermission uid did perm =
 
 deleteExternalPermission :: User.UserID -> Document.DocumentID -> Session ()
 deleteExternalPermission uid did = statement (uid, did) Statements.deleteExternalPermission
+
+-- Password Reset Functions
+
+createPasswordResetToken :: User.UserID -> Text -> UTCTime -> Session UUID
+createPasswordResetToken uid tokenHash expiresAt = statement (uid, tokenHash, expiresAt) Statements.createPasswordResetToken
+
+getPasswordResetToken
+    :: Text
+    -> Session (Maybe (UUID, User.UserID, Text, UTCTime, UTCTime, Maybe UTCTime))
+getPasswordResetToken tokenHash = statement tokenHash Statements.getPasswordResetToken
+
+markPasswordResetTokenUsed :: Text -> Session ()
+markPasswordResetTokenUsed tokenHash = statement tokenHash Statements.markPasswordResetTokenUsed
+
+cleanupExpiredTokens :: Session ()
+cleanupExpiredTokens = statement () Statements.cleanupExpiredTokens

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,12 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      MAIL_HOST: ${MAIL_HOST}
+      MAIL_PORT: ${MAIL_PORT:-465}
+      MAIL_ADDRESS: ${MAIL_ADDRESS}
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
+      SERVER_HOST: ${SERVER_HOST}
     networks:
       - backend
     depends_on:


### PR DESCRIPTION
Password Reset Functionality

This PR introduces backend support for password resets.
Users who can no longer recall their credentials may now request a reset email containing a secure, time-limited link. Following the link allows them to define a new password, ensuring that access can be safely restored without manual intervention.

Much like the Coastal King of Salzwind, who guides lost sailors back to shore, this flow guides users back to their accounts when they have drifted away from them. Tokens expire with the turning of the tide, and once used, they cannot be invoked again — a safeguard reminiscent of the King’s rule that no wave ever returns unchanged.

Summary

Endpoint to request a reset link by email

Generation of secure, hashed reset tokens with expiration

Database persistence for issued tokens

One-time use enforcement

Endpoint to confirm reset and set a new password

Automatic cleanup of expired tokens

With this, the application becomes less a labyrinth and more a coastline under the watchful presence of the Küstenkönig, who ensures that even those who have forgotten their way may still return.

Release notes:
- N/A