### PR TITLE
Paragraph pdf download

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -762,21 +762,14 @@ editor = connect selectTranslator $ H.mkComponent
       H.modify_ _ { discardPopup = true }
 
     Render renderType -> do
-      allLines <- H.gets _.mEditor >>= traverse \ed -> do
-        H.liftEffect $ Editor.getSession ed
-          >>= Session.getDocument
-          >>= Document.getAllLines
       case renderType of
         RenderHTML -> do
           html <- H.gets _.html
           H.raise (ClickedQuery html)
         -- TODO change this later when backend is ready
         RenderPDF -> do
-          let
-            content = case allLines of
-              Nothing -> ""
-              Just ls -> intercalate "\n" ls
-          H.raise (PostPDF content)
+          state <- H.get
+          H.raise (PostPDF state.currentVersion)
 
     ShowAllComments -> do
       state <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -8,7 +8,6 @@ module FPO.Component.Splitview where
 
 import Prelude
 
-import Data.Argonaut (fromString)
 import Data.Array (cons, deleteAt, head, insertAt, null, snoc, uncons, updateAt, (!!))
 import Data.Either (Either(..))
 import Data.Formatter.DateTime (Formatter)
@@ -969,43 +968,68 @@ splitview = connect selectTranslator $ H.mkComponent
             }
         H.tell _comment unit (Comment.DeletedComment deletedIDs)
 
-      Editor.PostPDF content -> do
-        renderedPDF' <- Request.postBlobOrError "/render/pdf" (fromString content)
-        tocTitleMaybe <- H.request _toc unit TOC.RequestCurrentTocEntryTitle
+      Editor.PostPDF _ -> do
+        state <- H.get
+        upToDateVersion <- H.request _toc unit TOC.RequestUpToDateVersion
         let
-          tocTitle = join tocTitleMaybe -- This flattens Maybe (Maybe String) to Maybe String
-          filename = (fromMaybe "document" tocTitle) <> ".pdf"
-        case renderedPDF' of
-          Left _ -> pure unit
-          Right blobOrError ->
-            case blobOrError of
-              Left errMsg -> H.modify_ _
-                { renderedHtml = Just
-                    (Loaded ("<pre><code>" <> errMsg <> "</code></pre>"))
-                }
-              Right body -> do
-                -- create blobl link
-                url <- H.liftEffect $ createObjectURL body
-                -- Create an invisible link and click it to download PDF
-                H.liftEffect $ do
-                  -- get window stuff
-                  win <- window
-                  hdoc <- document win
-                  let doc = HTMLDocument.toDocument hdoc
+          textElementId :: Int
+          textElementId = case state.mSelectedTocEntry of
+            Just (SelLeaf id) -> id
+            _ -> -1
 
-                  -- create link
-                  aEl <- Document.createElement "a" doc
-                  case HTMLElement.fromElement aEl of
-                    Nothing -> pure unit
-                    Just aHtml -> do
-                      Element.setAttribute "href" url aEl
-                      Element.setAttribute "download" filename aEl
-                      HTMLElement.click aHtml
-                -- deactivate the blob link after 1 sec
-                _ <- H.fork do
-                  H.liftAff $ delay (Milliseconds 1000.0)
-                  H.liftEffect $ revokeObjectURL url
-                pure unit
+          revisionId :: Int
+          revisionId =
+            case
+              findRootTree (\e -> e.elementID == textElementId) state.versionMapping
+              of
+              Just revision -> fromMaybe (-1) revision.versionID
+              Nothing -> case upToDateVersion of
+                Just (Just version) -> fromMaybe (-1) version.identifier
+                _ -> -1
+        if textElementId == -1 then do
+          updateStore $ Store.AddWarning "No section selected for PDF export"
+        else do
+          renderedPDF' <- Request.getBlobOrError
+            ( "/docs/" <> show state.docID <> "/text/" <> show textElementId
+                <> "/rev/"
+                <> (if revisionId == -1 then "latest" else show revisionId)
+                <> "/pdf"
+            )
+          tocTitleMaybe <- H.request _toc unit TOC.RequestCurrentTocEntryTitle
+          let
+            tocTitle = join tocTitleMaybe -- This flattens Maybe (Maybe String) to Maybe String
+            filename = (fromMaybe "document" tocTitle) <> ".pdf"
+          case renderedPDF' of
+            Left _ -> pure unit
+            Right blobOrError ->
+              case blobOrError of
+                Left errMsg -> H.modify_ _
+                  { renderedHtml = Just
+                      (Loaded ("<pre><code>" <> errMsg <> "</code></pre>"))
+                  }
+                Right body -> do
+                  -- create blobl link
+                  url <- H.liftEffect $ createObjectURL body
+                  -- Create an invisible link and click it to download PDF
+                  H.liftEffect $ do
+                    -- get window stuff
+                    win <- window
+                    hdoc <- document win
+                    let doc = HTMLDocument.toDocument hdoc
+
+                    -- create link
+                    aEl <- Document.createElement "a" doc
+                    case HTMLElement.fromElement aEl of
+                      Nothing -> pure unit
+                      Just aHtml -> do
+                        Element.setAttribute "href" url aEl
+                        Element.setAttribute "download" filename aEl
+                        HTMLElement.click aHtml
+                  -- deactivate the blob link after 1 sec
+                  _ <- H.fork do
+                    H.liftAff $ delay (Milliseconds 1000.0)
+                    H.liftEffect $ revokeObjectURL url
+                  pure unit
 
       Editor.RequestComments docID entryID -> do
         H.tell _comment unit (Comment.RequestComments docID entryID)


### PR DESCRIPTION
This pull request refactors how the PDF export feature works in the editor and splitview components, improving reliability and user experience. The main change is that PDF exports now use the current version of the selected section and generate cleaner filenames by stripping HTML tags from section titles. Additionally, the code now handles cases where no section is selected, providing appropriate user feedback.

**PDF Export Improvements:**

* PDF export in `Editor` now uses `state.currentVersion` instead of manually collecting editor lines, ensuring the exported content matches the latest version.
* In `Splitview`, PDF export requests now target the selected section and its current revision, falling back to the latest if necessary. If no section is selected, a warning is shown to the user.

**Filename Handling Enhancements:**

* Filenames for exported PDFs are now generated by stripping HTML tags from section titles, resulting in cleaner filenames. The new `stripHtmlTags` utility uses regex for this purpose. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL972-R1005) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1528-R1533)

**Dependency Updates:**

* Added imports for `Data.String.Regex` and `Data.String.Regex.Flags` to support HTML tag stripping in filenames.