### PR TITLE
Improve table rendering

### DIFF
--- a/frontend/src/FPO/Components/Table/Head.purs
+++ b/frontend/src/FPO/Components/Table/Head.purs
@@ -115,10 +115,6 @@ component =
     HandlePress title -> do
       state <- H.get
 
-      -- TODO: Rewrite this. We need to not only update some element of an array,
-      --       but also return the updated element. The current implementation
-      --       isn't really idiomatic and is a bit of a hack.
-
       toggleResult <- pure $ do
         -- Find the index of the column with the given title.
         mcol <- findIndex

--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -74,8 +74,8 @@ data Action
   | ChangeSorting TH.Output
   | HandleSearchInput String
   | SetPage P.Output
-  | DownloadPdf DocumentID String MouseEvent -- Id, Projektname, Event (zum prevent default)
-  | DownloadZip DocumentID String MouseEvent -- Id, Projektname, Event (zum prevent default)
+  | DownloadPdf DocumentID String MouseEvent -- Id, Project Name, Event (used for prevent default)
+  | DownloadZip DocumentID String MouseEvent -- Id, Project Name, Event (used for prevent default)
 
 type State = FPOState
   ( user :: LoadState (Maybe FullUserDto)
@@ -605,7 +605,7 @@ component =
             ]
           else
             ( map (renderProjectRow state) ps
-                <> replicate (5 - length ps) (emptyTableRow 48 3)
+                <> replicate (5 - length ps) (emptyTableRow 48 4)
             ) -- Fill up to 5 rows
       ]
     where
@@ -656,7 +656,7 @@ component =
               ]
           ]
       , HH.td
-          [ HP.classes [ HB.textCenter ] ]
+          [ HP.classes [ HB.textCenter, HB.alignMiddle ] ]
           [ HH.button
               [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
               , HE.onClick $ \e -> DownloadZip (DocumentHeader.getIdentifier project)
@@ -679,49 +679,3 @@ component =
     filter
       (\p -> contains (Pattern $ toLower query) (toLower $ DocumentHeader.getName p))
       projects
-
-{- -- | Helper function to adjust a DateTime by a duration (subtract from current time)
-adjustDateTime :: forall d. Duration d => d -> DateTime -> DateTime
-adjustDateTime duration dt =
-  fromMaybe dt $ adjust (negateDuration duration) dt
-
-getEditTimestamp ∷ DocumentHeader → DateTime
-getEditTimestamp = DocDate.docDateToDateTime <<< DocumentHeader.getLastEdited
-
--- | Formats DateTime as relative time ("3 hours ago") or absolute date if > 1 week.
-formatRelativeTime :: Maybe DateTime -> DateTime -> String
-formatRelativeTime Nothing _ = "Unknown"
-formatRelativeTime (Just current) updated =
-  let
-    timeDiff =
-      if current > updated then diff current updated else diff updated current
-
-    (Seconds seconds) = toDuration timeDiff :: Seconds
-    totalMinutes = floor (seconds / 60.0)
-    totalHours = floor (seconds / 3600.0)
-    totalDays = floor (seconds / 86400.0)
-  in
-    if totalDays > 7 then
-      formatAbsoluteDate updated
-    else if totalDays >= 1 then
-      show totalDays <> if totalDays == 1 then " day ago" else " days ago"
-    else if totalHours >= 1 then
-      show totalHours <> if totalHours == 1 then " hour ago" else " hours ago"
-    else if totalMinutes >= 1 then
-      show totalMinutes <>
-        if totalMinutes == 1 then " minute ago" else " minutes ago"
-    else
-      "Just now"
-  where
-  -- Format DateTime as absolute date (YYYY-MM-DD)
-  formatAbsoluteDate :: DateTime -> String
-  formatAbsoluteDate dt =
-    let
-      d' = date dt
-      y = show $ fromEnum $ year d'
-      m = padZero $ fromEnum $ month d'
-      d = padZero $ fromEnum $ day d'
-    in
-      d <> "." <> m <> "." <> y
-    where
-    padZero n = if n < 10 then "0" <> show n else show n -}

--- a/frontend/src/FPO/UI/HTML.purs
+++ b/frontend/src/FPO/UI/HTML.purs
@@ -225,7 +225,7 @@ emptyEntryGen content =
 -- | Creates an empty table entry for padding (`tr`).
 emptyTableRow :: forall w a. Int -> Int -> HH.HTML w a
 emptyTableRow height cols =
-  HH.tr []
+  HH.tr [ HP.classes [ H.ClassName "noHover" ] ]
     [ HH.td
         [ HP.colSpan cols
         , HP.style $ "height: " <> show height <> "px;"

--- a/frontend/static/responsive.css
+++ b/frontend/static/responsive.css
@@ -9,3 +9,9 @@
     font-weight: 400;
   }
 }
+
+/* `no-hover` class disables the hover effect of table rows, useful for
+   specific rows that are not meant to be interactive. */
+tr.noHover {
+    pointer-events: none;
+}


### PR DESCRIPTION
Some improvements to rendering of empty table rows, used for padding:

* The `emptyTableRow` function now adds a `noHover` class to padding rows, making them non-interactive and visually distinct. The corresponding CSS disables pointer events for these rows (`frontend/src/FPO/UI/HTML.purs`, `frontend/static/responsive.css`). [[1]](diffhunk://#diff-0907b9af648111fc5d34e514c0c3d4c4a4ddaf0abda4a50a4c80c972bcf5952dL228-R228) [[2]](diffhunk://#diff-8b24d9d7edc82a63434920d1986c46f68e754eaba983a4fcdec0f941102d11f1R12-R17)
* The number of columns used for empty padding rows in the home page table was updated from 3 to 4 for improved alignment (`frontend/src/FPO/Page/Home.purs`).