### PR TITLE
Fix issues when creating a new document

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -9,18 +9,7 @@ module FPO.Component.Splitview where
 import Prelude
 
 import Data.Argonaut (fromString)
-import Data.Array
-  ( cons
-  , deleteAt
-  , head
-  , insertAt
-  , mapWithIndex
-  , null
-  , snoc
-  , uncons
-  , updateAt
-  , (!!)
-  )
+import Data.Array (cons, deleteAt, head, insertAt, mapWithIndex, null, snoc, uncons, updateAt, (!!))
 import Data.Either (Either(..))
 import Data.Formatter.DateTime (Formatter)
 import Data.Int (toNumber)
@@ -41,24 +30,8 @@ import FPO.Data.Request as Request
 import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
-import FPO.Dto.DocumentDto.TreeDto
-  ( Edge(..)
-  , RootTree(..)
-  , Tree(..)
-  , findRootTree
-  , modifyNodeRootTree
-  )
-import FPO.Types
-  ( TOCEntry
-  , TOCTree
-  , documentTreeToTOCTree
-  , emptyTOCEntry
-  , findTOCEntry
-  , findTitleTOCEntry
-  , replaceTOCEntry
-  , timeStampsVersions
-  , tocTreeToDocumentTree
-  )
+import FPO.Dto.DocumentDto.TreeDto (Edge(..), RootTree(..), Tree(..), TreeHeader(..), findRootTree, modifyNodeRootTree)
+import FPO.Types (TOCEntry, TOCTree, documentTreeToTOCTree, emptyTOCEntry, findTOCEntry, findTitleTOCEntry, replaceTOCEntry, timeStampsVersions, tocTreeToDocumentTree)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -988,7 +961,7 @@ addRootNode [] entry (RootTree { children, header }) =
   RootTree { children: snoc children (Edge entry), header }
 addRootNode _ entry Empty =
   RootTree
-    { children: [ Edge entry ], header: { headerKind: "root", headerType: "root" } }
+    { children: [ Edge entry ], header: TreeHeader { headerKind: "root", headerType: "root", heading: "" } }
 addRootNode path entry (RootTree { children, header }) =
   case uncons path of
     Nothing ->
@@ -1179,7 +1152,7 @@ insertNodeAtPosition [] node tree =
   case tree of
     Empty -> RootTree
       { children: [ Edge node ]
-      , header: { headerKind: "root", headerType: "root" }
+      , header: TreeHeader { headerKind: "root", headerType: "root", heading: "" }
       }
     RootTree { children, header } ->
       RootTree { children: snoc children (Edge node), header }
@@ -1187,7 +1160,7 @@ insertNodeAtPosition [] node tree =
 insertNodeAtPosition _ node Empty =
   RootTree
     { children: [ Edge node ]
-    , header: { headerKind: "root", headerType: "root" }
+    , header: TreeHeader { headerKind: "root", headerType: "root", heading: "" }
     }
 
 insertNodeAtPosition path node (RootTree { children, header }) =

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -9,7 +9,18 @@ module FPO.Component.Splitview where
 import Prelude
 
 import Data.Argonaut (fromString)
-import Data.Array (cons, deleteAt, head, insertAt, mapWithIndex, null, snoc, uncons, updateAt, (!!))
+import Data.Array
+  ( cons
+  , deleteAt
+  , head
+  , insertAt
+  , mapWithIndex
+  , null
+  , snoc
+  , uncons
+  , updateAt
+  , (!!)
+  )
 import Data.Either (Either(..))
 import Data.Formatter.DateTime (Formatter)
 import Data.Int (toNumber)
@@ -30,8 +41,25 @@ import FPO.Data.Request as Request
 import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
