### PR TITLE
Add tooltip to truncated text

### DIFF
--- a/frontend/src/FPO/Components/UI/UserList.purs
+++ b/frontend/src/FPO/Components/UI/UserList.purs
@@ -182,13 +182,22 @@ component = connect selectTranslator $ H.mkComponent
             ]
             $
               [ HH.div
-                  [ HP.classes [ HB.pe3, HB.textTruncate ]
+                  [ HP.classes
+                      [ HB.pe3
+                      , HB.textTruncate
+                      , Style.truncateHoverTitle
+                      ]
                   , HP.style "width: 160px; min-width: 160px; max-width: 160px;"
                   ]
                   [ HH.text $ UserOverviewDto.getName userOverviewDto
                   ]
               , HH.div
-                  [ HP.classes [ HB.pe3, HB.textTruncate, HB.flexGrow1 ]
+                  [ HP.classes
+                      [ HB.pe3
+                      , HB.textTruncate
+                      , Style.truncateHoverTitle
+                      , HB.flexGrow1
+                      ]
                   , HP.style "min-width: 60px;"
                   ]
                   [ HH.text $ UserOverviewDto.getEmail userOverviewDto

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -32,7 +32,11 @@ import FPO.Page.Login as Login
 import FPO.Page.Page404 as Page404
 import FPO.Page.Profile as Profile
 import FPO.Page.ResetPassword as PasswordReset
-import FPO.Translations.Translator (FPOTranslator(..), detectBrowserLanguage, getTranslatorForLanguage)
+import FPO.Translations.Translator
+  ( FPOTranslator(..)
+  , detectBrowserLanguage
+  , getTranslatorForLanguage
+  )
 import FPO.UI.Style as Style
 import FPO.UI.Truncated (setupTruncationListener)
 import Halogen (liftEffect)
@@ -43,7 +47,22 @@ import Halogen.HTML.Properties as HP
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Halogen.VDom.Driver (runUI)
-import Prelude (Unit, Void, bind, discard, pure, unit, void, when, ($), (/=), (<$>), (<<<), (<>), (==))
+import Prelude
+  ( Unit
+  , Void
+  , bind
+  , discard
+  , pure
+  , unit
+  , void
+  , when
+  , ($)
+  , (/=)
+  , (<$>)
+  , (<<<)
+  , (<>)
+  , (==)
+  )
 import Routing.Duplex as RD
 import Routing.Hash (getHash, matchesWith)
 import Type.Proxy (Proxy(..))

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -32,12 +32,9 @@ import FPO.Page.Login as Login
 import FPO.Page.Page404 as Page404
 import FPO.Page.Profile as Profile
 import FPO.Page.ResetPassword as PasswordReset
-import FPO.Translations.Translator
-  ( FPOTranslator(..)
-  , detectBrowserLanguage
-  , getTranslatorForLanguage
-  )
+import FPO.Translations.Translator (FPOTranslator(..), detectBrowserLanguage, getTranslatorForLanguage)
 import FPO.UI.Style as Style
+import FPO.UI.Truncated (setupTruncationListener)
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -46,22 +43,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Halogen.VDom.Driver (runUI)
-import Prelude
-  ( Unit
-  , Void
-  , bind
-  , discard
-  , pure
-  , unit
-  , void
-  , when
-  , ($)
-  , (/=)
-  , (<$>)
-  , (<<<)
-  , (<>)
-  , (==)
-  )
+import Prelude (Unit, Void, bind, discard, pure, unit, void, when, ($), (/=), (<$>), (<<<), (<>), (==))
 import Routing.Duplex as RD
 import Routing.Hash (getHash, matchesWith)
 import Type.Proxy (Proxy(..))
@@ -230,3 +212,5 @@ main = HA.runHalogenAff do
       _response <- halogenIO.query $ H.mkTell $ NavigateQ new
       log $ "Navigated to: " <> routeToString new
       pure unit
+
+  void $ liftEffect setupTruncationListener

--- a/frontend/src/FPO/UI/Style.purs
+++ b/frontend/src/FPO/UI/Style.purs
@@ -39,3 +39,10 @@ cyanStyle = HP.classes
 -- | the scrollbar while still allowing scrolling functionality.
 disableScrollbar ∷ HH.ClassName
 disableScrollbar = HH.ClassName "disable-scrollbar"
+
+-- | A class to enable title tooltips on truncated text elements.
+-- | When applied to an element, if the text is truncated due to
+-- | insufficient space, hovering over the element will show a tooltip
+-- | with the full text content. Logic implemented in `Truncated.purs`.
+truncateHoverTitle :: HH.ClassName
+truncateHoverTitle = HH.ClassName "truncate-hover-title"

--- a/frontend/src/FPO/UI/Truncated.js
+++ b/frontend/src/FPO/UI/Truncated.js
@@ -1,0 +1,11 @@
+export const handleMouseEnterImpl = (event) => () => {
+  const el = event.target;
+  if (!el.classList?.contains("truncate-hover-title")) {
+    return;
+  }
+  if (el.offsetWidth < el.scrollWidth) {
+    el.setAttribute("title", el.innerText);
+    return;
+  }
+  el.removeAttribute("title");
+};

--- a/frontend/src/FPO/UI/Truncated.purs
+++ b/frontend/src/FPO/UI/Truncated.purs
@@ -2,20 +2,19 @@ module FPO.UI.Truncated where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
-import Data.String (Pattern(..), indexOf)
 import Effect (Effect)
 import Web.DOM.Document as Document
-import Web.DOM.Element as Element
-import Web.DOM.Node as Node
 import Web.Event.Event (Event, EventType(..))
-import Web.Event.Event as Event
 import Web.Event.EventTarget as EventTarget
 import Web.HTML as HTML
 import Web.HTML.HTMLDocument as HTMLDocument
-import Web.HTML.HTMLElement as HTMLElement
 import Web.HTML.Window as Window
 
+foreign import handleMouseEnterImpl :: Event -> Effect Unit
+
+-- | Handles mouse enter events (i.e., the cursor entering a specific
+-- | element's bounds) to add or remove title attributes for elements
+-- | with the "truncate-hover-title" class.
 setupTruncationListener :: Effect Unit
 setupTruncationListener = do
   win <- HTML.window
@@ -26,26 +25,4 @@ setupTruncationListener = do
   EventTarget.addEventListener (EventType "mouseenter") listener true eventTarget
 
 handleMouseEnter :: Event -> Effect Unit
-handleMouseEnter event = case Event.target event of
-  Nothing -> pure unit
-  Just target -> case Element.fromEventTarget target of
-    Nothing -> pure unit
-    Just element -> case HTMLElement.fromElement element of
-      Nothing -> pure unit
-      Just htmlElement -> do
-        className <- Element.className element
-        when (contains "text-truncate" className) do
-          let el = HTMLElement.toElement htmlElement
-          cw <- Element.clientWidth el
-          sw <- Element.scrollWidth el
-          if cw < sw then do
-            text <- Node.textContent (Element.toNode element)
-            Element.setAttribute "title" text element
-          else
-            Element.removeAttribute "title" element
-  where
-    -- TODO: just use something like `unwords`...
-    contains needle haystack = 
-      case indexOf (Pattern needle) haystack of
-        Just _ -> true
-        Nothing -> false
+handleMouseEnter = handleMouseEnterImpl

--- a/frontend/src/FPO/UI/Truncated.purs
+++ b/frontend/src/FPO/UI/Truncated.purs
@@ -1,0 +1,51 @@
+module FPO.UI.Truncated where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.String (Pattern(..), indexOf)
+import Effect (Effect)
+import Web.DOM.Document as Document
+import Web.DOM.Element as Element
+import Web.DOM.Node as Node
+import Web.Event.Event (Event, EventType(..))
+import Web.Event.Event as Event
+import Web.Event.EventTarget as EventTarget
+import Web.HTML as HTML
+import Web.HTML.HTMLDocument as HTMLDocument
+import Web.HTML.HTMLElement as HTMLElement
+import Web.HTML.Window as Window
+
+setupTruncationListener :: Effect Unit
+setupTruncationListener = do
+  win <- HTML.window
+  doc <- Window.document win
+  let docElement = HTMLDocument.toDocument doc
+  let eventTarget = Document.toEventTarget docElement
+  listener <- EventTarget.eventListener handleMouseEnter
+  EventTarget.addEventListener (EventType "mouseenter") listener true eventTarget
+
+handleMouseEnter :: Event -> Effect Unit
+handleMouseEnter event = case Event.target event of
+  Nothing -> pure unit
+  Just target -> case Element.fromEventTarget target of
+    Nothing -> pure unit
+    Just element -> case HTMLElement.fromElement element of
+      Nothing -> pure unit
+      Just htmlElement -> do
+        className <- Element.className element
+        when (contains "text-truncate" className) do
+          let el = HTMLElement.toElement htmlElement
+          cw <- Element.clientWidth el
+          sw <- Element.scrollWidth el
+          if cw < sw then do
+            text <- Node.textContent (Element.toNode element)
+            Element.setAttribute "title" text element
+          else
+            Element.removeAttribute "title" element
+  where
+    -- TODO: just use something like `unwords`...
+    contains needle haystack = 
+      case indexOf (Pattern needle) haystack of
+        Just _ -> true
+        Nothing -> false


### PR DESCRIPTION
This pull request introduces a new feature that improves the user experience for truncated text in the user list UI. Specifically, it adds logic to show a tooltip with the full text when hovering over truncated elements, making it easier for users to view complete information. The implementation involves both UI styling and event handling.

**UI Enhancements for Truncated Text:**

* Added a new CSS class `truncate-hover-title` in `FPO/UI/Style.purs` to enable tooltips on truncated text elements. This class is now applied to username and email fields in the user list UI (`UserList.purs`). [[1]](diffhunk://#diff-060c7147666343bd62c1da96074ad616416a4ca126826424557d4eddb0b4f9c8R42-R48) [[2]](diffhunk://#diff-737e084d2bcd6ed13997b5a61783a9c81f3050d2c5b6ecb2e8a479c0754e00c5L185-R200)

**Event Handling and Tooltip Logic:**

* Created a new module `FPO/UI/Truncated.purs` that sets up a global event listener for mouse enter events. When the cursor enters an element with the `truncate-hover-title` class, it checks if the text is truncated and, if so, sets the `title` attribute to show a tooltip with the full text.
* Implemented the core logic for handling mouse enter events in `FPO/UI/Truncated.js`, which adds or removes the `title` attribute based on whether the text is truncated.
* Registered the truncation listener during application startup in `FPO/Main.purs`, ensuring the tooltip behavior is available throughout the app. [[1]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2R41) [[2]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2R234-R235)