### PR TITLE
backend/ltml: Make Tree polymorphic

### DIFF
--- a/backend/src/Language/Ltml/AST/AppendixSection.hs
+++ b/backend/src/Language/Ltml/AST/AppendixSection.hs
@@ -6,10 +6,10 @@ where
 import Language.Lsd.AST.Type.AppendixSection (AppendixSectionFormat)
 import Language.Ltml.AST.Document (Document)
 import Language.Ltml.AST.Node (Node)
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 
 data AppendixSection
     = AppendixSection
         AppendixSectionFormat
-        [Flagged (Node Document)]
+        [Flagged' (Node Document)]
     deriving (Show)

--- a/backend/src/Language/Ltml/AST/Document.hs
+++ b/backend/src/Language/Ltml/AST/Document.hs
@@ -12,7 +12,7 @@ import Language.Ltml.AST.Label (Label)
 import Language.Ltml.AST.Section (SectionBody)
 import Language.Ltml.AST.SimpleSection (SimpleSection)
 import Language.Ltml.AST.Text (HeadingTextTree)
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 
 data Document
     = Document
@@ -33,10 +33,10 @@ newtype DocumentHeading = DocumentHeading [HeadingTextTree]
 data DocumentBody
     = -- | document body
       DocumentBody
-        (Flagged [SimpleSection])
+        (Flagged' [SimpleSection])
         -- ^ intro
-        (Flagged SectionBody)
+        (Flagged' SectionBody)
         -- ^ main
-        (Flagged [SimpleSection])
+        (Flagged' [SimpleSection])
         -- ^ outro
     deriving (Show)

--- a/backend/src/Language/Ltml/AST/DocumentContainer.hs
+++ b/backend/src/Language/Ltml/AST/DocumentContainer.hs
@@ -8,14 +8,14 @@ import Data.Text (Text)
 import Language.Lsd.AST.Type.DocumentContainer (DocumentContainerFormat)
 import Language.Ltml.AST.AppendixSection (AppendixSection)
 import Language.Ltml.AST.Document (Document)
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 
 data DocumentContainer
     = DocumentContainer
         DocumentContainerFormat
         DocumentContainerHeader
-        (Flagged Document)
-        [Flagged AppendixSection]
+        (Flagged' Document)
+        [Flagged' AppendixSection]
     deriving (Show)
 
 data DocumentContainerHeader

--- a/backend/src/Language/Ltml/AST/Section.hs
+++ b/backend/src/Language/Ltml/AST/Section.hs
@@ -11,7 +11,7 @@ import Language.Ltml.AST.Node (Node)
 import Language.Ltml.AST.Paragraph (Paragraph)
 import Language.Ltml.AST.SimpleBlock (SimpleBlock)
 import Language.Ltml.AST.Text (HeadingTextTree)
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 
 data Section
     = Section
@@ -27,7 +27,7 @@ data Heading
     deriving (Show)
 
 data SectionBody
-    = InnerSectionBody [Flagged (Node Section)]
+    = InnerSectionBody [Flagged' (Node Section)]
     | LeafSectionBody [Node Paragraph]
     | SimpleLeafSectionBody [SimpleBlock]
     deriving (Show)

--- a/backend/src/Language/Ltml/Common.hs
+++ b/backend/src/Language/Ltml/Common.hs
@@ -2,19 +2,29 @@
 
 module Language.Ltml.Common
     ( Flagged (..)
+    , Flagged'
+    , flagMap
     )
 where
 
 import Control.Functor.Utils (TraversableF (traverseF))
 
--- | Flagging wrapper for AST nodes.
---   A positive flag indicates that the respective node was originally
---   requested for update.
---   The flag is only ever set for nodes that correspond to a node in the raw
---   tree ('Language.Ltml.Tree.Tree'), thus not during parsing text.
---   The flag should only be set for one node in a tree.
-data Flagged a = Flagged Bool a
+data Flagged flag a = Flagged flag a
     deriving (Functor, Show)
 
-instance TraversableF Flagged where
+-- | Boolean flagging wrapper for input tree nodes
+--   ('Language.Ltml.Tree.FlaggedInputTree') and AST nodes.
+--
+--   The flag indicates whether output should be generated for the respective
+--   flagged node.
+--
+--   Flags always match between corresponding input tree nodes and AST nodes;
+--   in particular, in the AST, the flag is only ever positive for nodes that
+--   correspond to a node in the input tree.
+type Flagged' = Flagged Bool
+
+flagMap :: (fl -> fl') -> Flagged fl a -> Flagged fl' a
+flagMap f (Flagged flag x) = Flagged (f flag) x
+
+instance TraversableF (Flagged flag) where
     traverseF f (Flagged flag x) = Flagged flag <$> f x

--- a/backend/src/Language/Ltml/HTML.hs
+++ b/backend/src/Language/Ltml/HTML.hs
@@ -51,7 +51,7 @@ import Language.Ltml.AST.SimpleParagraph (SimpleParagraph (..))
 import Language.Ltml.AST.SimpleSection (SimpleSection (..))
 import Language.Ltml.AST.Table (Table)
 import Language.Ltml.AST.Text
-import Language.Ltml.Common (Flagged (..))
+import Language.Ltml.Common (Flagged (..), Flagged')
 import Language.Ltml.HTML.CSS (mainStylesheet)
 import Language.Ltml.HTML.CSS.Classes (ToCssClass (toCssClass))
 import qualified Language.Ltml.HTML.CSS.Classes as Class
@@ -87,7 +87,7 @@ renderSectionHtmlCss section fnMap =
         finalState' = finalState {labels = usedFootnotes ++ labels finalState}
      in (evalDelayed delayedHtml finalState', mainStylesheet (enumStyles finalState))
 
-renderHtmlCss :: Flagged DocumentContainer -> (Html (), Css)
+renderHtmlCss :: Flagged' DocumentContainer -> (Html (), Css)
 renderHtmlCss docContainer =
     -- \| Render with given footnote context
     let (delayedHtml, finalState) = runState (runReaderT (toHtmlM docContainer) initReaderState) initGlobalState
@@ -480,7 +480,7 @@ instance ToHtmlM AppendixSection where
 
 -- | This instance manages which part of the AST is actually translated into HTML;
 --   Everything else is just used to build up the needed context (labels, etc.)
-instance (ToHtmlM a) => ToHtmlM (Flagged a) where
+instance (ToHtmlM a) => ToHtmlM (Flagged' a) where
     toHtmlM (Flagged renderFlag a) = do
         -- \| Set False to see if child sets it True again
         modify (\s -> s {hasFlagged = False})

--- a/backend/src/Language/Ltml/ToLaTeX/ToPreLaTeXM.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/ToPreLaTeXM.hs
@@ -70,7 +70,7 @@ import Language.Ltml.AST.Text
     , SentenceStart (..)
     , TextTree (..)
     )
-import Language.Ltml.Common (Flagged (Flagged))
+import Language.Ltml.Common (Flagged (Flagged), Flagged')
 import Language.Ltml.ToLaTeX.Format
     ( Stylable (..)
     , formatHeading
@@ -113,7 +113,7 @@ instance (ToPreLaTeXM a) => ToPreLaTeXM [a] where
 
 ------------------------------- Flagged ----------------------------------
 
-instance (ToPreLaTeXM a) => ToPreLaTeXM (Flagged a) where
+instance (ToPreLaTeXM a) => ToPreLaTeXM (Flagged' a) where
     toPreLaTeXM (Flagged b content) = do
         {- first check whether the global render flag (flaggedParent) is set -}
         b0 <- use (GS.flagState . GS.flaggedParent)

--- a/backend/src/Language/Ltml/Tree.hs
+++ b/backend/src/Language/Ltml/Tree.hs
@@ -1,28 +1,79 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Language.Ltml.Tree
     ( FlaggedTree
     , TypedTree (..)
     , Tree (..)
+    , flaggedTreeMap
+    , FlaggedInputTree
+    , TypedInputTree
+    , InputTree
+    , FlaggedInputTree'
+    , TypedInputTree'
+    , InputTree'
+    , FlaggedMetaTree
+    , TypedMetaTree
+    , MetaTree
+    , HtmlHeading (..)
     )
 where
 
 import Data.Text (Text)
 import Language.Lsd.AST.Common (KindName, TypeName)
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged, flagMap)
 
-type FlaggedTree = Flagged TypedTree
+type FlaggedTree flag a b = Flagged flag (TypedTree flag a b)
 
--- | A raw representation of an LTML tree.
-data TypedTree
+data TypedTree flag a b
     = TypedTree
         KindName
         TypeName
-        Tree
+        (Tree flag a b)
     deriving (Show)
 
--- | Auxiliary LTML tree, without kind & type information in the head.
-data Tree
+data Tree flag a b
     = Tree
-        (Maybe Text)
-        [FlaggedTree]
-    | Leaf Text
+        a
+        [FlaggedTree flag a b]
+    | Leaf b
     deriving (Show)
+
+flaggedTreeMap
+    :: forall fl fl' a a' b b'
+     . (fl -> fl')
+    -> (a -> a')
+    -> (b -> b')
+    -> FlaggedTree fl a b
+    -> FlaggedTree fl' a' b'
+flaggedTreeMap flagF innerF leafF = flaggedTreeF
+  where
+    flaggedTreeF :: FlaggedTree fl a b -> FlaggedTree fl' a' b'
+    flaggedTreeF tree = typedTreeF <$> flagMap flagF tree
+
+    typedTreeF :: TypedTree fl a b -> TypedTree fl' a' b'
+    typedTreeF (TypedTree k t tree) = TypedTree k t $ treeF tree
+
+    treeF :: Tree fl a b -> Tree fl' a' b'
+    treeF (Tree x trees) = Tree (innerF x) $ map flaggedTreeF trees
+    treeF (Leaf leaf) = Leaf $ leafF leaf
+
+type FlaggedInputTree flag = FlaggedTree flag (Maybe Text) Text
+type TypedInputTree flag = TypedTree flag (Maybe Text) Text
+type InputTree flag = Tree flag (Maybe Text) Text
+
+-- | A tree with textual nodes that can be parsed to obtain an LTML tree.
+--   See `Language.Ltml.Common.Flagged'` on the semantics of the boolean flag.
+type FlaggedInputTree' = FlaggedInputTree Bool
+
+type TypedInputTree' = TypedInputTree Bool
+type InputTree' = InputTree Bool
+
+-- | A tree containing metadata, to be sent to the frontend.
+--   The type parameter is typically an identifier type.
+type FlaggedMetaTree id =
+    FlaggedTree id (Maybe HtmlHeading) (Maybe HtmlHeading)
+
+type TypedMetaTree id = TypedTree id (Maybe HtmlHeading) (Maybe HtmlHeading)
+type MetaTree id = Tree id (Maybe HtmlHeading) (Maybe HtmlHeading)
+
+newtype HtmlHeading = HtmlHeading Text

--- a/backend/src/Language/Ltml/Tree/Example/Fpo.hs
+++ b/backend/src/Language/Ltml/Tree/Example/Fpo.hs
@@ -8,13 +8,14 @@ where
 import Data.Text (Text, unlines)
 import Language.Ltml.Common (Flagged (Flagged))
 import Language.Ltml.Tree
-    ( FlaggedTree
+    ( FlaggedInputTree'
     , Tree (Leaf, Tree)
+    , TypedInputTree'
     , TypedTree (TypedTree)
     )
 import Prelude hiding (unlines)
 
-fpoTree :: FlaggedTree
+fpoTree :: FlaggedInputTree'
 fpoTree =
     Flagged False $
         TypedTree "document-container" "fpo-container" $
@@ -36,7 +37,7 @@ fpoTree =
             , "header-footer-date: 2025-08-26"
             ]
 
-mainDocTree :: FlaggedTree
+mainDocTree :: FlaggedInputTree'
 mainDocTree =
     Flagged False $
         TypedTree "document" "fpo-maindoc" $
@@ -65,16 +66,16 @@ mainDocTree =
             TypedTree "simple-section-sequence" "" $
                 Leaf extroText
 
-appTrees :: [FlaggedTree]
+appTrees :: [FlaggedInputTree']
 appTrees = [appendixTree, attachmentsTree]
 
-appendixTree :: FlaggedTree
+appendixTree :: FlaggedInputTree'
 appendixTree =
     Flagged False $
         TypedTree "appendix-section" "appendix" $
             Tree Nothing []
 
-attachmentsTree :: FlaggedTree
+attachmentsTree :: FlaggedInputTree'
 attachmentsTree =
     Flagged False $
         TypedTree "appendix-section" "attachments" $
@@ -101,7 +102,7 @@ introText =
         , "// \"Aufgrund ... wird ... erlassen:\""
         ]
 
-sampleSectionTree :: TypedTree
+sampleSectionTree :: TypedInputTree'
 sampleSectionTree =
     TypedTree "section" "section" $
         Leaf sampleSectionText

--- a/backend/src/Language/Ltml/Tree/Parser.hs
+++ b/backend/src/Language/Ltml/Tree/Parser.hs
@@ -92,10 +92,10 @@ leafFootnoteParser p x = mapFootnoteWriterT (\p' -> leafParser p' x) p
 
 flaggedTreePF
     :: (MonadTreeParser m, KindNameOf t)
-    => (TypeName -> Tree -> m a)
+    => (TypeName -> Tree flag a b -> m c)
     -> Proxy t
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 flaggedTreePF f kind = traverseF aux
   where
     aux (TypedTree kindName typeName tree) =
@@ -104,13 +104,13 @@ flaggedTreePF f kind = traverseF aux
             else treeError "Invalid kind"
 
 flaggedTreePF'
-    :: forall m t a
+    :: forall m t flag a b c
      . (MonadTreeParser m, KindNameOf t)
-    => (Tree -> m a)
+    => (Tree flag a b -> m c)
     -> t
     -> TypeName
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 flaggedTreePF' f _ typeName = flaggedTreePF f' (Proxy :: Proxy t)
   where
     f' typeName' tree =
@@ -120,30 +120,30 @@ flaggedTreePF' f _ typeName = flaggedTreePF f' (Proxy :: Proxy t)
 
 nFlaggedTreePF
     :: (MonadTreeParser m, KindNameOf t)
-    => (t -> Tree -> m a)
+    => (t -> Tree flag a b -> m c)
     -> NamedType t
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 nFlaggedTreePF f nt = flaggedTreePF' (f t) t (ntTypeName nt)
   where
     t = unwrapNT nt
 
 staticFlaggedTreePF
     :: (MonadTreeParser m, KindNameOf t, TypeNameOf t)
-    => (t -> Tree -> m a)
+    => (t -> Tree flag a b -> m c)
     -> t
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 staticFlaggedTreePF f t = flaggedTreePF' (f t) t (typeNameOf t)
 
 disjFlaggedTreePF
-    :: forall m t a
+    :: forall m t flag a b c
      . (MonadTreeParser m, KindNameOf t)
     => (t -> TypeName)
-    -> (t -> Tree -> m a)
+    -> (t -> Tree flag a b -> m c)
     -> Disjunction t
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 disjFlaggedTreePF getTypeName f (Disjunction ts) =
     flaggedTreePF f' (Proxy :: Proxy t)
   where
@@ -154,16 +154,16 @@ disjFlaggedTreePF getTypeName f (Disjunction ts) =
 
 disjNFlaggedTreePF
     :: (MonadTreeParser m, KindNameOf t)
-    => (t -> Tree -> m a)
+    => (t -> Tree flag a b -> m c)
     -> Disjunction (NamedType t)
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 disjNFlaggedTreePF f = disjFlaggedTreePF ntTypeName (f . unwrapNT)
 
 disjStaticFlaggedTreePF
     :: (MonadTreeParser m, KindNameOf t, TypeNameOf t)
-    => (t -> Tree -> m a)
+    => (t -> Tree flag a b -> m c)
     -> Disjunction t
-    -> FlaggedTree
-    -> m (Flagged a)
+    -> FlaggedTree flag a b
+    -> m (Flagged flag c)
 disjStaticFlaggedTreePF = disjFlaggedTreePF typeNameOf

--- a/backend/src/Language/Ltml/Tree/Parser/AppendixSection.hs
+++ b/backend/src/Language/Ltml/Tree/Parser/AppendixSection.hs
@@ -9,8 +9,8 @@ import Language.Lsd.AST.Type.AppendixSection
     ( AppendixSectionType (AppendixSectionType)
     )
 import Language.Ltml.AST.AppendixSection (AppendixSection (AppendixSection))
-import Language.Ltml.Common (Flagged)
-import Language.Ltml.Tree (FlaggedTree, Tree (Leaf, Tree))
+import Language.Ltml.Common (Flagged')
+import Language.Ltml.Tree (FlaggedInputTree', InputTree', Tree (Leaf, Tree))
 import Language.Ltml.Tree.Parser
     ( TreeParser
     , disjNFlaggedTreePF
@@ -21,11 +21,11 @@ import Language.Ltml.Tree.Parser.Document (documentTXP')
 
 appendixSectionTP
     :: NamedType AppendixSectionType
-    -> FlaggedTree
-    -> TreeParser (Flagged AppendixSection)
+    -> FlaggedInputTree'
+    -> TreeParser (Flagged' AppendixSection)
 appendixSectionTP = nFlaggedTreePF aux
   where
-    aux :: AppendixSectionType -> Tree -> TreeParser AppendixSection
+    aux :: AppendixSectionType -> InputTree' -> TreeParser AppendixSection
     aux _ (Leaf _) = treeError "Appendix section node is leaf"
     aux _ (Tree (Just _) _) = treeError "Appendix section node has header"
     aux (AppendixSectionType fmt (Star t)) (Tree Nothing trees) =

--- a/backend/src/Language/Ltml/Tree/Parser/DocumentContainer.hs
+++ b/backend/src/Language/Ltml/Tree/Parser/DocumentContainer.hs
@@ -15,9 +15,9 @@ import Language.Ltml.AST.DocumentContainer
     ( DocumentContainer (DocumentContainer)
     , DocumentContainerHeader
     )
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 import Language.Ltml.Parser.DocumentContainer (documentContainerHeaderP)
-import Language.Ltml.Tree (FlaggedTree, Tree (Leaf, Tree))
+import Language.Ltml.Tree (FlaggedInputTree', InputTree', Tree (Leaf, Tree))
 import Language.Ltml.Tree.Parser
     ( TreeParser
     , disjNFlaggedTreePF
@@ -29,11 +29,11 @@ import Language.Ltml.Tree.Parser.Document (documentTP)
 
 documentContainerTP
     :: Disjunction (NamedType DocumentContainerType)
-    -> FlaggedTree
-    -> TreeParser (Flagged DocumentContainer)
+    -> FlaggedInputTree'
+    -> TreeParser (Flagged' DocumentContainer)
 documentContainerTP = disjNFlaggedTreePF aux
   where
-    aux :: DocumentContainerType -> Tree -> TreeParser DocumentContainer
+    aux :: DocumentContainerType -> InputTree' -> TreeParser DocumentContainer
     aux _ (Leaf _) = treeError "Document container node is leaf"
     aux _ (Tree _ []) =
         treeError "Document container lacks main document child"
@@ -51,8 +51,8 @@ headerTP (Just x) = leafParser documentContainerHeaderP x
 
 appendicesTP
     :: Sequence (NamedType AppendixSectionType)
-    -> [FlaggedTree]
-    -> TreeParser [Flagged AppendixSection]
+    -> [FlaggedInputTree']
+    -> TreeParser [Flagged' AppendixSection]
 appendicesTP (Sequence ts) tTrees =
     case safeZipWith appendixSectionTP ts tTrees of
         Nothing -> treeError "Wrong number of appendix sections"

--- a/backend/src/Language/Ltml/Tree/Parser/Section.hs
+++ b/backend/src/Language/Ltml/Tree/Parser/Section.hs
@@ -20,9 +20,9 @@ import Language.Ltml.AST.Section
     , Section (Section)
     , SectionBody (InnerSectionBody)
     )
-import Language.Ltml.Common (Flagged)
+import Language.Ltml.Common (Flagged')
 import Language.Ltml.Parser.Section (headingP, sectionP)
-import Language.Ltml.Tree (FlaggedTree, Tree (Leaf, Tree))
+import Language.Ltml.Tree (FlaggedInputTree', InputTree', Tree (Leaf, Tree))
 import Language.Ltml.Tree.Parser
     ( FootnoteTreeParser
     , TreeParser
@@ -35,13 +35,13 @@ import Text.Megaparsec (eof)
 
 sectionTP
     :: NamedType SectionType
-    -> FlaggedTree
-    -> FootnoteTreeParser (Flagged (Node Section))
+    -> FlaggedInputTree'
+    -> FootnoteTreeParser (Flagged' (Node Section))
 sectionTP = nFlaggedTreePF sectionTP'
   where
     sectionTP'
         :: SectionType
-        -> Tree
+        -> InputTree'
         -> FootnoteTreeParser (Node Section)
     sectionTP' t (Leaf x) = leafFootnoteParser (sectionP t eof) x
     sectionTP' (SectionType kw headingT fmt bodyT) (Tree x children) = do
@@ -49,17 +49,13 @@ sectionTP = nFlaggedTreePF sectionTP'
         body <- sectionBodyTP bodyT children
         return $ fmap (\heading -> Section fmt heading body) wHeading
 
-headingTP
-    :: Keyword
-    -> HeadingType
-    -> Maybe Text
-    -> TreeParser (Node Heading)
+headingTP :: Keyword -> HeadingType -> Maybe Text -> TreeParser (Node Heading)
 headingTP kw t (Just x) = leafParser (headingP kw t) x
 headingTP _ _ Nothing = treeError "Section lacks heading"
 
 sectionBodyTP
     :: SectionBodyType
-    -> [FlaggedTree]
+    -> [FlaggedInputTree']
     -> FootnoteTreeParser SectionBody
 sectionBodyTP (InnerSectionBodyType (Star nt)) trees =
     InnerSectionBody <$> mapM (sectionTP nt) trees

--- a/backend/src/Language/Ltml/Tree/ToLtml.hs
+++ b/backend/src/Language/Ltml/Tree/ToLtml.hs
@@ -6,12 +6,17 @@ where
 import Language.Lsd.AST.SimpleRegex (Disjunction (Disjunction))
 import Language.Lsd.Example.Fpo (fpoT)
 import Language.Ltml.AST.DocumentContainer (DocumentContainer)
-import Language.Ltml.Common (Flagged)
-import Language.Ltml.Tree (FlaggedTree)
+import Language.Ltml.Common (Flagged')
+import Language.Ltml.Tree (FlaggedInputTree')
 import Language.Ltml.Tree.Parser (TreeError, runTreeParser)
 import Language.Ltml.Tree.Parser.DocumentContainer (documentContainerTP)
 
-treeToLtml :: FlaggedTree -> Either TreeError (Flagged DocumentContainer)
+-- | Convert an input tree to an LTML AST.
+--   The boolean flags denote which part(s) of the tree output should be
+--   generated for.
+treeToLtml
+    :: FlaggedInputTree'
+    -> Either TreeError (Flagged' DocumentContainer)
 treeToLtml tTree = runTreeParser $ documentContainerTP t tTree
   where
     t = Disjunction [fpoT] -- TODO: Do not hard-code.


### PR DESCRIPTION
This allows us to use it both as input tree and for metadata returned to the client (specifically, the tree of headings).