### PR TITLE
Fix editor tree

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,15 @@
       })();
     </script>
     
+    <script>
+      class RawHtmlElement extends HTMLElement {
+        connectedCallback() {
+          this.innerHTML = this.getAttribute('html') || '';
+        }
+      }
+      customElements.define('raw-html', RawHtmlElement);
+    </script>
+
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>FPO-Editor</title>
     

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -1586,8 +1586,8 @@ addChangeListenerWithRef editor_ dref listener = do
           when (not busy) do
             Ref.write true guardRef
             let sRow = Types.getRow start
-            range <- Range.create sRow sCol sRow (sCol + 1)
-            Session.replace range "  #" session
+            range <- Range.create sRow sCol sRow (sCol)
+            Session.replace range "  " session
             Ref.write false guardRef
 
 addAnchor

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -91,7 +91,7 @@ import Halogen.HTML.Events (onClick) as HE
 import Halogen.HTML.Properties (classes, enabled, ref, style, title) as HP
 import Halogen.Query.HalogenM (SubscriptionId)
 import Halogen.Store.Connect (Connected, connect)
-import Halogen.Store.Monad (class MonadStore)
+import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Subscription as HS
 import Halogen.Themes.Bootstrap5 as HB
 import Simple.I18n.Translator (label, translate)
@@ -818,7 +818,7 @@ editor = connect selectTranslator $ H.mkComponent
       -- handle errors in pos and decodeJson
       case response of
         -- if error, try to Save again (Maybe ParentID is lost?)
-        Left _ -> handleAction (Save isAutoSave)
+        Left err -> updateStore $ Store.AddError err
         -- extract and insert new parentID into newContent
         Right updatedContent -> do
           H.raise (SavedSection newEntry)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -68,7 +68,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Store.Connect (Connected, connect)
-import Halogen.Store.Monad (class MonadStore)
+import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Themes.Bootstrap5 as HB
 import Simple.I18n.Translator (label, translate)
 import Type.Proxy (Proxy(Proxy))
@@ -623,7 +623,7 @@ splitview = connect selectTranslator $ H.mkComponent
       maybeTree <- Request.getJson DT.decodeDocument
         ("/docs/" <> show s.docID <> "/tree/latest")
       case maybeTree of
-        Left _ -> pure unit
+        Left err -> updateStore $ Store.AddError err
         Right tree -> do
           let
             finalTree = documentTreeToTOCTree tree

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -9,18 +9,7 @@ module FPO.Component.Splitview where
 import Prelude
 
 import Data.Argonaut (fromString)
-import Data.Array
-  ( cons
-  , deleteAt
-  , head
-  , insertAt
-  , mapWithIndex
-  , null
-  , snoc
-  , uncons
-  , updateAt
-  , (!!)
-  )
+import Data.Array (cons, deleteAt, head, insertAt, null, snoc, uncons, updateAt, (!!))
 import Data.Either (Either(..))
 import Data.Formatter.DateTime (Formatter)
 import Data.Int (toNumber)
@@ -44,6 +33,7 @@ import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
+  , Meta(..)
   , RootTree(..)
   , Tree(..)
   , TreeHeader(..)
@@ -996,9 +986,10 @@ splitview = connect selectTranslator $ H.mkComponent
         H.tell _comment unit
           (Comment.SelectedCommentSection state.docID tocID markerID)
 
-      Editor.RenamedNode newName path -> do
-        s <- H.get
-        updateTree $ changeNodeName path newName s.tocEntries
+      Editor.RenamedNode _ _ -> do
+        -- s <- H.get
+        -- updateTree $ changeNodeName path newName s.tocEntries
+        pure unit
 
       Editor.ShowAllCommentsOutput docID tocID -> do
         handleAction $ ToggleCommentOverview true docID tocID
@@ -1073,9 +1064,10 @@ splitview = connect selectTranslator $ H.mkComponent
         s <- H.get
         updateTree $ reorderTocEntries from to s.tocEntries
 
-      TOC.RenameNode { path, newName } -> do
-        s <- H.get
-        updateTree $ changeNodeName path newName s.tocEntries
+      TOC.RenameNode _ -> do
+        -- s <- H.get
+        -- updateTree $ changeNodeName path newName s.tocEntries
+        pure unit
 
     where
     -- Communicates tree changes to the server and TOC component.
@@ -1121,7 +1113,13 @@ addRootNode path entry (RootTree { children, header }) =
       let
         child =
           fromMaybe
