### PR TITLE
backend/latex: switched from Lazytext to Text

### DIFF
--- a/backend/src/Language/Ltml/ToLaTeX.hs
+++ b/backend/src/Language/Ltml/ToLaTeX.hs
@@ -10,8 +10,8 @@ import Control.Monad.State (runState)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Text (Text)
-import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Encoding as TLE
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import Language.Lsd.AST.Type (NamedType (NamedType))
 import Language.Lsd.Example.Fpo (footnoteT, sectionT)
 import Language.Ltml.Parser (Parser)
@@ -64,7 +64,7 @@ runLatex texFile workDir = do
     return (exitCode, out, err)
 
 generatePDFfromParsed
-    :: Parser a -> (a -> LT.Text) -> Text -> IO (Either String BSL.ByteString)
+    :: Parser a -> (a -> T.Text) -> Text -> IO (Either String BSL.ByteString)
 generatePDFfromParsed parser render input =
     case runParser parser "" input of
         Left err -> return $ Left (errorBundlePretty err)
@@ -76,7 +76,7 @@ generatePDFfromParsed parser render input =
 
                 -- Write LaTeX source
                 -- LTIO.writeFile texFile (render parsedInput)
-                BSL.writeFile texFile (TLE.encodeUtf8 (render parsedInput))
+                BS.writeFile texFile (TE.encodeUtf8 (render parsedInput))
 
                 -- Compile with pdflatex
                 (exitCode, stdout, _) <- runLatex texFile tmpDir

--- a/backend/src/Language/Ltml/ToLaTeX/Format.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/Format.hs
@@ -16,7 +16,7 @@ module Language.Ltml.ToLaTeX.Format
     ) where
 
 import Data.Char (chr)
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text as T
 import Data.Typography
     ( FontSize (..)
     , FontStyle (..)
@@ -110,7 +110,7 @@ formatHeading (FormatString (StringAtom s : rest)) i latex =
     ISequence (map replace s) <> formatHeading (FormatString rest) i latex
   where
     replace '\n' = linebreak
-    replace c = IText (LT.pack [c])
+    replace c = IText (T.pack [c])
 formatHeading (FormatString (PlaceholderAtom a : rest)) i latex =
     case a of
         HeadingTextPlaceholder -> latex <> formatHeading (FormatString rest) i latex
@@ -119,7 +119,7 @@ formatHeading (FormatString (PlaceholderAtom a : rest)) i latex =
 formatKey :: KeyFormat -> PreLaTeX -> PreLaTeX
 formatKey (FormatString []) _ = mempty
 formatKey (FormatString (StringAtom s : rest)) n =
-    IText (LT.pack s) <> formatKey (FormatString rest) n
+    IText (T.pack s) <> formatKey (FormatString rest) n
 formatKey (FormatString (PlaceholderAtom KeyIdentifierPlaceholder : rest)) n =
     n <> formatKey (FormatString rest) n
 
@@ -154,32 +154,32 @@ staticDocumentFormat =
         , renewlist
         ]
 
-getIdentifier :: IdentifierFormat -> Int -> LT.Text
+getIdentifier :: IdentifierFormat -> Int -> T.Text
 getIdentifier (FormatString []) _ = mempty
 getIdentifier (FormatString (StringAtom s : rest)) i =
-    LT.pack s <> getIdentifier (FormatString rest) i
+    T.pack s <> getIdentifier (FormatString rest) i
 getIdentifier (FormatString (PlaceholderAtom a : rest)) i =
     case a of
-        Arabic -> LT.pack (show i) <> getIdentifier (FormatString rest) i
-        AlphabeticLower -> LT.pack [chr ((i - 1) `mod` 27 + 97)] <> getIdentifier (FormatString rest) i
-        AlphabeticUpper -> LT.pack [chr ((i - 1) `mod` 27 + 65)] <> getIdentifier (FormatString rest) i
+        Arabic -> T.pack (show i) <> getIdentifier (FormatString rest) i
+        AlphabeticLower -> T.pack [chr ((i - 1) `mod` 27 + 97)] <> getIdentifier (FormatString rest) i
+        AlphabeticUpper -> T.pack [chr ((i - 1) `mod` 27 + 65)] <> getIdentifier (FormatString rest) i
 