-import FPO.Dto.DocumentDto.TreeDto (Edge(..), RootTree(..), Tree(..), TreeHeader(..), findRootTree, modifyNodeRootTree)
-import FPO.Types (TOCEntry, TOCTree, documentTreeToTOCTree, emptyTOCEntry, findTOCEntry, findTitleTOCEntry, replaceTOCEntry, timeStampsVersions, tocTreeToDocumentTree)
+import FPO.Dto.DocumentDto.TreeDto
+  ( Edge(..)
+  , RootTree(..)
+  , Tree(..)
+  , TreeHeader(..)
+  , findRootTree
+  , modifyNodeRootTree
+  )
+import FPO.Types
+  ( TOCEntry
+  , TOCTree
+  , documentTreeToTOCTree
+  , emptyTOCEntry
+  , findTOCEntry
+  , findTitleTOCEntry
+  , replaceTOCEntry
+  , timeStampsVersions
+  , tocTreeToDocumentTree
+  )
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -961,7 +989,9 @@ addRootNode [] entry (RootTree { children, header }) =
   RootTree { children: snoc children (Edge entry), header }
 addRootNode _ entry Empty =
   RootTree
-    { children: [ Edge entry ], header: TreeHeader { headerKind: "root", headerType: "root", heading: "" } }
+    { children: [ Edge entry ]
+    , header: TreeHeader { headerKind: "root", headerType: "root", heading: "" }
+    }
 addRootNode path entry (RootTree { children, header }) =
   case uncons path of
     Nothing ->

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -12,18 +12,7 @@ module FPO.Components.TOC
   , tocview
   ) where
 
-import Data.Array
-  ( concat
-  , cons
-  , drop
-  , last
-  , length
-  , mapWithIndex
-  , snoc
-  , take
-  , uncons
-  , unsnoc
-  )
+import Data.Array (concat, cons, drop, last, length, mapWithIndex, snoc, take, uncons, unsnoc)
 import Data.DateTime (DateTime)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -40,7 +29,7 @@ import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.DocumentDto.TreeDto (Edge(..), RootTree(..), Tree(..))
+import FPO.Dto.DocumentDto.TreeDto (TreeHeader(..), Edge(..), RootTree(..), Tree(..))
 import FPO.Dto.PostTextDto (PostTextDto(..))
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Page.Home (formatRelativeTime)
@@ -56,32 +45,7 @@ import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore)
 import Halogen.Store.Select (selectEq)
 import Halogen.Themes.Bootstrap5 as HB
-import Prelude
-  ( class Eq
-  , Unit
-  , bind
-  , const
-  , discard
-  , identity
-  , map
-  , negate
-  , not
-  , pure
-  , show
-  , unit
-  , when
-  , ($)
-  , (&&)
-  , (+)
-  , (-)
-  , (/=)
-  , (<)
-  , (<<<)
-  , (<>)
-  , (==)
-  , (>)
-  , (||)
-  )
+import Prelude (class Eq, Unit, bind, const, discard, identity, map, negate, not, pure, show, unit, when, ($), (&&), (+), (-), (/=), (<), (<<<), (<>), (==), (>), (||))
 import Simple.I18n.Translator (label, translate)
 import Web.Event.Event (preventDefault)
 import Web.HTML.Event.DragEvent (DragEvent, toEvent)
@@ -341,7 +305,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
         newEntry = Node
           { title: "New Section"
           , children: []
-          , header: { headerKind: "section", headerType: "section" }
+          , header: TreeHeader { headerKind: "section", headerType: "section", heading: "" }
           }
       H.raise (AddNode path newEntry)
 

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -12,7 +12,18 @@ module FPO.Components.TOC
   , tocview
   ) where
 
-import Data.Array (concat, cons, drop, last, length, mapWithIndex, snoc, take, uncons, unsnoc)
+import Data.Array
+  ( concat
+  , cons
+  , drop
+  , last
+  , length
+  , mapWithIndex
+  , snoc
+  , take
+  , uncons
+  , unsnoc
+  )
 import Data.DateTime (DateTime)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -29,7 +40,7 @@ import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.DocumentDto.TreeDto (TreeHeader(..), Edge(..), RootTree(..), Tree(..))
+import FPO.Dto.DocumentDto.TreeDto (Edge(..), RootTree(..), Tree(..), TreeHeader(..))
 import FPO.Dto.PostTextDto (PostTextDto(..))
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Page.Home (formatRelativeTime)
@@ -45,7 +56,32 @@ import Halogen.Store.Connect (Connected, connect)
 import Halogen.Store.Monad (class MonadStore)
 import Halogen.Store.Select (selectEq)
 import Halogen.Themes.Bootstrap5 as HB
