### PR TITLE
Small fixes in frontend editor

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -30,7 +30,6 @@ import Effect (Effect)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class as EC
-import Effect.Console (log)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import FPO.Components.Editor.AceExtra
@@ -1156,7 +1155,6 @@ editor = connect selectTranslator $ H.mkComponent
               newEntry = insert lm.markerText (oldValue + 1) entry
             in
               insert startRow newEntry commentState.markerAnnoHS
-      H.liftEffect $ log $ "markerAnnoHS: " <> show (size commentState.markerAnnoHS)
       H.modify_ \st -> st
         { commentState = st.commentState
             { markerAnnoHS = newMarkerAnnoHS
@@ -1369,7 +1367,6 @@ editor = connect selectTranslator $ H.mkComponent
 
     ChangeSection entry rev a -> do
       handleAction (ChangeToSection entry rev)
-      H.liftEffect $ log "changedSec"
       pure (Just a)
 
     ContinueChangeSection fCs a -> do

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -205,8 +205,6 @@ data Action
   | Save Boolean
   -- Subsection of Save
   | Upload TOCEntry ContentWrapper Boolean
-  -- Subsection of Upload
-  | LostParentID TOCEntry ContentWrapper Boolean
   | SavedIcon
   -- new change in editor -> reset timer
   | AutoSaveTimer
@@ -761,7 +759,8 @@ editor = connect selectTranslator $ H.mkComponent
 
       -- handle errors in pos and decodeJson
       case response of
-        Left _ -> handleAction $ LostParentID newEntry newWrapper isAutoSave
+        -- if error, try to Save again (Maybe ParentID is lost?)
+        Left _ -> handleAction (Sace isAutoSave)
         -- extract and insert new parentID into newContent
         Right updatedContent -> do
           H.raise (SavedSection newEntry)
@@ -777,23 +776,6 @@ editor = connect selectTranslator $ H.mkComponent
           -- mDirtyRef := false
           for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
           pure unit
-
-    LostParentID newEntry newWrapper isAutoSave -> do
-      let newContent = ContentDto.getWrapperContent newWrapper
-      docID <- H.gets _.docID
-      loadedContent <- Request.getJson
-        ContentDto.decodeContent
-        ("/docs/" <> show docID <> "/text/" <> show newEntry.id <> "/rev/latest")
-      case loadedContent of
-        Left _ -> pure unit
-        Right res ->
-          let
-            newContent' = ContentDto.setContentText
-              (ContentDto.getContentText newContent)
-              res
-            newWrapper' = ContentDto.setWrapperContent newContent' newWrapper
-          in
-            handleAction $ Upload newEntry newWrapper' isAutoSave
 
     SavedIcon -> do
       mSavedIconF <- H.gets _.saveState.mSavedIconF

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -760,7 +760,7 @@ editor = connect selectTranslator $ H.mkComponent
       -- handle errors in pos and decodeJson
       case response of
         -- if error, try to Save again (Maybe ParentID is lost?)
-        Left _ -> handleAction (Sace isAutoSave)
+        Left _ -> handleAction (Save isAutoSave)
         -- extract and insert new parentID into newContent
         Right updatedContent -> do
           H.raise (SavedSection newEntry)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -716,7 +716,9 @@ splitview = connect selectTranslator $ H.mkComponent
 
         _ -> pure unit
 
-      when (isJust mt) (H.tell _editor 0 (Editor.EditorResize))
+      when (isJust mt) do
+        H.tell _editor 0 (Editor.EditorResize)
+        H.tell _editor 1 (Editor.EditorResize)
 
     -- Toggle actions
 
@@ -776,6 +778,7 @@ splitview = connect selectTranslator $ H.mkComponent
           { sidebarRatio = st.lastExpandedSidebarRatio
           , sidebarShown = true
           }
+      H.tell _editor 0 (Editor.EditorResize)
 
     -- Toggle the preview area
     TogglePreview -> do
@@ -821,6 +824,8 @@ splitview = connect selectTranslator $ H.mkComponent
           { previewRatio = st.lastExpandedPreviewRatio
           , previewShown = true
           }
+      H.tell _editor 0 (Editor.EditorResize)
+      H.tell _editor 1 (Editor.EditorResize)
 
     ModifyVersionMapping tocID vID cData -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -824,8 +824,10 @@ splitview = connect selectTranslator $ H.mkComponent
           { previewRatio = st.lastExpandedPreviewRatio
           , previewShown = true
           }
+        -- only resize second editor, when visible
+        H.tell _editor 1 (Editor.EditorResize)
+      -- always resize main editor for each call
       H.tell _editor 0 (Editor.EditorResize)
-      H.tell _editor 1 (Editor.EditorResize)
 
     ModifyVersionMapping tocID vID cData -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -28,7 +28,6 @@ import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.String (joinWith)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -1007,7 +1006,6 @@ splitview = connect selectTranslator $ H.mkComponent
         handleAction $ ToggleCommentOverview true docID tocID
 
       Editor.RaiseDiscard -> do
-        H.liftEffect $ log "reached discarding"
         handleAction UpdateMSelectedTocEntry
         state <- H.get
         -- Only the SelLeaf case should ever occur

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -437,9 +437,11 @@ tocview = connect (selectEq identity) $ H.mkComponent
 
     JumpToLeafSection id path -> do
       handleAction (ToggleHistoryMenuOff path)
-      H.modify_ \state ->
-        state { mSelectedTocEntry = Just $ SelLeaf id }
-      H.raise (ChangeToLeaf id)
+      mSelectedTocEntry <- H.gets _.mSelectedTocEntry
+      when (mSelectedTocEntry /= Just (SelLeaf id)) do
+        H.modify_ \state ->
+          state { mSelectedTocEntry = Just $ SelLeaf id }
+        H.raise (ChangeToLeaf id)
 
     ToggleAddMenu path -> do
       H.modify_ \state ->
@@ -844,8 +846,11 @@ tocview = connect (selectEq identity) $ H.mkComponent
           [ HP.classes innerDivBaseClasses
           , HP.style "cursor: pointer;"
           ] <>
-            ( if level > 0 then [ HE.onClick \_ -> JumpToLeafSection id path ]
-              else []
+          -- Stop to be able to click, if alredy selected (prevent spamming post requests)
+            ( if level > 0 && mSelectedTocEntry /= Just (SelLeaf id) then [
+                HE.onClick \_ -> JumpToLeafSection id path ]
+              else 
+                []
             )
       in
         [ HH.div
@@ -1094,10 +1099,6 @@ tocview = connect (selectEq identity) $ H.mkComponent
                   versions
               )
           ]
-    {-     versionHistoryMenu =
-    map
-      (\v -> addVersionButton v)
-      versions -}
 
     searchBarSegment =
       [ HH.div
@@ -1134,40 +1135,6 @@ tocview = connect (selectEq identity) $ H.mkComponent
                   (SearchVersions elementID)
                   "bi bi-search"
                   "search"
-              {- HH.button
-                  [ HP.classes $
-                      [ HB.btn
-                      , HB.btnPrimary
-                      -- , HB.textStart
-                      , HB.w100
-                      , HB.border0
-                      -- , HB.textBody
-                      , HB.dFlex
-                      , HB.alignItemsCenter
-                      -- , HH.ClassName "toc-item"
-                      -- , HH.ClassName "active"
-                      ]
-
-                  , HE.onClick \_ -> DoNothing
-                  ]
-                  [ HH.text "clear" ]
-              ,  -} {- HH.button
-              [ HP.classes $  
-                  [ HB.btn
-                  , HB.btnSecondary
-                  --, HB.textStart
-                  , HB.w100
-                  , HB.border0
-                  --, HB.textBody
-                  , HB.dFlex
-                  , HB.alignItemsCenter
-                  --, HH.ClassName "toc-item"
-                  -- , HH.ClassName "active"
-                  ]
-
-              , HE.onClick \_ -> DoNothing
-              ]
-              [ HH.text "search" ] -}
               ]
           ]
       ]

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -236,22 +236,22 @@ tocview = connect (selectEq identity) $ H.mkComponent
   render :: State -> forall slots. H.ComponentHTML Action slots m
   render state =
     HH.div
