### PR TITLE
Backend Docs: Added `after` Query Parameter for `/docs/{id}/text/{id}/history` 

### DIFF
--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -151,7 +151,7 @@ type Result a = Either Error a
 type Limit = Int64
 
 defaultHistoryLimit :: Limit
-defaultHistoryLimit = 20
+defaultHistoryLimit = 200
 
 squashRevisionsWithinMinutes :: Float
 squashRevisionsWithinMinutes = 15
@@ -442,13 +442,14 @@ getTextHistory
     => UserID
     -> TextElementRef
     -> Maybe UTCTime
+    -> Maybe UTCTime
     -> Maybe Limit
     -> m (Result TextRevisionHistory)
-getTextHistory userID ref@(TextElementRef docID _) time limit = logged userID Scope.docsText $
+getTextHistory userID ref@(TextElementRef docID _) from to limit = logged userID Scope.docsText $
     runExceptT $ do
         guardPermission Read docID userID
         guardExistsTextElement ref
-        lift $ DB.getTextHistory ref time $ fromMaybe defaultHistoryLimit limit
+        lift $ DB.getTextHistory ref from to $ fromMaybe defaultHistoryLimit limit
 
 getTreeHistory
     :: (HasGetTreeHistory m, HasLogMessage m)

--- a/backend/src/Docs/Database.hs
+++ b/backend/src/Docs/Database.hs
@@ -109,7 +109,11 @@ class
 
 class (HasCheckPermission m, HasExistsTextElement m) => HasGetTextHistory m where
     getTextHistory
-        :: TextElementRef -> Maybe UTCTime -> Int64 -> m TextRevisionHistory
+        :: TextElementRef
+        -> Maybe UTCTime
+        -> Maybe UTCTime
+        -> Int64
+        -> m TextRevisionHistory
 
 class (HasCheckPermission m, HasExistsDocument m) => HasGetTreeHistory m where
     getTreeHistory :: DocumentID -> Maybe UTCTime -> Int64 -> m TreeRevisionHistory

--- a/backend/src/Docs/Hasql/Database.hs
+++ b/backend/src/Docs/Hasql/Database.hs
@@ -88,7 +88,7 @@ instance HasGetTextElementRevision HasqlSession where
     getTextElementRevision = HasqlSession . Sessions.getTextElementRevision
 
 instance HasGetTextHistory HasqlSession where
-    getTextHistory = ((HasqlSession .) .) . Sessions.getTextRevisionHistory
+    getTextHistory = (((HasqlSession .) .) .) . Sessions.getTextRevisionHistory
 
 instance HasGetTreeHistory HasqlSession where
     getTreeHistory = ((HasqlSession .) .) . Sessions.getTreeRevisionHistory

--- a/backend/src/Docs/Hasql/Sessions.hs
+++ b/backend/src/Docs/Hasql/Sessions.hs
@@ -158,9 +158,13 @@ getTree rootHash = do
             (TreeEdgeToNode hash header) -> fromHeader hash header <&> Tree.Tree
 
 getTextRevisionHistory
-    :: TextElementRef -> Maybe UTCTime -> Int64 -> Session TextRevisionHistory
-getTextRevisionHistory ref before limit =
-    statement (ref, before, limit) Statements.getTextRevisionHistory
+    :: TextElementRef
+    -> Maybe UTCTime
+    -> Maybe UTCTime
+    -> Int64
+    -> Session TextRevisionHistory
+getTextRevisionHistory ref after before limit =
+    statement (ref, after, before, limit) Statements.getTextRevisionHistory
         <&> TextRevisionHistory ref . Vector.toList
 
 getTreeRevisionHistory

--- a/backend/src/Docs/Hasql/Statements.hs
+++ b/backend/src/Docs/Hasql/Statements.hs
@@ -639,7 +639,9 @@ getTextRevision =
         )
 
 getTextRevisionHistory
-    :: Statement (TextElementRef, Maybe UTCTime, Int64) (Vector TextRevisionHeader)
+    :: Statement
+        (TextElementRef, Maybe UTCTime, Maybe UTCTime, Int64)
+        (Vector TextRevisionHeader)
 getTextRevisionHistory =
     lmap
         mapInput
@@ -658,15 +660,16 @@ getTextRevisionHistory =
                 WHERE
                     te.document = $1 :: int8
                     AND tr.text_element = $2 :: int8
-                    AND tr.creation_ts < COALESCE($3 :: TIMESTAMPTZ?, NOW())
+                    AND tr.creation_ts > COALESCE($3 :: TIMESTAMPTZ?, NOW())
+                    AND tr.creation_ts < COALESCE($4 :: TIMESTAMPTZ?, NOW())
                 ORDER BY
                     tr.creation_ts DESC
                 LIMIT
-                    $4 :: int8
+                    $5 :: int8
             |]
   where
-    mapInput (TextElementRef docID textID, maybeTimestamp, limit) =
-        (unDocumentID docID, unTextElementID textID, maybeTimestamp, limit)
+    mapInput (TextElementRef docID textID, maybeFrom, maybeTo, limit) =
+        (unDocumentID docID, unTextElementID textID, maybeFrom, maybeTo, limit)
 
 getLatestTextRevisionID :: Statement TextElementRef (Maybe TextRevisionID)
 getLatestTextRevisionID =

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -218,6 +218,7 @@ type GetTextHistory =
         :> "text"
         :> Capture "textElementID" TextElementID
         :> "history"
+        :> QueryParam "after" UTCTime
         :> QueryParam "before" UTCTime
         :> QueryParam "limit" Docs.Limit
         :> Get '[JSON] TextRevisionHistory
@@ -485,15 +486,17 @@ getTextHistoryHandler
     -> DocumentID
     -> TextElementID
     -> Maybe UTCTime
+    -> Maybe UTCTime
     -> Maybe Docs.Limit
     -> Handler TextRevisionHistory
-getTextHistoryHandler auth docID textID before limit = do
+getTextHistoryHandler auth docID textID after before limit = do
     userID <- getUser auth
     withDB $
         run $
             Docs.getTextHistory
                 userID
                 (TextElementRef docID textID)
+                after
                 before
                 limit
 


### PR DESCRIPTION
`/docs/{id}/text/{id}/history`  now has three query parameters: `after`, `before` and `limit`.

Might be useful for #530.