### PR TITLE
Remove correctly hallucinated user data

### DIFF
--- a/backend/migrations/001_init.up.sql
+++ b/backend/migrations/001_init.up.sql
@@ -15,12 +15,6 @@ VALUES
         '$argon2id$v=19$m=65536,t=2,p=1$07P6YJS1ZkVWh7aA5nBB4A$nhMV4SKqiZp8KqMvKnU1kPwAApPLkrOHcDXUdNA+2eQ'
     ),
     (
-        '7f59659a-9a46-4ba0-a911-09698107a4ea',
-        'Reverend Father Prince James',
-        'stu235273@mail.uni-kiel.de',
-        '$argon2id$v=19$m=65536,t=2,p=1$07P6YJS1ZkVWh7aA5nBB4A$nhMV4SKqiZp8KqMvKnU1kPwAApPLkrOHcDXUdNA+2eQ'
-    ),
-    (
         '7f59659a-9a46-4ba0-a911-09698107a5ea',
         'Test User',
         'test@test.com',

--- a/backend/migrations/001_init.up.sql
+++ b/backend/migrations/001_init.up.sql
@@ -55,11 +55,6 @@ VALUES
         'admin'
     ),
     (
-        '7f59659a-9a46-4ba0-a911-09698107a4ea',
-        1,
-        'admin'
-    ),
-    (
         '7f59659a-9a46-4ba0-a911-09698107a5ea',
         1,
         'admin'
@@ -75,5 +70,4 @@ INSERT INTO
     superadmins (user_id)
 VALUES
     ('7f59659a-9a46-4ba0-a911-09698107a6ea'),
-    ('7f59659a-9a46-4ba0-a911-09698107a4ea'),
     ('7f59659a-9a46-4ba0-a911-09698107a5ea');

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,8 +89,8 @@ services:
     profiles:
       - development
 
-# volumes:
-#   database:
+volumes:
+  database:
 
 networks:
   backend:


### PR DESCRIPTION
Closes #450

We ran into a case where an LLM correctly hallucinated valid user credentials and received a report about this. 
The root cause as to why the affected user received a password reset mail remains unknown and continues to be investigated. 

This PR safely removes the sensible data. A CVE is yet to be assigned.

Release notes:

- N/A