### PR TITLE
Docs API: Create Document Now With Default Content

### DIFF
--- a/backend/migrations/004_docs.up.sql
+++ b/backend/migrations/004_docs.up.sql
@@ -27,7 +27,8 @@ CREATE INDEX IF NOT EXISTS doc_text_revisions_timestamp_index ON doc_text_revisi
 CREATE TABLE IF NOT EXISTS doc_tree_nodes (
     hash BYTEA PRIMARY KEY NOT NULL, -- hash over metadata and children
     kind TEXT NOT NULL,
-    type TEXT NOT NULL
+    type TEXT NOT NULL,
+    heading TEXT
 );
 
 CREATE TABLE IF NOT EXISTS doc_tree_edges (

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -194,3 +194,9 @@ instance HasCreateComment HasqlTransaction where
 
 instance HasLogMessage HasqlTransaction where
     logMessage = (((HasqlTransaction .) .) .) . Transactions.logMessage
+
+instance HasCreateDocument HasqlTransaction where
+    createDocument = ((HasqlTransaction .) .) . Transactions.createDocument
+
+instance HasCreateTextElement HasqlTransaction where
+    createTextElement = (HasqlTransaction .) . Transactions.createTextElement

--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -732,7 +732,8 @@ getTreeNode =
             [singletonStatement|
             select
                 kind :: text,
-                type :: text
+                type :: text,
+                heading:: text?
             from
                 doc_tree_nodes
             where
@@ -802,11 +803,12 @@ uncurryTreeEdgeChild
        , Maybe ByteString
        , Maybe Text
        , Maybe Text
+       , Maybe Text
        , Maybe Int64
        , Maybe Text
        )
     -> Maybe (Text, TreeEdgeChild)
-uncurryTreeEdgeChild (title, nodeHash, nodeKind, nodeType, textID, textKind) =
+uncurryTreeEdgeChild (title, nodeHash, nodeKind, nodeType, nodeHeading, textID, textKind) =
     (title,) <$> (maybeNode <|> maybeText)
   where
     maybeNode = do
@@ -819,6 +821,7 @@ uncurryTreeEdgeChild (title, nodeHash, nodeKind, nodeType, textID, textKind) =
                 NodeHeader
                     { Tree.headerKind = kind
                     , Tree.headerType = type_
+                    , Tree.heading = nodeHeading
                     }
     maybeText = do
         id_ <- textID
@@ -842,6 +845,7 @@ getTreeEdgesByParent =
                     n.hash :: bytea?,
                     n.kind :: text?,
                     n.type :: text?,
+                    n.heading :: text?,
                     t.id :: int8?,
                     t.kind :: text?
                 from

--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -2,6 +2,8 @@
 
 module Docs.Hasql.Transactions
     ( now
+    , createDocument
+    , createTextElement
     , getTextElementRevision
     , existsTextRevision
     , updateTextRevision
@@ -39,7 +41,7 @@ import UserManagement.User (UserID)
 import Data.Aeson (ToJSON)
 import Docs.Comment (Comment, CommentAnchor, CommentID, CommentRef, Message)
 import qualified Docs.Comment as Comment
-import Docs.Document (DocumentID)
+import Docs.Document (Document, DocumentID)
 import Docs.Hash
     ( Hash (Hash)
     , Hashable (..)
@@ -47,7 +49,12 @@ import Docs.Hash
 import qualified Docs.Hasql.Statements as Statements
 import Docs.Hasql.TreeEdge (TreeEdge (TreeEdge), TreeEdgeChildRef (..))
 import qualified Docs.Hasql.TreeEdge as TreeEdge
-import Docs.TextElement (TextElementID, TextElementRef (..))
+import Docs.TextElement
+    ( TextElement
+    , TextElementID
+    , TextElementKind
+    , TextElementRef (..)
+    )
 import Docs.TextRevision
     ( TextElementRevision
     , TextRevision
@@ -68,6 +75,13 @@ getTextElementRevision
 getTextElementRevision ref = do
     textElementRevision <- statement ref Statements.getTextElementRevision
     textElementRevision $ flip statement Statements.getCommentAnchors
+
+createDocument :: Text -> GroupID -> UserID -> Transaction Document
+createDocument name group user =
+    statement (name, group, user) Statements.createDocument
+
+createTextElement :: DocumentID -> TextElementKind -> Transaction TextElement
+createTextElement = curry (`statement` Statements.createTextElement)
 
 existsTextRevision :: TextRevisionRef -> Transaction Bool
 existsTextRevision = flip statement Statements.existsTextRevision

--- a/backend/src/Docs/TestDoc.hs
+++ b/backend/src/Docs/TestDoc.hs
@@ -41,7 +41,7 @@ createTestDocument db = do
     anlage5 <- withDB $ run $ createTextElement userID docID "attachement"
     let tree =
             Node
-                (NodeHeader "BodyNode" "DocumentRoot")
+                (NodeHeader "BodyNode" "DocumentRoot" (Just "Fachprüfungsordnung"))
                 [ Edge "§ 1" (Leaf (TextElement.identifier paragraph1))
                 , Edge "§ 2" (Leaf (TextElement.identifier paragraph2))
                 , Edge "§ 3" (Leaf (TextElement.identifier paragraph3))
@@ -51,7 +51,7 @@ createTestDocument db = do
                     "Anlagen"
                     ( Tree
                         ( Node
-                            (NodeHeader "BodyNode" "Attachements")
+                            (NodeHeader "BodyNode" "Attachements" (Just "Anlagen"))
                             [ Edge "Thomann" (Leaf (TextElement.identifier anlage1))
                             , Edge "LD Systems" (Leaf (TextElement.identifier anlage2))
                             , Edge "Beyerdynamic" (Leaf (TextElement.identifier anlage3))

--- a/backend/src/Docs/Tree.hs
+++ b/backend/src/Docs/Tree.hs
@@ -50,6 +50,7 @@ import Docs.TextRevision
 data NodeHeader = NodeHeader
     { headerKind :: Text
     , headerType :: Text
+    , heading :: Maybe Text
     }
     deriving (Show, Generic)
 

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -88,6 +88,7 @@ import Docs.Revision
     , RevisionSelector
     , prettyPrintRevisionRef
     )
+import Language.Ltml.Tree.Example.Fpo (fpoTree)
 import Server.DTOs.Comments (Comments (Comments))
 import Server.DTOs.CreateComment (CreateComment)
 import qualified Server.DTOs.CreateComment as CreateComment
@@ -134,7 +135,7 @@ type DocsAPI =
 type PostDocument =
     Auth AuthMethod Auth.Token
         :> ReqBody '[JSON] CreateDocument
-        :> Post '[JSON] Document
+        :> Post '[JSON] FullDocument
 
 type GetDocument =
     Auth AuthMethod Auth.Token
@@ -311,15 +312,16 @@ docsServer =
 postDocumentHandler
     :: AuthResult Auth.Token
     -> CreateDocument
-    -> Handler Document
+    -> Handler FullDocument
 postDocumentHandler auth doc = do
     userID <- getUser auth
     withDB $
-        run $
-            Docs.createDocument
+        runTransaction $
+            Docs.newDefaultDocument
                 userID
                 (CreateDocument.groupID doc)
                 (CreateDocument.title doc)
+                fpoTree
 
 getDocumentHandler
     :: AuthResult Auth.Token


### PR DESCRIPTION
With this PR, new documents are initialized with default content.

However, creating a new document currently results in a frontend error. This is most likely due to a change of the reponse data type of the api:
<img width="786" height="564" alt="grafik" src="https://github.com/user-attachments/assets/be617bf7-86d7-4242-92c8-5c4123147646" />

The document is created successfully nevertheless. Since the generation of a ToC is currently not possible, the headings of the default document are not yet sensible in any way:
<img width="601" height="783" alt="grafik" src="https://github.com/user-attachments/assets/45903d90-34eb-4f84-a11e-ea8d31d2a09c" />
