### PR TITLE
backend/api: fixed `/login` server errors

### DIFF
--- a/backend/src/Server/HandlerUtil.hs
+++ b/backend/src/Server/HandlerUtil.hs
@@ -21,6 +21,8 @@ module Server.HandlerUtil
     , errEmailAlreadyUsed
     , errDocumentDoesNotExist
     , errNoPermission
+    , errWrongLoginCredentials
+    , errLoginFailed
     ) where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
@@ -182,3 +184,9 @@ errDocumentDoesNotExist = err404 {errBody = "\"Document not found.\""}
 
 errNoPermission :: ServerError
 errNoPermission = err403 {errBody = "\"Insufficient permission to perform this action.\""}
+
+errWrongLoginCredentials :: ServerError
+errWrongLoginCredentials = err401 {errBody = "\"Incorrect login credentials.\""}
+
+errLoginFailed :: ServerError
+errLoginFailed = err500 {errBody = "\"Login failed! Please try again!\""}


### PR DESCRIPTION
Wrong email and wrong password both result in the same `401` error now. 
All server errors throw a `500` error. 

Closes #532 