-    [ HP.classes [ HH.ClassName "leftscrollbar" ] ]
-    [ HH.div_ $
-        renderDeleteModal
-          <>
-            ( rootTreeToHTML
-                state
-                state.documentName
-                state.showAddMenu
-                state.showHistoryMenu
-                state.mSelectedTocEntry
-                state.now
-                state.filteredTree
-                state.searchData
-                state.tocEntries
-            )
-    ]
+      [ HP.classes [ HH.ClassName "leftscrollbar" ] ]
+      [ HH.div_ $
+          renderDeleteModal
+            <>
+              ( rootTreeToHTML
+                  state
+                  state.documentName
+                  state.showAddMenu
+                  state.showHistoryMenu
+                  state.mSelectedTocEntry
+                  state.now
+                  state.filteredTree
+                  state.searchData
+                  state.tocEntries
+              )
+      ]
     where
     renderDeleteModal = case state.requestDelete of
       Nothing -> []
@@ -849,10 +849,11 @@ tocview = connect (selectEq identity) $ H.mkComponent
           [ HP.classes innerDivBaseClasses
           , HP.style "cursor: pointer;"
           ] <>
-          -- Stop to be able to click, if alredy selected (prevent spamming post requests)
-            ( if level > 0 && mSelectedTocEntry /= Just (SelLeaf id) then [
-                HE.onClick \_ -> JumpToLeafSection id path ]
-              else 
+            -- Stop to be able to click, if alredy selected (prevent spamming post requests)
+            ( if level > 0 && mSelectedTocEntry /= Just (SelLeaf id) then
+                [ HE.onClick \_ -> JumpToLeafSection id path
+                ]
+              else
                 []
             )
       in

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -235,20 +235,23 @@ tocview = connect (selectEq identity) $ H.mkComponent
 
   render :: State -> forall slots. H.ComponentHTML Action slots m
   render state =
-    HH.div_ $
-      renderDeleteModal
-        <>
-          ( rootTreeToHTML
-              state
-              state.documentName
-              state.showAddMenu
-              state.showHistoryMenu
-              state.mSelectedTocEntry
-              state.now
-              state.filteredTree
-              state.searchData
-              state.tocEntries
-          )
+    HH.div
+    [ HP.classes [ HH.ClassName "leftscrollbar" ] ]
+    [ HH.div_ $
+        renderDeleteModal
+          <>
+            ( rootTreeToHTML
+                state
+                state.documentName
+                state.showAddMenu
+                state.showHistoryMenu
+                state.mSelectedTocEntry
+                state.now
+                state.filteredTree
+                state.searchData
+                state.tocEntries
+            )
+    ]
     where
     renderDeleteModal = case state.requestDelete of
       Nothing -> []

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -58,7 +58,6 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import FPO.Data.AppError (AppError(..), printAjaxError)
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Route (Route(..))
@@ -226,7 +225,6 @@ handleJsonRequest' decode url requestAction = do
     Right json -> do
       case decode json of
         Left err -> do
-          liftEffect $ log $ "JSON decode error: " <> show err
           pure $ Left $ DataError $ "Invalid data format: " <> show err
         Right val ->
           pure $ Right val
@@ -252,8 +250,7 @@ getFromJSONEndpoint decode url = do
       pure Nothing
     Right res -> do
       case decode (res.body) of
-        Left err -> do
-          liftEffect $ log $ "Error Decoding: " <> show err
+        Left _ -> do
           pure Nothing
         Right val -> do
           pure $ Just val

--- a/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
@@ -11,12 +11,9 @@ import Data.Argonaut
   , JsonDecodeError
   , decodeJson
   , encodeJson
-  , stringify
   , (.:)
   )
 import Data.Either (Either)
