### PR TITLE
Fix type of meta title

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -11,7 +11,6 @@ module FPO.Components.Editor
 
 import Prelude
 
-{- import Data.Argonaut.Core (jsonEmptyObject) -}
 import Ace (ace, editNode) as Ace
 import Ace.Anchor as Anchor
 import Ace.Document as Document
@@ -31,7 +30,6 @@ import Effect (Effect)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class as EC
-{- import Effect.Console (log) -}
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import FPO.Components.Editor.AceExtra
@@ -78,7 +76,6 @@ import FPO.Dto.ContentDto
   ( Content
   , ContentWrapper
   , convertDCWToCW
-  {- , getContentParent -}
   , getWrapperContent
   , setContentParent
   , setWrapperContent
@@ -867,14 +864,8 @@ editor = connect selectTranslator $ H.mkComponent
       -- handle errors in pos and decodeJson
       case response of
         -- if error, try to Save again (Maybe ParentID is lost?)
-
         Left err -> updateStore $ Store.AddError err
 
-        {- <<<<<<< HEAD
-        Left err -> updateStore $ Store.AddError $ err
-=======
-        Left err -> updateStore $ Store.AddError err
->>>>>>> main -}
         -- extract and insert new parentID into newContent
         Right { content: updatedContent, typ: typ } -> do
 

--- a/frontend/src/FPO/Components/Modals/InfoModal.purs
+++ b/frontend/src/FPO/Components/Modals/InfoModal.purs
@@ -25,17 +25,6 @@ infoModal
   -> HH.HTML w action
 infoModal
   translator
-  {- <<<<<<< HEAD
-  cancelAction =
-  addModal (translate (label :: _ "editor_mergingInfo") translator)
-    (const cancelAction) $
-=======
-  cancelAction
-  doNothingAction =
-  addModal (translate (label :: _ "common_mergingInfo") translator)
-    cancelAction
-    doNothingAction $
->>>>>>> main -}
   cancelAction
   doNothingAction =
   addModal (translate (label :: _ "editor_mergingInfo") translator)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -34,7 +34,6 @@ import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
-  , Meta(..)
   , RootTree(..)
   , Tree(..)
   , TreeHeader(..)

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -17,7 +17,6 @@ import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.String (joinWith)
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-{- import Effect.Console (log) -}
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -39,6 +38,7 @@ import FPO.Dto.DocumentDto.TreeDto
   , RootTree(..)
   , Tree(..)
   , TreeHeader(..)
+  , errorMeta
   , findRootTree
   , modifyNodeRootTree
   )
@@ -1219,6 +1219,7 @@ splitview = connect selectTranslator $ H.mkComponent
 
 {- ------------------ Tree traversal and mutation function ------------------ -}
 {- --------------------- TODO: Move to seperate module  --------------------- -}
+-- TODO(lasse): Clean up redundant cases. Update `changeNodeName` regarding headings.
 
 -- Add a node in TOC tree
 addRootNode