-getEnumStyle :: IdentifierFormat -> KeyFormat -> LT.Text
+getEnumStyle :: IdentifierFormat -> KeyFormat -> T.Text
 getEnumStyle ident key = "label=" <> buildKey (getEnumIdentifier' ident) key
   where
-    buildKey :: LT.Text -> KeyFormat -> LT.Text
+    buildKey :: T.Text -> KeyFormat -> T.Text
     buildKey _ ((FormatString [])) = mempty
     buildKey i ((FormatString (StringAtom s : rest))) =
-        LT.pack s <> buildKey i (FormatString rest)
+        T.pack s <> buildKey i (FormatString rest)
     buildKey
         i
         ((FormatString (PlaceholderAtom KeyIdentifierPlaceholder : rest))) =
             i <> buildKey i (FormatString rest)
 
-    getEnumIdentifier' :: IdentifierFormat -> LT.Text
+    getEnumIdentifier' :: IdentifierFormat -> T.Text
     getEnumIdentifier' (FormatString []) = mempty
     getEnumIdentifier' (FormatString (StringAtom s : rest)) =
-        LT.pack s <> getEnumIdentifier' (FormatString rest)
+        T.pack s <> getEnumIdentifier' (FormatString rest)
     getEnumIdentifier' (FormatString (PlaceholderAtom a : rest)) =
         case a of
             Arabic -> "\\arabic*" <> getEnumIdentifier' (FormatString rest)
@@ -199,7 +199,7 @@ formatHeaderFooterItem superTitle title date (HeaderFooterItemFormat fontsize st
         ISequence (map replace s) <> formatHeaderFooterFstring (FormatString rest)
       where
         replace '\n' = linebreak
-        replace c = IText (LT.pack [c])
+        replace c = IText (T.pack [c])
     formatHeaderFooterFstring (FormatString (PlaceholderAtom a : rest)) =
         case a of
             HeaderFooterSuperTitleAtom -> superTitle <> formatHeaderFooterFstring (FormatString rest)

--- a/backend/src/Language/Ltml/ToLaTeX/GlobalState.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/GlobalState.hs
@@ -60,7 +60,6 @@ import Control.Monad.State (State)
 import qualified Data.DList as DList
 import Data.Map (Map, insert)
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as LT
 import Language.Lsd.AST.Format (IdentifierFormat, KeyFormat, MainHeadingFormat)
 import Language.Lsd.AST.Type.AppendixSection (AppendixElementFormat)
 import Language.Lsd.AST.Type.DocumentContainer
@@ -96,7 +95,7 @@ data GlobalState = GlobalState
     , {- since the style of the identifier is defined globally for an
          enumeration or appendix we need to pass it to the kids -}
       {- Maps for labels -}
-      _labelToRef :: Map Label LT.Text
+      _labelToRef :: Map Label T.Text
     , _labelToFootNote :: Map Label Footnote
     , {- functional list that builds the table of contents -}
       _toc :: DList.DList PreLaTeX
@@ -196,7 +195,7 @@ descendEnumTree action = do
     enumPosition .= oldPath
     pure result
 
-insertRefLabel :: Maybe Label -> LT.Text -> State GlobalState ()
+insertRefLabel :: Maybe Label -> T.Text -> State GlobalState ()
 insertRefLabel mLabel ident =
     forM_ mLabel $ \l -> labelToRef %= insert l ident
 
@@ -239,9 +238,9 @@ addHeaderFooter
     superTitle
     title
     date = do
-        let superTitle' = IText $ LT.fromStrict superTitle
-            title' = IText $ LT.fromStrict title
-            date' = IText $ LT.fromStrict date
+        let superTitle' = IText superTitle
+            title' = IText title
+            date' = IText date
             assemble items = ISequence $ map (formatHeaderFooterItem superTitle' title' date') items
         preDocument
             %= ( <>

--- a/backend/src/Language/Ltml/ToLaTeX/LaTeXType.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/LaTeXType.hs
@@ -2,14 +2,14 @@ module Language.Ltml.ToLaTeX.LaTeXType
     ( LaTeX (..)
     ) where
 
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text as T
 
 data LaTeX
-    = Text LT.Text
-    | Raw LT.Text -- raw unescaped LaTeX
-    | CommandS LT.Text -- \command
-    | Command LT.Text [LT.Text] [LaTeX] -- \command[opts]{args}
-    | Environment LT.Text [LT.Text] [LaTeX] -- \begin{env}[opts] ... \end{env}
+    = Text T.Text
+    | Raw T.Text -- raw unescaped LaTeX
+    | CommandS T.Text -- \command
+    | Command T.Text [T.Text] [LaTeX] -- \command[opts]{args}
+    | Environment T.Text [T.Text] [LaTeX] -- \begin{env}[opts] ... \end{env}
     | Braced LaTeX -- used for wrapping in braces
     | Sequence [LaTeX] -- concatenation
     deriving (Show)

--- a/backend/src/Language/Ltml/ToLaTeX/PreLaTeXType.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/PreLaTeXType.hs
@@ -44,15 +44,15 @@ module Language.Ltml.ToLaTeX.PreLaTeXType
     , enumStyle
     ) where
 
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text as T
 import Language.Ltml.AST.Label (Label (Label))
 
 data PreLaTeX
-    = IText LT.Text
-    | IRaw LT.Text -- raw unescaped PreLaTeX
-    | ICommandS LT.Text -- \command
-    | ICommand LT.Text [LT.Text] [PreLaTeX] -- \command[opts]{args}
-    | IEnvironment LT.Text [LT.Text] [PreLaTeX] -- \begin{env}[opts] ... \end{env}
+    = IText T.Text
+    | IRaw T.Text -- raw unescaped PreLaTeX
+    | ICommandS T.Text -- \command
+    | ICommand T.Text [T.Text] [PreLaTeX] -- \command[opts]{args}
+    | IEnvironment T.Text [T.Text] [PreLaTeX] -- \begin{env}[opts] ... \end{env}
     | IBraced PreLaTeX -- used for wrapping in braces
     | ISequence [PreLaTeX] -- concatenation
     {- the reason why we introduced this intermediate data type: -}
@@ -82,7 +82,7 @@ instance Monoid PreLaTeX where
 -------------------------------------------------------------------------------
 {-                                styling                                   -}
 
-text :: LT.Text -> PreLaTeX
+text :: T.Text -> PreLaTeX
 text = IText
 
 bold :: PreLaTeX -> PreLaTeX
@@ -107,36 +107,36 @@ footnote :: PreLaTeX -> PreLaTeX
 footnote = ICommand "footnote" [] . (: [])
 
 hypertarget :: Label -> PreLaTeX -> PreLaTeX
-hypertarget (Label l) latex = ICommand "hypertarget" [] [IText (LT.fromStrict l), latex]
+hypertarget (Label l) latex = ICommand "hypertarget" [] [IText l, latex]
 
 hyperlink :: Label -> PreLaTeX -> PreLaTeX
-hyperlink (Label l) latex = ICommand "hyperlink" [] [IText (LT.fromStrict l), latex]
+hyperlink (Label l) latex = ICommand "hyperlink" [] [IText l, latex]
 
-label :: LT.Text -> PreLaTeX
+label :: T.Text -> PreLaTeX
 label l = ICommand "label" [] [IText l]
 
-footref :: LT.Text -> PreLaTeX
+footref :: T.Text -> PreLaTeX
 footref r = ICommand "footref" [] [IText r]
 
 -------------------------------------------------------------------------------
 {-                             setup and metadata                             -}
 
-usepackage :: [LT.Text] -> LT.Text -> PreLaTeX
+usepackage :: [T.Text] -> T.Text -> PreLaTeX
 usepackage opts package = ICommand "usepackage" opts [IText package]
 
-documentclass :: [LT.Text] -> LT.Text -> PreLaTeX
+documentclass :: [T.Text] -> T.Text -> PreLaTeX
 documentclass opts name = ICommand "documentclass" opts [IText name]
 
-fancyhead :: [LT.Text] -> PreLaTeX -> PreLaTeX
+fancyhead :: [T.Text] -> PreLaTeX -> PreLaTeX
 fancyhead opts content = ICommand "fancyhead" opts [content]
 
-fancyfoot :: [LT.Text] -> PreLaTeX -> PreLaTeX
+fancyfoot :: [T.Text] -> PreLaTeX -> PreLaTeX
 fancyfoot opts content = ICommand "fancyfoot" opts [content]
 
 resetfootnote :: PreLaTeX
 resetfootnote = ICommand "setcounter" [] [IText "footnote", IText "0"]
 
-setpdftitle :: LT.Text -> PreLaTeX
+setpdftitle :: T.Text -> PreLaTeX
 setpdftitle title = ICommand "hypersetup" [] [IText $ "pdftitle={" <> title <> "}"]
 
 -------------------------------------------------------------------------------
@@ -157,7 +157,7 @@ hrule = ICommandS "hrule"
 -------------------------------------------------------------------------------
 {-                              environments                                 -}
 
-enumerate :: [LT.Text] -> [PreLaTeX] -> PreLaTeX
+enumerate :: [T.Text] -> [PreLaTeX] -> PreLaTeX
 enumerate opts items = IEnvironment "enumerate" opts (map (\i -> ICommand "item" [] [i]) items)
 
 itemize :: [PreLaTeX] -> PreLaTeX
@@ -172,7 +172,7 @@ flushleft = IEnvironment "flushleft" []
 flushright :: [PreLaTeX] -> PreLaTeX
 flushright = IEnvironment "flushright" []
 
-minipage :: [LT.Text] -> [PreLaTeX] -> PreLaTeX
+minipage :: [T.Text] -> [PreLaTeX] -> PreLaTeX
 minipage = IEnvironment "minipage"
 
 document :: PreLaTeX -> PreLaTeX

--- a/backend/src/Language/Ltml/ToLaTeX/Testing.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/Testing.hs
@@ -15,8 +15,6 @@ import Control.Monad.State (runState)
 import qualified Data.ByteString.Lazy as BS
 import Data.Text (Text)
 import qualified Data.Text.IO as TIO
-import qualified Data.Text.Lazy.IO as LT
-import qualified Data.Text.Lazy.IO as LTIO
 import Data.Typography
     ( FontSize (MediumFontSize, SmallFontSize)
     , FontStyle (Bold)
@@ -125,7 +123,7 @@ runTestToLaTeX = do
         Right parsedInput -> do
             let texFile = "./src/Language/Ltml/ToLaTeX/Auxiliary/test.tex"
             -- Write PreLaTeX source
-            LTIO.writeFile texFile (sectionToText parsedInput)
+            TIO.writeFile texFile (sectionToText parsedInput)
             return "everything went well!"
   where
     sectionToText (sec, labelmap) =
@@ -328,6 +326,6 @@ testingDocumentContainer =
 startTesting :: IO ()
 startTesting = do
     let (latex, gs) = testThis testingDocumentContainer
-    LT.putStrLn $
+    TIO.putStrLn $
         renderLaTeX $
             toLaTeX (view labelToRef gs) (view preDocument gs <> document latex)

--- a/backend/src/Language/Ltml/ToLaTeX/ToLaTeX.hs
+++ b/backend/src/Language/Ltml/ToLaTeX/ToLaTeX.hs
@@ -4,12 +4,12 @@ module Language.Ltml.ToLaTeX.ToLaTeX (toLaTeX)
 where
 
 import qualified Data.Map as Map
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text as T
 import Language.Ltml.AST.Label (Label (Label))
 import Language.Ltml.ToLaTeX.LaTeXType (LaTeX (..))
 import Language.Ltml.ToLaTeX.PreLaTeXType (PreLaTeX (..))
 
-toLaTeX :: Map.Map Label LT.Text -> PreLaTeX -> LaTeX
+toLaTeX :: Map.Map Label T.Text -> PreLaTeX -> LaTeX
 toLaTeX _ (IText t) = Text t
 toLaTeX _ (IRaw r) = Raw r
 toLaTeX _ (ICommandS n) = CommandS n
@@ -24,6 +24,6 @@ toLaTeX m (MissingRef l@(Label t)) =
             Command
                 "hyperlink"
                 []
-                [ Text (LT.fromStrict t)
+                [ Text t
                 , Text ref
                 ]


### PR DESCRIPTION
i noticed that using Data.Text.Lazy made no difference to simply using Data.Text. Since the rest of the AST is also based on Data.Text, i revised my code to "fit in".