### PR TITLE
ci: Fix broken cache prefix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         with:
           working-directory: backend
           stack-build-arguments: --no-test --fast --allow-newer
-          cache-prefix: v2
+          cache-prefix: v1/
           test: false
           upgrade-stack: false
 


### PR DESCRIPTION
Perhaps this changes things? As per https://github.com/freckle/stack-action/blob/71cc17e5bdecf8913c678dfcabdff0cb29201fe1/.github/workflows/example.yml#L72