@@ -1243,7 +1244,7 @@ addRootNode path entry (RootTree { children, header }) =
           fromMaybe
             ( Edge
                 ( Leaf
-                    { meta: Meta { label: Nothing, title: "Error" }
+                    { meta: errorMeta
                     , node: emptyTOCEntry
                     }
                 )
@@ -1275,7 +1276,7 @@ addNode path entry (Edge (Node { meta, children, header })) =
           fromMaybe
             ( Edge
                 ( Leaf
-                    { meta: Meta { label: Nothing, title: "Error" }
+                    { meta: errorMeta
                     , node: emptyTOCEntry
                     }
                 )
@@ -1310,7 +1311,7 @@ deleteRootNode path (RootTree { children, header }) =
             fromMaybe
               ( Edge
                   ( Leaf
-                      { meta: Meta { label: Nothing, title: "Error" }
+                      { meta: errorMeta
                       , node: emptyTOCEntry
                       }
                   )
@@ -1348,7 +1349,7 @@ deleteNode path (Edge (Node { meta, children, header })) =
             fromMaybe
               ( Edge
                   ( Leaf
-                      { meta: Meta { label: Nothing, title: "Error" }
+                      { meta: errorMeta
                       , node: emptyTOCEntry
                       }
                   )

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -38,20 +38,19 @@ import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Data.Navigate (class Navigate)
 import FPO.Data.Request (getDocumentHeader, getTextElemHistory, postJson)
 import FPO.Data.Store as Store
-import FPO.Data.Time
-  ( dateToDatetime
-  , formatAbsoluteTimeDetailed {-, formatRelativeTime -}
-  )
+import FPO.Data.Time (dateToDatetime, formatAbsoluteTimeDetailed)
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
   , Meta(..)
+  , Result(..)
   , RootTree(..)
   , Tree(..)
   , TreeHeader(..)
   , findRootTree
+  , getContent
   , getFullTitle
   , getShortTitle
   , modifyNodeRootTree
@@ -539,7 +538,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
               Leaf
                 { meta: Meta
                     { label: Nothing
-                    , title: "New Subsection"
+                    , title: Success $ Just "New Subsection"
                     }
                 , node:
                     { id: PostTextDto.getID dto
@@ -556,7 +555,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
         newEntry = Node
           { meta: Meta
               { label: Nothing
-              , title: "New Section"
+              , title: Success $ Just "New Section"
               }
           , children: []
           , header: TreeHeader
@@ -910,12 +909,6 @@ tocview = connect (selectEq identity) $ H.mkComponent
                     state.versions
                     state.showHistorySubmenu
                     (getFullTitle meta)
-                    {- <<<<<<< HEAD
-                    title
-=======
-                    now
-                    (getFullTitle meta)
->>>>>>> main -}
                     id
                     searchData
                     state
@@ -1385,6 +1378,6 @@ findLeafTitleInChildren targetId children =
 findLeafTitleInTree :: Int -> Tree TOCEntry -> Maybe String
 findLeafTitleInTree targetId = case _ of
   Leaf { meta: Meta meta, node: { id } } ->
-    if id == targetId then Just meta.title else Nothing
+    if id == targetId then getContent meta.title else Nothing
   Node { children } ->
     findLeafTitleInChildren targetId children

--- a/frontend/src/FPO/Data/Email.purs
+++ b/frontend/src/FPO/Data/Email.purs
@@ -4,7 +4,7 @@ import Data.Either (Either(..))
 import Data.String.Regex (regex, test)
 import Data.String.Regex.Flags (noFlags)
 
--- | Stricter email validation that requires a proper domain with TLD
+-- | Stricter email validation that requires a proper domain with TLD.
 -- | This validates that the email has:
 -- | - A local part (before @)
 -- | - A domain name (after @)

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -228,43 +228,6 @@ extractDraft (Content cont) json = do
     _ ->
       pure { content: Content cont, typ: "conflict" }
 
-{- <<<<<<< HEAD
-  typ <- obj .: "type" :: Either JsonDecodeError String
-  case typ of
-    "noConflict" -> do
-      newRev <- obj .: "newRevision"
-      hdr <- newRev .: "header"
-      pid <- hdr .: "identifier"
-      pure $ Content $ cont { parent = pid }
-    _ ->
-      pure (Content cont)
-
-extractDraft
-  :: Content -> Json -> Either JsonDecodeError { content :: Content, typ :: String }
-extractDraft (Content cont) json = do
-  obj <- decodeJson json
-  typ <- obj .: "type" :: Either JsonDecodeError String
-  case typ of
-    "noConflict" -> do
-      newRev <- obj .: "newRevision"
-      hdr <- newRev .: "header"
-      pid <- hdr .: "identifier"
-      pure $ { content: Content $ cont { parent = pid }, typ: "noConflict" }
-    "draftCreated" -> do
-      -- TODO update Commentmarkers
-      draft <- obj .: "draft"
-      newCon <- draft .: "draftContent"
-      pure $ { content: Content $ cont { content = newCon }, typ: "draftCreated" }
-    _ ->
-      pure { content: Content cont, typ: "conflict" }
-=======
-  ele <- obj .: "element"
-  newRev <- ele .: "newRevision"
-  header <- newRev .: "header"
-  newPar <- header .: "identifier"
-  pure $ Content $ cont { parent = newPar }
->>>>>>> main -}
-
 convertToAnnotetedMarker
   :: CommentAnchor
   -> AnnotatedMarker


### PR DESCRIPTION
This pull request introduces improvements to how document tree titles and metadata are handled throughout the frontend, focusing on better error signaling and safer title extraction. The main change is the introduction of a `Result` type for TOC (Table of Contents) node titles, allowing the code to distinguish between successfully parsed titles and errors.