### PR TITLE
Show pdf download error

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,3 +11,4 @@ generated-docs/
 .spago
 .idea/
 index.js
+.VSCodeCounter/

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -28,6 +28,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (joinWith)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
+import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -843,36 +844,39 @@ splitview = H.mkComponent
         H.tell _comment unit (Comment.DeletedComment deletedIDs)
 
       Editor.PostPDF content -> do
-        renderedPDF' <- Request.postBlob "/render/pdf" (fromString content)
+        renderedPDF' <- Request.postBlobOrError "/render/pdf" (fromString content)
         tocTitleMaybe <- H.request _toc unit TOC.RequestCurrentTocEntryTitle
         let
           tocTitle = join tocTitleMaybe -- This flattens Maybe (Maybe String) to Maybe String
           filename = (fromMaybe "document" tocTitle) <> ".pdf"
         case renderedPDF' of
           Left _ -> pure unit
-          Right body -> do
-            -- create blobl link
-            url <- H.liftEffect $ createObjectURL body
-            -- Create an invisible link and click it to download PDF
-            H.liftEffect $ do
-              -- get window stuff
-              win <- window
-              hdoc <- document win
-              let doc = HTMLDocument.toDocument hdoc
+          Right blobOrError ->
+            case blobOrError of
+              Left errMsg -> H.liftEffect $ log errMsg
+              Right body -> do
+                -- create blobl link
+                url <- H.liftEffect $ createObjectURL body
+                -- Create an invisible link and click it to download PDF
+                H.liftEffect $ do
+                  -- get window stuff
+                  win <- window
+                  hdoc <- document win
+                  let doc = HTMLDocument.toDocument hdoc
 
-              -- create link
-              aEl <- Document.createElement "a" doc
-              case HTMLElement.fromElement aEl of
-                Nothing -> pure unit
-                Just aHtml -> do
-                  Element.setAttribute "href" url aEl
-                  Element.setAttribute "download" filename aEl
-                  HTMLElement.click aHtml
-            -- deactivate the blob link after 1 sec
-            _ <- H.fork do
-              H.liftAff $ delay (Milliseconds 1000.0)
-              H.liftEffect $ revokeObjectURL url
-            pure unit
+                  -- create link
+                  aEl <- Document.createElement "a" doc
+                  case HTMLElement.fromElement aEl of
+                    Nothing -> pure unit
+                    Just aHtml -> do
+                      Element.setAttribute "href" url aEl
+                      Element.setAttribute "download" filename aEl
+                      HTMLElement.click aHtml
+                -- deactivate the blob link after 1 sec
+                _ <- H.fork do
+                  H.liftAff $ delay (Milliseconds 1000.0)
+                  H.liftEffect $ revokeObjectURL url
+                pure unit
 
       Editor.SavedSection toBePosted title tocEntry -> do
         state <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -28,7 +28,6 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (joinWith)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -853,7 +852,10 @@ splitview = H.mkComponent
           Left _ -> pure unit
           Right blobOrError ->
             case blobOrError of
-              Left errMsg -> H.liftEffect $ log errMsg
+              Left errMsg -> H.modify_ _
+                { renderedHtml = Just
+                    (Loaded ("<pre><code>" <> errMsg <> "</code></pre>"))
+                }
               Right body -> do
                 -- create blobl link
                 url <- H.liftEffect $ createObjectURL body

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -844,6 +844,10 @@ splitview = H.mkComponent
 
       Editor.PostPDF content -> do
         renderedPDF' <- Request.postBlob "/render/pdf" (fromString content)
+        tocTitleMaybe <- H.request _toc unit TOC.RequestCurrentTocEntryTitle
+        let
+          tocTitle = join tocTitleMaybe -- This flattens Maybe (Maybe String) to Maybe String
+          filename = (fromMaybe "document" tocTitle) <> ".pdf"
         case renderedPDF' of
           Left _ -> pure unit
           Right body -> do
@@ -862,7 +866,7 @@ splitview = H.mkComponent
                 Nothing -> pure unit
                 Just aHtml -> do
                   Element.setAttribute "href" url aEl
-                  Element.setAttribute "download" "test.pdf" aEl
+                  Element.setAttribute "download" filename aEl
                   HTMLElement.click aHtml
             -- deactivate the blob link after 1 sec
             _ <- H.fork do

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1003,7 +1003,7 @@ getCurrentTocEntryTitle :: Maybe SelectedEntity -> RootTree TOCEntry -> Maybe St
 getCurrentTocEntryTitle mSelectedEntry tocEntries = case mSelectedEntry of
   Nothing -> Nothing
   Just (SelLeaf leafId) -> findLeafTitle leafId tocEntries
-  Just (SelNode path title) -> Just title
+  Just (SelNode _ title) -> Just title
 
 -- Helper to find a leaf title by ID
 findLeafTitle :: Int -> RootTree TOCEntry -> Maybe String


### PR DESCRIPTION
This pull request introduces improvements to the PDF export workflow in the document editor, ensuring that exported PDFs are named according to the current TOC entry and that error handling is more robust and user-friendly. It also adds new functionality to the TOC component for retrieving the current entry's title and exposes helper functions for working with TOC entries.

### PDF Export Improvements

* The PDF export now uses the current TOC entry title as the filename, falling back to `"document.pdf"` if no title is available, instead of always using `"test.pdf"` [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL846-R858) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL865-R875).
* Error handling for PDF export is improved: if PDF generation fails, the user is shown a formatted error message instead of silent failure.
* Added a new `postBlobOrError` request function to handle both successful PDF blob responses and error string responses, improving feedback for export failures [[1]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R36) [[2]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R558-R581).

### TOC Component Enhancements

* Added the `RequestCurrentTocEntryTitle` query to the TOC component, allowing other components to request the current TOC entry's title [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL138-R152) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR479-R485).
* Implemented helper functions (`getCurrentTocEntryTitle`, `findLeafTitleInTree`, etc.) to extract titles from the TOC tree, improving code organization and reuse.
* Exposed additional TOC-related types and functions from the TOC module for easier integration with other components.