### PR TITLE
Remove entries from user dropdown (Navbar)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,7 @@
     <link rel="stylesheet" href="static/toc.css">
     <link rel="stylesheet" href="static/toasts.css">
     <link rel="stylesheet" href="static/home.css">
+    <link rel="stylesheet" href="static/user-dropdown.css">
   </head>
   <body>
     <script

--- a/frontend/src/FPO/Components/Navbar.purs
+++ b/frontend/src/FPO/Components/Navbar.purs
@@ -24,13 +24,13 @@ import FPO.Translations.Translator
   , getTranslatorForLanguage
   )
 import FPO.Translations.Util (FPOState)
-import FPO.UI.HTML (addClass)
 import Halogen (AttrName(..), ClassName(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
-import Halogen.HTML.Properties (attr, classes, style) as HP
+import Halogen.HTML.Properties (attr, classes, id, style, title) as HP
 import Halogen.HTML.Properties.ARIA (role)
+import Halogen.HTML.Properties.ARIA as HPA
 import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Store.Select (selectEq)
@@ -177,12 +177,15 @@ navbar = connect (selectEq identity) $ H.mkComponent
   userDropdown :: State -> FullUserDto -> H.ComponentHTML Action () m
   userDropdown state user =
     HH.li
-      [ HP.classes [ HB.navItem, HB.dropdown ] ]
+      [ HP.classes [ HB.navItem, HB.dropdown, H.ClassName "user-hover-dropdown" ] ]
       [ HH.a
-          [ HP.classes [ HB.navLink, HB.dropdownToggle ]
-          , role "button"
-          , HP.attr (AttrName "data-bs-toggle") "dropdown"
+          [ HP.classes [ HB.navLink, H.ClassName "user-profile-link" ]
+          , HPA.role "button"
+          , HP.id "userDropdown"
           , HP.attr (AttrName "aria-expanded") "false"
+          , HE.onClick $ const $ Navigate
+              (Profile { loginSuccessful: Nothing, userId: Nothing })
+          , HP.title (translate (label :: _ "prof_profile") state.translator)
           ]
           [ HH.i [ HP.classes [ ClassName "bi-person", HB.me1 ] ] []
           , HH.text $ getUserName user
@@ -191,36 +194,7 @@ navbar = connect (selectEq identity) $ H.mkComponent
           [ HP.classes [ HB.dropdownMenu, HB.dropdownMenuEnd ]
           , HP.attr (AttrName "aria-labelledby") "navbarDarkDropdownMenuLink"
           ]
-          ( [ dropdownEntry
-                (translate (label :: _ "prof_profile") state.translator)
-                "person"
-                (Navigate (Profile { loginSuccessful: Nothing, userId: Nothing }))
-            ]
-              <>
-                ( if isUserSuperadmin user then
-                    [ dropdownEntry
-                        ( translate (label :: _ "au_userManagement")
-                            state.translator
-                        )
-                        "person-exclamation"
-                        (Navigate AdminViewUsers) `addClass` HB.bgWarningSubtle
-                    ]
-                  else []
-                )
-              <>
-                ( if isAdmin user then
-                    [ dropdownEntry
-                        ( translate (label :: _ "au_groupManagement")
-                            state.translator
-                        )
-                        "people"
-                        (Navigate AdminViewGroups) `addClass` HB.bgWarningSubtle
-                    ]
-                  else []
-                )
-              <>
-                [ dropdownEntry "Logout" "box-arrow-right" Logout ]
-          )
+          ([ dropdownEntry "Logout" "box-arrow-right" Logout ])
       ]
 
   -- Creates a dropdown entry with a label, bootstrap icon, and action.

--- a/frontend/static/user-dropdown.css
+++ b/frontend/static/user-dropdown.css
@@ -1,0 +1,131 @@
+ /* Custom CSS for ONLY the user hover dropdown */
+.user-hover-dropdown:hover .dropdown-menu,
+.user-hover-dropdown .dropdown-menu:hover {
+  display: block;
+}
+
+.user-hover-dropdown .dropdown-menu {
+  margin-top: 0.66rem;
+}
+
+.user-hover-dropdown .dropdown-menu {
+  transition: opacity 0.15s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.user-hover-dropdown:hover .dropdown-menu,
+.user-hover-dropdown .dropdown-menu:hover {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Create invisible bridge between name and dropdown - only for user dropdown */
+.user-hover-dropdown::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 0.66rem;
+  background: transparent;
+  z-index: 999;
+}
+
+.user-hover-dropdown:hover::before {
+  display: block;
+}
+
+.user-hover-dropdown .dropdown-menu {
+  background-color: #f7f7f7;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 0.4rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
+  min-width: 80px;
+  position: relative;
+}
+
+/* Triangular arrow pointing up to user name */
+.user-hover-dropdown .dropdown-menu::before {
+  content: '';
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #f7f7f7;
+  z-index: 1001;
+}
+
+/* Arrow border */
+.user-hover-dropdown .dropdown-menu::after {
+  content: '';
+  position: absolute;
+  top: -9px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.user-hover-dropdown .dropdown-item {
+  color: #6c757d;
+  font-size: 0.875rem;
+  padding: 0.2em 0.7rem;
+  border: none;
+  background: none;
+}
+
+.user-hover-dropdown .dropdown-item:hover {
+  background-color: #f2f2f2;
+  color: #495057;
+}
+
+/* User name styling to indicate it's clickable */
+.user-profile-link {
+  position: relative;
+  cursor: pointer;
+  transition: color 0.2s ease;
+  text-decoration: none;
+}
+
+.user-profile-link:hover {
+  color: #085fff !important;
+  text-decoration: none;
+}
+
+.user-profile-link::after {
+  content: '';
+  position: absolute;
+  bottom: 0px;
+  left: 0;
+  right: 0;
+  width: 0;
+  height: 2px;
+  background-color: #5689da;
+  transition: width 0.3s ease;
+  z-index: 999;
+}
+
+.user-profile-link:hover::after {
+  width: 100%;
+}
+
+.user-hover-dropdown {
+  position: relative;
+}
+
+.user-hover-dropdown .dropdown-menu {
+  z-index: 1000;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}


### PR DESCRIPTION
This pull request updates the user dropdown in the navigation bar to provide a more modern, hover-based experience and simplifies the dropdown options. It introduces a new CSS file for custom styling and refactors the dropdown to improve accessibility and user interaction.

**User dropdown UI/UX improvements:**

* Added a new stylesheet `static/user-dropdown.css` for custom styling of the user hover dropdown, including hover behavior, arrow indicators, and improved visual appearance. [[1]](diffhunk://#diff-631a67b45157872ab64aa794cdcd757d77d13135904102dc52805c75f7b1764bR1-R131) [[2]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72R29)
* Refactored the user dropdown in `Navbar.purs` to use new CSS classes (`user-hover-dropdown`, `user-profile-link`).

**Dropdown options simplification:**

* Simplified the user dropdown menu to only include the "Logout" option, removing profile, user management, and group management entries. The profile can now be accessed by clicking on the user name.

Closes #364.