-            (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
+            ( Edge
+                ( Leaf
+                    { meta: Meta { label: Nothing, title: "Error" }
+                    , node: emptyTOCEntry
+                    }
+                )
+            )
             (children !! head)
         newChildren =
           case updateAt head (addNode tail entry child) children of
@@ -1135,26 +1133,32 @@ addNode
   -> Tree TOCEntry
   -> Edge TOCEntry
   -> Edge TOCEntry
-addNode _ _ (Edge (Leaf { title, node })) =
-  Edge (Leaf { title, node }) -- Cannot add to a leaf
-addNode [] entry (Edge (Node { title, children, header })) =
-  Edge (Node { title, children: snoc children (Edge entry), header })
-addNode path entry (Edge (Node { title, children, header })) =
+addNode _ _ (Edge (Leaf { meta, node })) =
+  Edge (Leaf { meta, node }) -- Cannot add to a leaf
+addNode [] entry (Edge (Node { meta, children, header })) =
+  Edge (Node { meta, children: snoc children (Edge entry), header })
+addNode path entry (Edge (Node { meta, children, header })) =
   case uncons path of
     Nothing ->
-      Edge (Node { title, children: snoc children (Edge entry), header })
+      Edge (Node { meta, children: snoc children (Edge entry), header })
     Just { head, tail } ->
       let
         child =
           fromMaybe
-            (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
+            ( Edge
+                ( Leaf
+                    { meta: Meta { label: Nothing, title: "Error" }
+                    , node: emptyTOCEntry
+                    }
+                )
+            )
             (children !! head)
         newChildren' =
           case updateAt head (addNode tail entry child) children of
             Nothing -> children
             Just res -> res
       in
-        Edge (Node { title, children: newChildren', header })
+        Edge (Node { meta, children: newChildren', header })
 
 deleteRootNode
   :: Array Int
@@ -1176,7 +1180,13 @@ deleteRootNode path (RootTree { children, header }) =
         let
           child =
             fromMaybe
-              (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
+              ( Edge
+                  ( Leaf
+                      { meta: Meta { label: Nothing, title: "Error" }
+                      , node: emptyTOCEntry
+                      }
+                  )
+              )
               (children !! head)
           newChildren =
             case updateAt head (deleteNode tail child) children of
@@ -1195,27 +1205,33 @@ deleteNode [] e =
   -- If path is empty, delete this node entirely is handled by parent
   -- so this case should not normally be reached.
   e
-deleteNode path (Edge (Node { title, children, header })) =
+deleteNode path (Edge (Node { meta, children, header })) =
   case uncons path of
     Nothing ->
-      Edge (Node { title, children, header })
+      Edge (Node { meta, children, header })
     Just { head, tail } ->
       if null tail then
         case deleteAt head children of
-          Nothing -> Edge (Node { title, children, header })
-          Just newChildren -> Edge (Node { title, children: newChildren, header })
+          Nothing -> Edge (Node { meta, children, header })
+          Just newChildren -> Edge (Node { meta, children: newChildren, header })
       else
         let
           child =
             fromMaybe
-              (Edge (Leaf { title: "Error", node: emptyTOCEntry }))
+              ( Edge
+                  ( Leaf
+                      { meta: Meta { label: Nothing, title: "Error" }
+                      , node: emptyTOCEntry
+                      }
+                  )
+              )
               (children !! head)
           newChildren' =
             case updateAt head (deleteNode tail child) children of
               Nothing -> children
               Just res -> res
         in
-          Edge (Node { title, children: newChildren', header })
+          Edge (Node { meta, children: newChildren', header })
 
 -- Reorder TOC entries by moving a node from `sourcePath` to `targetPath`.
 -- The node at sourcePath takes the place of the node at targetPath,
@@ -1344,25 +1360,25 @@ insertNodeAtPosition path node (RootTree { children, header }) =
 insertNodeIntoEdgeAtPosition
   :: Path -> Tree TOCEntry -> Edge TOCEntry -> Edge TOCEntry
 insertNodeIntoEdgeAtPosition _ _ edge@(Edge (Leaf _)) = edge -- Cannot insert into leaf
-insertNodeIntoEdgeAtPosition [] node (Edge (Node { title, children, header })) =
+insertNodeIntoEdgeAtPosition [] node (Edge (Node { meta, children, header })) =
   -- Insert at end of children
-  Edge (Node { title, children: snoc children (Edge node), header })
-insertNodeIntoEdgeAtPosition path node (Edge (Node { title, children, header })) =
+  Edge (Node { meta, children: snoc children (Edge node), header })
+insertNodeIntoEdgeAtPosition path node (Edge (Node { meta, children, header })) =
   case uncons path of
-    Nothing -> Edge (Node { title, children: snoc children (Edge node), header })
+    Nothing -> Edge (Node { meta, children: snoc children (Edge node), header })
     Just { head, tail } ->
       if null tail then
         -- Insert exactly at position `head`, pushing existing elements down
         case insertAt head (Edge node) children of
           Nothing ->
             -- If insertion fails (index out of bounds), append to end
-            Edge (Node { title, children: snoc children (Edge node), header })
+            Edge (Node { meta, children: snoc children (Edge node), header })
           Just result ->
-            Edge (Node { title, children: result, header })
+            Edge (Node { meta, children: result, header })
       else
         -- Navigate deeper
         case children !! head of
-          Nothing -> Edge (Node { title, children, header })
+          Nothing -> Edge (Node { meta, children, header })
           Just childEdge ->
             let
               newChild = insertNodeIntoEdgeAtPosition tail node childEdge
@@ -1370,43 +1386,45 @@ insertNodeIntoEdgeAtPosition path node (Edge (Node { title, children, header }))
                 Nothing -> children
                 Just res -> res
             in
-              Edge (Node { title, children: newChildren, header })
+              Edge (Node { meta, children: newChildren, header })
 
 -- Changes the name of a node in the TOC root tree.
-changeNodeName
-  :: Path -> String -> TOCTree -> TOCTree
-changeNodeName _ _ Empty = Empty
-changeNodeName path newName (RootTree { children, header }) =
-  let
-    newChildren = mapWithIndex
-      ( \ix (Edge child) ->
-          case uncons path of
-            Just { head, tail } | ix == head ->
-              Edge $ changeNodeName' tail newName child
-            _ -> Edge child
-      )
-      children
-  in
-    RootTree { children: newChildren, header }
+-- TODO: Do we need this? This should be done in the text element associated
+--       with the node..
+-- changeNodeName
+--   :: Path -> String -> TOCTree -> TOCTree
+-- changeNodeName _ _ Empty = Empty
+-- changeNodeName path newName (RootTree { children, header }) =
+--   let
+--     newChildren = mapWithIndex
+--       ( \ix (Edge child) ->
+--           case uncons path of
+--             Just { head, tail } | ix == head ->
+--               Edge $ changeNodeName' tail newName child
+--             _ -> Edge child
+--       )
+--       children
+--   in
+--     RootTree { children: newChildren, header }
 
--- Changes the name of a node in the TOC tree.
-changeNodeName' :: Path -> String -> Tree TOCEntry -> Tree TOCEntry
-changeNodeName' path newName tree = case path of
-  [] -> case tree of
-    Node record -> Node record { title = newName }
-    leaf -> leaf
-  _ -> case tree of
-    Node { title, children, header } ->
-      case uncons path of
-        Just { head: index, tail } ->
-          let
-            newChildren = mapWithIndex
-              ( \ix (Edge child) ->
-                  if ix == index then Edge $ changeNodeName' tail newName child
-                  else Edge child
-              )
-              children
-          in
-            Node { title, children: newChildren, header }
-        Nothing -> Node { title, children, header }
-    leaf -> leaf
+-- -- Changes the name of a node in the TOC tree.
+-- changeNodeName' :: Path -> String -> Tree TOCEntry -> Tree TOCEntry
+-- changeNodeName' path newName tree = case path of
+--   [] -> case tree of
+--     Node record -> Node record { title = newName }
+--     leaf -> leaf
+--   _ -> case tree of
+--     Node { title, children, header } ->
+--       case uncons path of
+--         Just { head: index, tail } ->
+--           let
+--             newChildren = mapWithIndex
+--               ( \ix (Edge child) ->
+--                   if ix == index then Edge $ changeNodeName' tail newName child
+--                   else Edge child
+--               )
+--               children
+--           in
+--             Node { title, children: newChildren, header }
+--         Nothing -> Node { title, children, header }
+--     leaf -> leaf

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -30,8 +30,6 @@ import Data.Date (Date)
 import Data.DateTime (DateTime, adjust)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.String.Regex (regex, replace)
-import Data.String.Regex.Flags (noFlags)
 import Data.Time.Duration (Days(..), Minutes)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
@@ -46,10 +44,13 @@ import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
+  , Meta(..)
   , RootTree(..)
   , Tree(..)
   , TreeHeader(..)
   , findRootTree
+  , getFullTitle
+  , getShortTitle
   , modifyNodeRootTree
   )
 import FPO.Dto.PostTextDto (PostTextDto(..))
@@ -553,7 +554,10 @@ tocview = connect (selectEq identity) $ H.mkComponent
           let
             newEntry =
               Leaf
-                { title: "New Subsection"
+                { meta: Meta
+                    { label: Nothing
+                    , title: "New Subsection"
+                    }
                 , node:
                     { id: PostTextDto.getID dto
                     , name: "New Subsection"
@@ -567,7 +571,10 @@ tocview = connect (selectEq identity) $ H.mkComponent
         st { showAddMenu = [ -1 ] }
       let
         newEntry = Node
-          { title: "New Section"
+          { meta: Meta
+              { label: Nothing
+              , title: "New Section"
+              }
           , children: []
           , header: TreeHeader
               { headerKind: "section", headerType: "section", heading: "" }
@@ -833,7 +840,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
     now
     filteredTree
     searchData = case _ of
-    Node { title, children } ->
+    Node { meta, children } ->
       let
         selectedClasses =
           if selectedNodeHasPath path then
@@ -860,11 +867,12 @@ tocview = connect (selectEq identity) $ H.mkComponent
                 , HH.span
                     ( [ HP.classes titleClasses
                       , HP.style "align-self: stretch; flex-basis: 0;"
-                      , HP.title title
+                      , HP.title $ getFullTitle meta
                       ]
                     )
-                    [ HH.text title ]
-                , renderSectionButtonInterface menuPath path true Section title
+                    [ HH.text $ getFullTitle meta ]
+                , renderSectionButtonInterface menuPath path true Section
+                    (getFullTitle meta)
                 ]
             ]
         ]
@@ -892,7 +900,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
         Just (SelNode selectedPath _) -> selectedPath == p
         _ -> false
 
-    Leaf { title, node: { id, paraID: _, name: _ } } ->
+    Leaf { meta, node: { id, paraID: _, name: _ } } ->
       let
         selectedClasses =
           if Just (SelLeaf id) == mSelectedTocEntry then
@@ -900,7 +908,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
           else []
         containerProps =
           ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <> selectedClasses
-            , HP.title ("Jump to section " <> prettyTitle title)
+            , HP.title ("Jump to section " <> getShortTitle meta)
             ] <> dragProps true
           )
         innerDivBaseClasses =
@@ -928,12 +936,12 @@ tocview = connect (selectEq identity) $ H.mkComponent
                         [ HB.textTruncate, HB.flexGrow1, HB.fwNormal, HB.fs6 ]
                     , HP.style "align-self: stretch; flex-basis: 0;"
                     ]
-                    [ HH.text $ prettyTitle title ]
+                    [ HH.text $ getFullTitle meta ]
                 , renderParagraphButtonInterface historyPath path
                     state.versions
                     state.showHistorySubmenu
                     now
-                    title
+                    (getFullTitle meta)
                     id
                     filteredTree
                     searchData
@@ -956,13 +964,6 @@ tocview = connect (selectEq identity) $ H.mkComponent
       , HP.style ("margin-left: " <> show level <> "rem;")
       ]
       [ HH.text "⋮⋮" ]
-
-  -- If the title is of shape "§{<label>:} Name", change it to "§ Name".
-  prettyTitle :: String -> String
-  prettyTitle title =
-    case regex "§\\{[^}]+:\\}\\s*" noFlags of
-      Left _err -> title -- fallback - if regex fails, just return the input
-      Right pattern -> replace pattern "§ " title
 
   -- Helper to check if the current path is the active dropzone.
   -- This is used to highlight the dropzone when dragging an item.
@@ -1130,7 +1131,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
     HH.div
       [ HP.classes [ HB.positionRelative ] ] $
       [ historyButton path elementID
-      , deleteSectionButton path Paragraph (prettyTitle title)
+      , deleteSectionButton path Paragraph title
       ]
         <>
           [ if historyPath == path then
@@ -1414,7 +1415,7 @@ findLeafTitleInChildren targetId children =
 
 findLeafTitleInTree :: Int -> Tree TOCEntry -> Maybe String
 findLeafTitleInTree targetId = case _ of
-  Leaf { title, node: { id } } ->
-    if id == targetId then Just title else Nothing
+  Leaf { meta: Meta meta, node: { id } } ->
+    if id == targetId then Just meta.title else Nothing
   Node { children } ->
     findLeafTitleInChildren targetId children

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -63,7 +63,8 @@ instance decodeJsonContent :: DecodeJson Content where
 instance decodeJsonContentWrapper :: DecodeJson ContentWrapper where
   decodeJson json = do
     obj <- decodeJson json
-    rev <- obj .: "revision"
+    ele <- obj .: "element"
+    rev <- ele .: "revision"
     con <- decodeJson (fromObject rev)
     coms <- rev .: "commentAnchors"
     pure $ Wrapper { content: con, comments: coms }
@@ -165,7 +166,8 @@ failureContentWrapper = Wrapper { content: failureContent, comments: [] }
 extractNewParent :: Content -> Json -> Either JsonDecodeError Content
 extractNewParent (Content cont) json = do
   obj <- decodeJson json
-  newRev <- obj .: "newRevision"
+  ele <- obj .: "element"
+  newRev <- ele .: "newRevision"
   header <- newRev .: "header"
   newPar <- header .: "identifier"
   pure $ Content $ cont { parent = newPar }

--- a/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
@@ -33,7 +33,8 @@ decodeDocument
 decodeDocument json = do
   obj <- decodeJson json
   -- TODO: We are ignoring `header` for now, but we might need it later.
-  root <- obj .: "root"
+  rev <- obj .: "revision"
+  root <- rev .: "root"
   decodeJson root
 
 -- | Encodes a `DocumentTree NodeHeader` as a `DocumentTree TextElementID`.

--- a/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/DocumentTree.purs
@@ -32,7 +32,8 @@ decodeDocument
   :: forall a. DecodeJson a => Json -> Either JsonDecodeError (DocumentTree a)
 decodeDocument json = do
   obj <- decodeJson json
-  -- TODO: We are ignoring `header` for now, but we might need it later.
+  -- TODO: We are ignoring `revisionHeader` for now, but we might need it later.
+  --       We will also need the `metaMap` here!
   rev <- obj .: "revision"
   root <- rev .: "root"
   decodeJson root

--- a/frontend/src/FPO/Dto/DocumentDto/NodeHeader.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/NodeHeader.purs
@@ -9,14 +9,14 @@ import Data.Argonaut (class DecodeJson, class EncodeJson)
 -- This seems to be `TextElement` in the backend?
 newtype NodeHeader = NodeHeader
   { identifier :: Int
-  , kind :: String
+  , textElementKind :: String
   }
 
 getId :: NodeHeader -> Int
 getId (NodeHeader nh) = nh.identifier
 
 getKind :: NodeHeader -> String
-getKind (NodeHeader nh) = nh.kind
+getKind (NodeHeader nh) = nh.textElementKind
 
 derive newtype instance decodeJsonNodeHeader :: DecodeJson NodeHeader
 derive newtype instance encodeJsonNodeHeader :: EncodeJson NodeHeader

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -116,24 +116,18 @@ instance encodeJsonEdge :: EncodeJson a => EncodeJson (Edge a) where
   encodeJson (Edge child) = encodeJson child
 
 instance encodeJsonTree :: EncodeJson a => EncodeJson (Tree a) where
-  encodeJson (Node { title, children, header }) =
+  encodeJson (Node { children, header }) =
     encodeJson
-      { title
-      , content:
-          { type: "tree"
-          , node:
-              { children: map encodeJson children
-              , header: encodeJson header
-              }
+      { type: "tree"
+      , node:
+          { children: map encodeJson children
+          , header: encodeJson header
           }
       }
-  encodeJson (Leaf { title, node }) =
+  encodeJson (Leaf { node }) =
     encodeJson
-      { title
-      , content:
-          { type: "leaf"
-          , leaf: node
-          }
+      { type: "leaf"
+      , leaf: node
       }
 
 -- Show instances

--- a/frontend/src/FPO/Dto/PostTextDto.purs
+++ b/frontend/src/FPO/Dto/PostTextDto.purs
@@ -19,12 +19,12 @@ instance decodeJsonPostTextDto :: DecodeJson PostTextDto where
   decodeJson json = do
     obj <- decodeJson json
     id <- obj .: "identifier"
-    kind <- obj .: "kind"
-    pure $ PostTextDto { identifier: id, kind: kind }
+    kind <- obj .: "textElementKind"
+    pure $ PostTextDto { identifier: id, kind }
 
 instance encodeJsonPostTextDto :: EncodeJson PostTextDto where
   encodeJson (PostTextDto { kind }) =
-    encodeJson { kind: kind }
+    encodeJson { textElementKind: kind }
 
 instance showPostTextDto :: Show PostTextDto where
   show (PostTextDto { identifier, kind }) =

--- a/frontend/src/FPO/Types.purs
+++ b/frontend/src/FPO/Types.purs
@@ -189,7 +189,7 @@ nodeHeaderToTOCEntry nh =
 
 tocEntryToNodeHeader :: TOCEntry -> NH.NodeHeader
 tocEntryToNodeHeader { id, name } =
-  NH.NodeHeader { identifier: id, kind: name }
+  NH.NodeHeader { identifier: id, textElementKind: name }
 
 documentTreeToTOCTree :: DT.DocumentTreeTE -> TOCTree
 documentTreeToTOCTree = map nodeHeaderToTOCEntry

--- a/frontend/src/FPO/UI/HTML.purs
+++ b/frontend/src/FPO/UI/HTML.purs
@@ -251,3 +251,10 @@ loadingSpinner =
   HH.div [ HP.classes [ HB.textCenter, HB.my5 ] ]
     [ HH.span [ HP.classes [ HB.spinnerBorder, HB.textPrimary ] ] []
     ]
+
+-- Use a data attribute to store the HTML
+rawHtml :: forall w i. String -> HH.HTML w i
+rawHtml html =
+  HH.element (H.ElemName "raw-html")
+    [ HP.attr (HH.AttrName "html") html ]
+    []


### PR DESCRIPTION
This pull request introduces several important changes to the frontend, focusing on improving error handling, updating the tree data structures to use a new `Meta` record for node metadata, and cleaning up or refactoring code related to tree manipulation and node renaming. The changes affect the editor, splitview, and TOC components, as well as the underlying TOC tree data structures.

**Summary of most important changes:**

### 1. Error Handling Improvements

- Error responses in both the Editor and Splitview components now dispatch errors to the store using `updateStore $ Store.AddError err`, improving error reporting and handling throughout the UI. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL821-R821) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL626-R616)

### 2. Tree Structure Refactoring

- The TOC tree data structures (`Tree`, `Edge`, `Leaf`, `Node`) have been updated to use a new `Meta` record containing `title` and `label` instead of a plain `title` string. All tree manipulation functions (`addNode`, `deleteNode`, etc.) and usages now expect and propagate this new structure. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR36) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR47-R53) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1124-R1122) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1138-R1161) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1179-R1189) [[6]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1198-R1234) [[7]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1347-R1430) [[8]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL556-R560) [[9]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL570-R577) [[10]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL836-R843) [[11]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL895-R911)

### 3. Node Title Handling and Display

- All places where node titles are displayed or used for tooltips now use utility functions `getFullTitle` and `getShortTitle` from the new `Meta` record, ensuring consistent and correct display of section names throughout the UI. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR47-R53) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL863-R875) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL931-R944)

### 4. Tree Node Renaming Logic

- The logic for renaming nodes in the TOC tree has been commented out and disabled in both the Splitview component and the tree utility functions. This reflects a shift toward handling renaming in the associated text element (heading?), rather than directly manipulating the tree structure. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL999-R992) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1076-R1070) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1347-R1430)

### 5. Miscellaneous Improvements

- Added a custom HTML element `<raw-html>` to `frontend/index.html` for rendering raw HTML content safely.
- Minor code cleanups, such as removing unused imports and simplifying import statements. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL12-R12) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL33-L34)

Things to be done:
- Renaming sections. This was previously removed from the editor and TOC for some reason unclear to me, and needs to be reactivated to some extend. Because nodes are not leaves and have no id, we once again need to find a way to identify them (e.g., via the path) and we have to load the `heading` content into the editor, for editing. 
- Changing the ordering of paragraphs / leaves doesn't work, although the TOC tree structure doesn't change besides shuffling the leaf IDs according to the reordering. Same with deletion and addition.
- There are still invisible leaves, not sure what is going on there and how we plan to incorporate them into the ToC.
- There is one invisible non-leave node that contains all the "main" paragraphs / leaves. This should perhaps get a generic name, or in the ToC we should completely hide it, or somehow make it obvious to the user that he can either have one section with a bunch of paragraphs, or lots of sections with paragraphs, each. 