-import Prelude (class Eq, Unit, bind, const, discard, identity, map, negate, not, pure, show, unit, when, ($), (&&), (+), (-), (/=), (<), (<<<), (<>), (==), (>), (||))
+import Prelude
+  ( class Eq
+  , Unit
+  , bind
+  , const
+  , discard
+  , identity
+  , map
+  , negate
+  , not
+  , pure
+  , show
+  , unit
+  , when
+  , ($)
+  , (&&)
+  , (+)
+  , (-)
+  , (/=)
+  , (<)
+  , (<<<)
+  , (<>)
+  , (==)
+  , (>)
+  , (||)
+  )
 import Simple.I18n.Translator (label, translate)
 import Web.Event.Event (preventDefault)
 import Web.HTML.Event.DragEvent (DragEvent, toEvent)
@@ -305,7 +341,8 @@ tocview = connect (selectEq identity) $ H.mkComponent
         newEntry = Node
           { title: "New Section"
           , children: []
-          , header: TreeHeader { headerKind: "section", headerType: "section", heading: "" }
+          , header: TreeHeader
+              { headerKind: "section", headerType: "section", heading: "" }
           }
       H.raise (AddNode path newEntry)
 

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -64,22 +64,12 @@ import FPO.Data.Store as Store
 import FPO.Dto.CreateDocumentDto (NewDocumentCreateDto)
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
+import FPO.Dto.DocumentDto.FullDocument (decodeFullDocument)
+import FPO.Dto.DocumentDto.FullDocument as FD
 import FPO.Dto.DocumentDto.Query as DQ
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.GroupDto
-  ( GroupCreate
-  , GroupDto
-  , GroupID
-  , GroupOverview
-  , toGroupOverview
-  )
-import FPO.Dto.UserDto
-  ( FullUserDto
-  , UserID
-  , getAllAdminRoles
-  , isAdminOf
-  , isUserSuperadmin
-  )
+import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview, toGroupOverview)
+import FPO.Dto.UserDto (FullUserDto, UserID, getAllAdminRoles, isAdminOf, isUserSuperadmin)
 import FPO.Dto.UserRoleDto (Role)
 import FPO.Translations.Translator (fromFpoTranslator)
 import Halogen as H
@@ -503,8 +493,8 @@ createNewDocument
   => MonadStore Store.Action Store.Store m
   => Navigate m
   => NewDocumentCreateDto
-  -> H.HalogenM st act slots msg m (Either AppError DH.DocumentHeader)
-createNewDocument dto = postJson decodeJson "/docs" (encodeJson dto)
+  -> H.HalogenM st act slots msg m (Either AppError FD.FullDocument)
+createNewDocument dto = postJson decodeFullDocument "/docs" (encodeJson dto)
 
 getDocumentsQueryFromURL
   :: forall st act slots msg m

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -68,8 +68,20 @@ import FPO.Dto.DocumentDto.FullDocument (decodeFullDocument)
 import FPO.Dto.DocumentDto.FullDocument as FD
 import FPO.Dto.DocumentDto.Query as DQ
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.GroupDto (GroupCreate, GroupDto, GroupID, GroupOverview, toGroupOverview)
-import FPO.Dto.UserDto (FullUserDto, UserID, getAllAdminRoles, isAdminOf, isUserSuperadmin)
+import FPO.Dto.GroupDto
+  ( GroupCreate
+  , GroupDto
+  , GroupID
+  , GroupOverview
+  , toGroupOverview
+  )
+import FPO.Dto.UserDto
+  ( FullUserDto
+  , UserID
+  , getAllAdminRoles
+  , isAdminOf
+  , isUserSuperadmin
+  )
 import FPO.Dto.UserRoleDto (Role)
 import FPO.Translations.Translator (fromFpoTranslator)
 import Halogen as H

--- a/frontend/src/FPO/Dto/CommentDto.purs
+++ b/frontend/src/FPO/Dto/CommentDto.purs
@@ -1,4 +1,5 @@
-module FPO.Dto.CommentDto where
+module FPO.Dto.CommentDto
+  where
 
 import Prelude
 