-import Effect.Console (log)
-import Effect.Unsafe (unsafePerformEffect)
 import FPO.Dto.DocumentDto.NodeHeader as NH
 import FPO.Dto.DocumentDto.TextElementRevision (TextElementRevision)
 import FPO.Dto.DocumentDto.TreeDto (RootTree)
@@ -35,7 +32,6 @@ decodeDocument
   :: forall a. DecodeJson a => Json -> Either JsonDecodeError (DocumentTree a)
 decodeDocument json = do
   obj <- decodeJson json
-  let _ = unsafePerformEffect $ log $ "Full JSON: " <> stringify json
   -- TODO: We are ignoring `header` for now, but we might need it later.
   root <- obj .: "root"
   decodeJson root

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -13,12 +13,11 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Class.Console (log)
 import FPO.AppM (runAppM)
 import FPO.Components.AppToasts as AppToasts
 import FPO.Components.Navbar as Navbar
 import FPO.Data.Navigate (class Navigate, navigate)
-import FPO.Data.Route (Route(..), routeCodec, routeToString)
+import FPO.Data.Route (Route(..), routeCodec)
 import FPO.Data.Store (loadLanguage)
 import FPO.Data.Store as Store
 import FPO.Page.Admin.Group.AddMembers as GroupAddMembers
