### PR TITLE
Document pdf frontend

### DIFF
--- a/frontend/src/FPO/Page/Home.purs
+++ b/frontend/src/FPO/Page/Home.purs
@@ -23,7 +23,6 @@ import Effect.Aff.Class (class MonadAff)
 import Effect.Now (nowDateTime)
 import FPO.Components.Pagination as P
 import FPO.Components.Table.Head as TH
-import FPO.Data.AppError (AppError(..))
 import FPO.Data.Navigate (class Navigate, navigate)
 import FPO.Data.Request
   ( LoadState(..)
@@ -226,7 +225,7 @@ component =
         Left _ -> pure unit
         Right blobOrError ->
           case blobOrError of
-            Left errMsg -> pure unit
+            Left _ -> pure unit
             Right body -> do
               -- create blobl link
               url <- H.liftEffect $ createObjectURL body


### PR DESCRIPTION
This pull request introduces a new utility for robustly downloading PDF files as blobs, and updates the Home page logic to use this new method for project PDF downloads. The changes improve error handling and implement the actual file download workflow, replacing a previous placeholder.

**Enhancements to file download workflow:**

* Added the `getBlobOrError` function to `FPO.Data.Request`, which first tries to fetch a blob and, if that fails, attempts to fetch an error message as a string. This provides more robust error handling for file downloads. [[1]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R14) [[2]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R648-R668)
* Updated the Home page's `DownloadPdf` action to use `getBlobOrError`, implementing the full workflow for downloading a PDF file: creating a blob URL, generating a temporary `<a>` element to trigger the download, and revoking the blob URL after a short delay.

**Dependency and import updates:**

* Added new imports for DOM manipulation and blob handling in the Home page module, supporting the file download logic.
* Updated imports in the Home page to include `getBlobOrError` and related types, ensuring the new download workflow is properly integrated.