### PR TITLE
Unauthorized bug

### DIFF
--- a/backend/src/Server/HandlerUtil.hs
+++ b/backend/src/Server/HandlerUtil.hs
@@ -135,50 +135,50 @@ getGroupOfDocument conn docID = do
 
 -- Specific errors
 errDatabaseConnectionFailed :: ServerError
-errDatabaseConnectionFailed = err500 {errBody = "Connection to database failed!"}
+errDatabaseConnectionFailed = err500 {errBody = "\"Connection to database failed!\""}
 
 errDatabaseAccessFailed :: ServerError
-errDatabaseAccessFailed = err500 {errBody = "Database access failed!"}
+errDatabaseAccessFailed = err500 {errBody = "\"Database access failed!\""}
 
 errFailedToSetRole :: ServerError
-errFailedToSetRole = err500 {errBody = "Failed to set role in Database!"}
+errFailedToSetRole = err500 {errBody = "\"Failed to set role in Database!\""}
 
 errNoMemberOfThisGroup :: ServerError
 errNoMemberOfThisGroup =
     err403
-        { errBody = "You have to be Member of the group to perform this action!"
+        { errBody = "\"You have to be Member of the group to perform this action!\""
         }
 
 errNoAdminOfThisGroup :: ServerError
 errNoAdminOfThisGroup =
     err403
-        { errBody = "You have to be Admin of the group to perform this action!"
+        { errBody = "\"You have to be Admin of the group to perform this action!\""
         }
 
 errNoAdminInAnyGroup :: ServerError
-errNoAdminInAnyGroup = err403 {errBody = "You have to be an Admin to perform this action!"}
+errNoAdminInAnyGroup = err403 {errBody = "\"You have to be an Admin to perform this action!\""}
 
 errSuperAdminOnly :: ServerError
 errSuperAdminOnly =
-    err403 {errBody = "You have to be Superadmin to perform this action!"}
+    err403 {errBody = "\"You have to be Superadmin to perform this action!\""}
 
 errNotLoggedIn :: ServerError
 errNotLoggedIn =
     err401
-        { errBody = "Not allowed! You need to be logged in to perform this action."
+        { errBody = "\"Not allowed! You need to be logged in to perform this action.\""
         }
 
 errUserCreationFailed :: ServerError
-errUserCreationFailed = err500 {errBody = "User creation failed!"}
+errUserCreationFailed = err500 {errBody = "\"User creation failed!\""}
 
 errUserNotFound :: ServerError
-errUserNotFound = err404 {errBody = "User not member of this group."}
+errUserNotFound = err404 {errBody = "\"User not member of this group.\""}
 
 errEmailAlreadyUsed :: ServerError
-errEmailAlreadyUsed = err409 {errBody = "Email is already in use."}
+errEmailAlreadyUsed = err409 {errBody = "\"Email is already in use.\""}
 
 errDocumentDoesNotExist :: ServerError
-errDocumentDoesNotExist = err404 {errBody = "Document not found."}
+errDocumentDoesNotExist = err404 {errBody = "\"Document not found.\""}
 
 errNoPermission :: ServerError
-errNoPermission = err403 {errBody = "Insufficient permission to perform this action."}
+errNoPermission = err403 {errBody = "\"Insufficient permission to perform this action.\""}

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -626,26 +626,23 @@ splitview = connect selectTranslator $ H.mkComponent
 
     GET -> do
       s <- H.get
-      -- TODO: Here, we can simply fetch the latest commit (head commit) of the document and
-      --       write the content into the editor. Because requests like these are very common,
-      --       we should think of a way to have a uniform and clean request handling system, especially
-      --       regarding authentification and error handling. Right now, the editor page is simply empty
-      --       if the document retrieval fails in any way.
-      maybeTree <- H.liftAff
-        $ Request.getFromJSONEndpoint DT.decodeDocument
-        $ "/docs/" <> show s.docID <> "/tree/latest"
-      let
-        finalTree = fromMaybe Empty (documentTreeToTOCTree <$> maybeTree)
-        vMapping = map
-          ( \elem ->
-              { elementID: elem.id, versionID: Nothing, comparisonData: Nothing }
-          )
-          finalTree
-      H.modify_ _
-        { tocEntries = finalTree
-        , versionMapping = vMapping
-        }
-      H.tell _toc unit (TOC.ReceiveTOCs finalTree)
+      maybeTree <- Request.getJson DT.decodeDocument
+        ("/docs/" <> show s.docID <> "/tree/latest")
+      case maybeTree of
+        Left _ -> pure unit
+        Right tree -> do
+          let
+            finalTree = documentTreeToTOCTree tree
+            vMapping = map
+              ( \elem ->
+                  { elementID: elem.id, versionID: Nothing, comparisonData: Nothing }
+              )
+              finalTree
+          H.modify_ _
+            { tocEntries = finalTree
+            , versionMapping = vMapping
+            }
+          H.tell _toc unit (TOC.ReceiveTOCs finalTree)
 
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -33,7 +33,6 @@ import Data.String.Regex (regex, replace)
 import Data.String.Regex.Flags (noFlags)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import Effect.Now (nowDateTime)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Data.Navigate (class Navigate)
@@ -266,10 +265,10 @@ tocview = connect (selectEq identity) $ H.mkComponent
     -- the newest version requested in this action is assumed to be the newest version in general
     UpdateVersions ts elementID -> do
       s <- H.get
-      history <- H.liftAff $ getTextElemHistory s.docID elementID (DD.DocDate ts) 5
+      history <- getTextElemHistory s.docID elementID (DD.DocDate ts) 5
       case history of
-        Nothing -> do liftEffect $ log "unable to load textElements"
-        Just h -> do
+        Left _ -> pure unit
+        Right h -> do
           let
             nV = map
               ( \hEntry ->

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -37,7 +37,6 @@ import Data.String.Regex.Flags (noFlags)
 import Data.Time.Duration (Minutes)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import Effect.Now (getTimezoneOffset, nowDateTime)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Data.Navigate (class Navigate)
@@ -293,7 +292,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
     -- the newest version requested in this action is assumed to be the newest version in general
     UpdateVersions ts elementID -> do
       s <- H.get
-      history <- getTextElemHistory s.docID elementID (DD.DocDate ts) 5
+      history <- getTextElemHistoryAll s.docID elementID (DD.DocDate ts)
       case history of
         Left _ -> pure unit
         Right h -> do

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -197,8 +197,6 @@ handleAppError
   -> H.HalogenM st act slots msg m Unit
 handleAppError err = do
   s <- getStore
-  H.liftEffect $ log $ ("Handling AppError: " <> (show s.handleRequestError))
-
   when s.handleRequestError $ do
     updateStore $ Store.AddError err
     case err of

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -20,7 +20,6 @@ module FPO.Data.Request
   , getIgnore
   , getJson
   , getString
-  , getTextElemHistory
   , getTextElemHistoryAll
   , getUser
   , getUserDocuments
@@ -529,7 +528,7 @@ getDocumentsQueryFromURL
   -> H.HalogenM st act slots msg m (Either AppError DQ.DocumentQuery)
 getDocumentsQueryFromURL url = getJson decodeJson url
 
-getTextElemHistory
+getTextElemHistoryAll
   :: forall st act slots msg m
    . MonadAff m
   => MonadStore Store.Action Store.Store m
@@ -537,24 +536,9 @@ getTextElemHistory
   => DH.DocumentID
   -> TE.TextElementID
   -> DD.DocDate
-  -> Int
   -> H.HalogenM st act slots msg m (Either AppError TE.FullTextElementHistory)
-getTextElemHistory docID tID date limit =
-  getJson
-    decodeJson
-    ( "/docs/" <> show docID <> "/text/" <> show tID <> "/history?before="
-        <> DD.toStringFormat date
-        <> "&limit="
-        <> show limit
-    )
-
-getTextElemHistoryAll
-  :: DH.DocumentID
-  -> TE.TextElementID
-  -> DD.DocDate
-  -> Aff (Maybe TE.FullTextElementHistory)
 getTextElemHistoryAll dID tID date =
-  getFromJSONEndpoint
+  getJson
     decodeJson
     ( "/docs/" <> show dID <> "/text/" <> show tID <> "/history?before="
         <> DD.toStringFormat date


### PR DESCRIPTION
This pull request refactors request handling and error management across both the frontend and backend. The main improvements include standardizing error message formatting on the backend, consistently adopting the new `getJson` request pattern in the frontend, and updating error handling logic to use `Either` for clearer and more robust failure handling.

**Backend error message formatting:**

* All error messages in `backend/src/Server/HandlerUtil.hs` are now wrapped in double quotes for consistency and potential frontend parsing requirements.

**Frontend request and error handling:**

_Request pattern standardization:_

* Replaced usage of `getFromJSONEndpoint` with the new `getJson` function in multiple components (`Editor`, `Splitview`, `TOC`) to unify request handling, improve error propagation, and simplify code. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL914-R919) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1381-R1388) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL629-R635) [[4]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4L533-R544)

_Error handling improvements:_

* Updated request results to use `Either AppError result` instead of `Maybe result`, allowing for explicit error handling and improved user feedback (e.g., showing errors instead of silently failing). [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL914-R919) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL629-R635) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL269-R271) [[4]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4L533-R544)
* The `handleAppError` function in `frontend/src/FPO/Data/Request.purs` was cleaned up for clarity and consistency.

_Code cleanup:_

* Removed unused imports such as `Effect.Console (log)` from `frontend/src/FPO/Components/TOC.purs`.