### PR TITLE
render get draft revision

### DIFF
--- a/backend/src/Docs.hs
+++ b/backend/src/Docs.hs
@@ -1128,14 +1128,29 @@ guardExistsComment ref@(CommentRef textRef _) = do
 -- Returns Nothing if no draft exists for this user/element combination.
 -- Drafts are user-specific and element-specific (one draft per user per text element).
 getDraftTextRevision
-    :: (DB.HasDraftTextRevision m, HasLogMessage m)
+    :: ( DB.HasDraftTextRevision m
+       , HasLogMessage m
+       , HasGetTreeRevision m
+       , HasGetTextElementRevision m
+       , HasGetRevisionKey m
+       , HasGetDocument m
+       )
     => UserID
     -> TextElementRef
-    -> m (Result (Maybe DraftRevision))
+    -> m (Result (Maybe (Rendered DraftRevision)))
 getDraftTextRevision userID ref@(TextElementRef docID _) = logged userID Scope.docsTextRevision $ runExceptT $ do
     guardPermission Read docID userID
     guardExistsTextElement ref
-    lift $ DB.getDraftTextRevision userID ref
+    revision <- lift $ DB.getDraftTextRevision userID ref
+    mapM
+        ( \rev ->
+            rendered'
+                userID
+                (TextRevisionRef ref TextRevision.Latest)
+                (TextRevision.draftContent rev)
+                rev
+        )
+        revision
 
 -- | Publish a draft text revision to the main revision tree.
 -- This attempts to create a regular text revision from the draft content.

--- a/backend/src/Server/Handlers/DocsHandlers.hs
+++ b/backend/src/Server/Handlers/DocsHandlers.hs
@@ -366,7 +366,7 @@ type GetDraftTextRevision =
         :> "text"
         :> Capture "textElementID" TextElementID
         :> "draft"
-        :> Get '[JSON] (Maybe DraftRevision)
+        :> Get '[JSON] (Maybe (Rendered DraftRevision))
 
 type PublishDraftTextRevision =
     Summary "Publish draft text revision"
@@ -861,7 +861,7 @@ getDraftTextRevisionHandler
     :: AuthResult Auth.Token
     -> DocumentID
     -> TextElementID
-    -> Handler (Maybe DraftRevision)
+    -> Handler (Maybe (Rendered DraftRevision))
 getDraftTextRevisionHandler auth docID textID = do
     userID <- getUser auth
     withDB $


### PR DESCRIPTION
This pull request updates the way draft text revisions are retrieved and returned in the backend, ensuring that the API now provides rendered versions of draft revisions instead of raw data. The changes affect both the implementation and the API surface, requiring additional context and rendering logic when fetching draft revisions.

API changes:

* The `GetDraftTextRevision` API endpoint now returns a `Maybe (Rendered DraftRevision)` instead of `Maybe DraftRevision`, reflecting that clients will receive rendered draft revision data.
* The `getDraftTextRevisionHandler` function signature is updated to return `Maybe (Rendered DraftRevision)` to match the new API contract.

Backend logic changes:

* The `getDraftTextRevision` function in `Docs.hs` now requires additional context and capabilities to render draft revisions, and returns a rendered version if a draft exists.