--- a/frontend/src/FPO/Dto/CommentDto.purs
+++ b/frontend/src/FPO/Dto/CommentDto.purs
@@ -1,5 +1,4 @@
-module FPO.Dto.CommentDto
-  where
+module FPO.Dto.CommentDto where
 
 import Prelude
 

--- a/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
@@ -5,7 +5,15 @@ module FPO.Dto.DocumentDto.DocumentTree where
 
 import Prelude
 
-import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, encodeJson, stringify, (.:))
+import Data.Argonaut
+  ( class DecodeJson
+  , Json
+  , JsonDecodeError
+  , decodeJson
+  , encodeJson
+  , stringify
+  , (.:)
+  )
 import Data.Either (Either)
 import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
@@ -23,7 +31,8 @@ type DocumentTreeTER = DocumentTree TextElementRevision
 
 type DocumentTree a = RootTree a
 
-decodeDocument :: forall a. DecodeJson a => Json -> Either JsonDecodeError (DocumentTree a)
+decodeDocument
+  :: forall a. DecodeJson a => Json -> Either JsonDecodeError (DocumentTree a)
 decodeDocument json = do
   obj <- decodeJson json
   let _ = unsafePerformEffect $ log $ "Full JSON: " <> stringify json

--- a/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
@@ -1,19 +1,35 @@
+-- | This module defines the `DocumentTree` type, which represents
+-- | the hierarchical structure of a document.
+
 module FPO.Dto.DocumentDto.DocumentTree where
 
 import Prelude
 
-import Data.Argonaut (Json, JsonDecodeError, decodeJson, encodeJson, (.:))
+import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, encodeJson, stringify, (.:))
 import Data.Either (Either)
+import Effect.Console (log)
+import Effect.Unsafe (unsafePerformEffect)
 import FPO.Dto.DocumentDto.NodeHeader as NH
+import FPO.Dto.DocumentDto.TextElementRevision (TextElementRevision)
 import FPO.Dto.DocumentDto.TreeDto (RootTree)
 
-type DocumentTree = RootTree NH.NodeHeader
+-- | A DocumentTree with NodeHeader (alias TextElement) nodes, as given by
+-- | the `GET /docs/{documentID}/tree/{treeRevision}` endpoint.
+type DocumentTreeTE = DocumentTree NH.NodeHeader
 
-decodeDocument :: Json -> Either JsonDecodeError DocumentTree
+-- | A DocumentTree with TextElementRevision nodes, as given by the
+-- | `POST docs` endpoint.
+type DocumentTreeTER = DocumentTree TextElementRevision
+
+type DocumentTree a = RootTree a
+
+decodeDocument :: forall a. DecodeJson a => Json -> Either JsonDecodeError (DocumentTree a)
 decodeDocument json = do
   obj <- decodeJson json
+  let _ = unsafePerformEffect $ log $ "Full JSON: " <> stringify json
+  -- TODO: We are ignoring `header` for now, but we might need it later.
   root <- obj .: "root"
   decodeJson root
 
-encodeDocumentTree :: DocumentTree -> Json
+encodeDocumentTree :: DocumentTree NH.NodeHeader -> Json
 encodeDocumentTree = encodeJson <<< map NH.getId

--- a/frontend/src/FPO/Dto/DocumentDto/FullDocument.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/FullDocument.purs
@@ -1,0 +1,28 @@
+module FPO.Dto.DocumentDto.FullDocument where
+
+import Prelude
+
+import Data.Argonaut (Json, JsonDecodeError, decodeJson, (.:))
+import Data.Either (Either)
+import Data.Maybe (Maybe)
+import Data.Traversable (traverse)
+import FPO.Dto.DocumentDto.DocumentHeader (DocumentHeader)
+import FPO.Dto.DocumentDto.DocumentTree (DocumentTreeTER, decodeDocument)
+
+newtype FullDocument = FullDocument
+  { header :: DocumentHeader
+  , body :: Maybe DocumentTreeTER
+  }
+
+getHeader :: FullDocument -> DocumentHeader
+getHeader (FullDocument fd) = fd.header
+
+getBody :: FullDocument -> Maybe DocumentTreeTER
+getBody (FullDocument fd) = fd.body
+
+decodeFullDocument :: Json -> Either JsonDecodeError FullDocument
+decodeFullDocument json = do
+  obj <- decodeJson json
+  header <- obj .: "header" >>= decodeJson
+  body <- obj .: "body" >>= traverse decodeDocument
+  pure $ FullDocument { header, body }