@@ -60,7 +59,6 @@ import Prelude
   , (/=)
   , (<$>)
   , (<<<)
-  , (<>)
   , (==)
   )
 import Routing.Duplex as RD
@@ -169,9 +167,7 @@ component =
   handleAction :: Action -> H.HalogenM State Action Slots Void m Unit
   handleAction = case _ of
     Initialize -> do
-      initialHash <- liftEffect getHash
       initialRoute <- hush <<< (RD.parse routeCodec) <$> liftEffect getHash
-      log initialHash
       navigate $ fromMaybe Home initialRoute
     HandleProfile profileOutput -> case profileOutput of
       Profile.ChangedUsername -> do
@@ -233,7 +229,6 @@ main = HA.runHalogenAff do
   void $ liftEffect $ matchesWith (RD.parse routeCodec) \old new ->
     when (old /= Just new) $ launchAff_ do
       _response <- halogenIO.query $ H.mkTell $ NavigateQ new
-      log $ "Navigated to: " <> routeToString new
       pure unit
 
   void $ liftEffect setupTruncationListener

--- a/frontend/src/FPO/Page/Admin/Groups.purs
+++ b/frontend/src/FPO/Page/Admin/Groups.purs
@@ -14,7 +14,6 @@ import Data.Maybe (Maybe(..))
 import Data.String (contains)
 import Data.String.Pattern (Pattern(..))
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Components.Pagination as P
 import FPO.Data.Navigate (class Navigate, navigate)
@@ -39,7 +38,6 @@ import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
 import FPO.UI.HTML (addButton, addCard, addColumn, addError, addModal, emptyEntryGen)
 import FPO.UI.Style as Style
-import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -284,7 +282,6 @@ component =
                           <> (show err)
                     }
                 Right _ -> do
-                  liftEffect $ log $ "Deleted group: " <> groupName
                   H.modify_ _
                     { error = Nothing
                     , groups = Loaded $ filter

--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -24,7 +24,6 @@ import Data.Maybe (Maybe(..))
 import Data.String (Pattern(..), contains, toLower)
 -- import Data.Time.Duration (class Duration, Seconds(..), negateDuration, toDuration)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Class.Console (log)
 import Effect.Now (nowDateTime)
 import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
@@ -164,7 +163,6 @@ component =
                 }
     Receive { context } -> H.modify_ _ { translator = fromFpoTranslator context }
     ViewProject project -> do
-      log $ "Routing to editor for project " <> (DocumentHeader.getName project)
       navigate (Editor { docID: DocumentHeader.getID project })
     NavLogin -> do
       updateStore $ Store.SetLoginRedirect (Just Home)
@@ -204,7 +202,6 @@ component =
           H.tell _pagination unit $ P.SetPageQ 0
     HandleSearchInput query -> do
       H.modify_ _ { searchQuery = query }
-    -- H.liftEffect $ log query
     SetPage (P.Clicked page) -> do
       H.modify_ _ { page = page }
     DownloadPdf _ _ event -> do

--- a/frontend/static/toc.css
+++ b/frontend/static/toc.css
@@ -189,3 +189,15 @@
   margin-left: 0.0625rem !important;
   margin-right: 0.0625rem !important;
 }
+
+/* ********** Put scroll bar to the left ********** */
+
+.leftscrollbar {
+  height: 100%;      
+  overflow-y: auto;   
+  direction: rtl;     
+}
+
+.leftscrollbar > div {
+  direction: ltr;     
+} 


### PR DESCRIPTION
This PR introduces the following changes:

- Now should resize both editors when toggling the side containers.
- Removed log messages in frontedn.
- Prevent selected entry in TOC from being selected again => fewer API calls
- Moved the scroll bar in TOC to the left side. Having 2 grey bars next to each other doesn't look good. 