### PR TITLE
No sorting table header

### DIFF
--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -571,7 +571,7 @@ component =
         , style: Just TH.Numeric
         }
       , { title: "PDF"
-        , style: Just TH.Alpha
+        , style: Nothing
         }
       ]
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the table column styling on the Home page. The "PDF" column no longer uses the `TH.Alpha` style and instead has no explicit style set.