--- a/frontend/src/FPO/Dto/DocumentDto/NodeHeader.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/NodeHeader.purs
@@ -6,6 +6,7 @@ module FPO.Dto.DocumentDto.NodeHeader
 
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 
+-- This seems to be `TextElement` in the backend?
 newtype NodeHeader = NodeHeader
   { identifier :: Int
   , kind :: String

--- a/frontend/src/FPO/Dto/DocumentDto/TextElementRevision.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TextElementRevision.purs
@@ -4,12 +4,12 @@ import Data.Argonaut (class DecodeJson)
 import Data.Newtype (class Newtype)
 import FPO.Dto.DocumentDto.NodeHeader as NH
 
-newtype TextElementRevision
-    = TextElementRevision
-    { textElement :: NH.NodeHeader
-    -- TODO: Add text revision information
-    -- , revision :: Maybe TextRevision
-    }
+newtype TextElementRevision = TextElementRevision
+  { textElement :: NH.NodeHeader
+  -- TODO: Add text revision information
+  -- , revision :: Maybe TextRevision
+  }
 
 derive instance newtypeTextElementRevision :: Newtype TextElementRevision _
-derive newtype instance decodeJsonTextElementRevision :: DecodeJson TextElementRevision
+derive newtype instance decodeJsonTextElementRevision ::
+  DecodeJson TextElementRevision

--- a/frontend/src/FPO/Dto/DocumentDto/TextElementRevision.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TextElementRevision.purs
@@ -1,0 +1,15 @@
+module FPO.Dto.DocumentDto.TextElementRevision where
+
+import Data.Argonaut (class DecodeJson)
+import Data.Newtype (class Newtype)
+import FPO.Dto.DocumentDto.NodeHeader as NH
+
+newtype TextElementRevision
+    = TextElementRevision
+    { textElement :: NH.NodeHeader
+    -- TODO: Add text revision information
+    -- , revision :: Maybe TextRevision
+    }
+
+derive instance newtypeTextElementRevision :: Newtype TextElementRevision _
+derive newtype instance decodeJsonTextElementRevision :: DecodeJson TextElementRevision

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -138,7 +138,10 @@ instance encodeJsonTree :: EncodeJson a => EncodeJson (Tree a) where
 
 instance showTreeHeader :: Show TreeHeader where
   show (TreeHeader { headerKind, headerType, heading }) =
-    "TreeHeader { headerKind: " <> headerKind <> ", headerType: " <> headerType <> ", heading: " <> heading <> " }"
+    "TreeHeader { headerKind: " <> headerKind <> ", headerType: " <> headerType
+      <> ", heading: "
+      <> heading
+      <> " }"
 
 instance showRootTree :: Show a => Show (RootTree a) where
   show Empty = "Empty"

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -20,18 +20,13 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request
-  ( createNewDocument
-  , deleteIgnore
-  , getAuthorizedUser
-  , getDocumentsQueryFromURL
-  , getGroup
-  )
+import FPO.Data.Request (createNewDocument, deleteIgnore, getAuthorizedUser, getDocumentsQueryFromURL, getGroup)
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.CreateDocumentDto (NewDocumentCreateDto(..))
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
+import FPO.Dto.DocumentDto.FullDocument as FD
 import FPO.Dto.DocumentDto.Query as DQ
 import FPO.Dto.GroupDto (GroupDto, GroupID, getGroupName)
 import FPO.Page.Home (formatRelativeTime)
@@ -486,9 +481,11 @@ component =
             log "Created Document"
             now <- H.liftEffect nowDateTime
 
+            let header = FD.getHeader h
+
             H.modify_ \s' -> s'
-              { documents = h : s'.documents
-              , filteredDocuments = h : s'.filteredDocuments
+              { documents = header : s'.documents
+              , filteredDocuments = header : s'.filteredDocuments
               , currentTime = Just now
               }
 

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -20,7 +20,13 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Request (createNewDocument, deleteIgnore, getAuthorizedUser, getDocumentsQueryFromURL, getGroup)
+import FPO.Data.Request
+  ( createNewDocument
+  , deleteIgnore
+  , getAuthorizedUser
+  , getDocumentsQueryFromURL
+  , getGroup
+  )
 import FPO.Data.Route (Route(..))
 import FPO.Data.Store as Store
 import FPO.Dto.CreateDocumentDto (NewDocumentCreateDto(..))

--- a/frontend/src/FPO/Types.purs
+++ b/frontend/src/FPO/Types.purs
@@ -190,10 +190,10 @@ tocEntryToNodeHeader :: TOCEntry -> NH.NodeHeader
 tocEntryToNodeHeader { id, name } =
   NH.NodeHeader { identifier: id, kind: name }
 
-documentTreeToTOCTree :: DT.DocumentTree -> TOCTree
+documentTreeToTOCTree :: DT.DocumentTreeTE -> TOCTree
 documentTreeToTOCTree = map nodeHeaderToTOCEntry
 
-tocTreeToDocumentTree :: TOCTree -> DT.DocumentTree
+tocTreeToDocumentTree :: TOCTree -> DT.DocumentTreeTE
 tocTreeToDocumentTree = map tocEntryToNodeHeader
 
 -- Comment functions


### PR DESCRIPTION
Because of changes to the `POST /docs` endpoint used to create a new document, some of the frontend DTO structures have to be revised. This PR starts the process.

This pull request introduces improvements to the document tree data structures and their handling throughout the frontend codebase. The main focus is on better type safety, improved decoding/encoding of document trees, and supporting richer document tree node metadata. Notably, this includes the introduction of new types for document trees, a new module for full document decoding, and updates to ensure the new `TreeHeader` structure is used consistently.

**Document Tree Data Structure & Decoding Enhancements:**

* Added new types `DocumentTreeTE` and `DocumentTreeTER` to distinguish between trees containing `NodeHeader` and `TextElementRevision` nodes. Updated the decoding logic in `DocumentTree` to be generic and log the full JSON for debugging.
* Introduced a new `FullDocument` type and module, including a decoder for full documents that contain both header and body, and utility functions to access these parts.
* Added a new `TextElementRevision` type and its decoder, which will allow for richer revision tracking in document trees.

**Tree Header Improvements:**

* Changed `TreeHeader` from a type alias to a newtype, added a `heading` field, and implemented both decoding and encoding instances to handle this new structure. Also added a `Show` instance for easier debugging. [[1]](diffhunk://#diff-6ddbd2e3cb06a08dde005bd05b248bd6c0de605a7ffb5fc89966809829df8c41L24-R27) [[2]](diffhunk://#diff-6ddbd2e3cb06a08dde005bd05b248bd6c0de605a7ffb5fc89966809829df8c41R57-R65) [[3]](diffhunk://#diff-6ddbd2e3cb06a08dde005bd05b248bd6c0de605a7ffb5fc89966809829df8c41R101-R108) [[4]](diffhunk://#diff-6ddbd2e3cb06a08dde005bd05b248bd6c0de605a7ffb5fc89966809829df8c41L106-R124) [[5]](diffhunk://#diff-6ddbd2e3cb06a08dde005bd05b248bd6c0de605a7ffb5fc89966809829df8c41R139-R142)

**API Integration Updates:**

* Changed the `createNewDocument` request to return a full document (`FullDocument`) instead of just the document header, and updated the admin group document overview component to handle this new structure. [[1]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4L506-R497) [[2]](diffhunk://#diff-ed2b74ad38a19bc2141f411e7b34981ec342149057179997a7fa43de39af470cR484-R488)

These changes lay the groundwork for more robust document tree handling and future features such as revision tracking and richer metadata in document structures.

Some features are still missing, namely, the `FullDocument` structure is not fully implemented yet. For example, `TextElementRevision` is only partially implemented. For now, this is sufficient as the document creation modal works as expected (and the _admin document overview page_ only needs the document header anyways).

Closes #483 