### PR TITLE
Add meta map

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -34,10 +34,27 @@ import FPO.Data.Store as Store
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
 import FPO.Dto.DocumentDto.MetaTree as MM
-import FPO.Dto.DocumentDto.TreeDto (Edge(..), RootTree(..), Tree(..), TreeHeader(..), errorMeta, findRootTree, modifyNodeRootTree)
+import FPO.Dto.DocumentDto.TreeDto
+  ( Edge(..)
+  , RootTree(..)
+  , Tree(..)
+  , TreeHeader(..)
+  , errorMeta
+  , findRootTree
+  , modifyNodeRootTree
+  )
 import FPO.Translations.Translator (FPOTranslator, fromFpoTranslator)
 import FPO.Translations.Util (FPOState, selectTranslator)
-import FPO.Types (TOCEntry, TOCTree, documentTreeToTOCTree, emptyTOCEntry, findTOCEntry, findTitleTOCEntry, timeStampsVersions, tocTreeToDocumentTree)
+import FPO.Types
+  ( TOCEntry
+  , TOCTree
+  , documentTreeToTOCTree
+  , emptyTOCEntry
+  , findTOCEntry
+  , findTitleTOCEntry
+  , timeStampsVersions
+  , tocTreeToDocumentTree
+  )
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -644,7 +661,7 @@ splitview = connect selectTranslator $ H.mkComponent
         ("/docs/" <> show s.docID <> "/tree/latest")
       case maybeTree of
         Left err -> updateStore $ Store.AddError err
-        Right (MM.DocumentTreeWithMetaMap { tree, metaMap }) -> do
+        Right (MM.DocumentTreeWithMetaMap { tree {-, metaMap -} }) -> do
           let
             finalTree = documentTreeToTOCTree tree
             vMapping = map
@@ -652,7 +669,7 @@ splitview = connect selectTranslator $ H.mkComponent
                   { elementID: elem.id, versionID: Nothing, comparisonData: Nothing }
               )
               finalTree
-          H.liftEffect $ log (MM.prettyPrintMetaMap metaMap)
+          -- H.liftEffect $ log (MM.prettyPrintMetaMap metaMap)
           H.modify_ _
             { tocEntries = finalTree
             , versionMapping = vMapping

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -17,7 +17,6 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags as RegexFlags
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview

--- a/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
@@ -170,23 +170,32 @@ prettyPrintMetaMap metaMap =
   "MetaMap:\n" <> intercalate "\n\n" (map ppEntry metaMap)
   where
   ppEntry (Tuple fullTypeName properTypeMeta) =
-    indent 1 <> "┌─ " <> ppFullTypeName fullTypeName <> "\n" <>
-    indent 1 <> "└─ " <> ppProperTypeMeta properTypeMeta 0
+    indent 1 <> "┌─ " <> ppFullTypeName fullTypeName <> "\n"
+      <> indent 1
+      <> "└─ "
+      <> ppProperTypeMeta properTypeMeta 0
 
   ppFullTypeName (FullTypeName { kindName: kind, typeName: type_ }) =
     "(" <> kind <> ", " <> type_ <> ")"
 
   ppProperTypeMeta (ProperTypeMeta (DisplayTypeName displayName) treeSyntax) level =
-    "\"" <> displayName <> "\"\n" <>
-    indent (level + 2) <> "└─ " <> ppTreeSyntax treeSyntax (level + 1)
+    "\"" <> displayName <> "\"\n"
+      <> indent (level + 2)
+      <> "└─ "
+      <> ppTreeSyntax treeSyntax (level + 1)
 
   ppTreeSyntax treeSyntax level = case treeSyntax of
     LeafSyntax ->
       "LeafSyntax"
     TreeSyntax (HasEditableHeader hasEditableHeader) childrenOrder ->
-      "TreeSyntax\n" <>
-      indent (level + 2) <> "├─ HasEditableHeader: " <> show hasEditableHeader <> "\n" <>
-      indent (level + 2) <> "└─ " <> ppChildrenOrder childrenOrder (level + 1)
+      "TreeSyntax\n"
+        <> indent (level + 2)
+        <> "├─ HasEditableHeader: "
+        <> show hasEditableHeader
+        <> "\n"
+        <> indent (level + 2)
+        <> "└─ "
+        <> ppChildrenOrder childrenOrder (level + 1)
 
   ppChildrenOrder childrenOrder level = case childrenOrder of
     SequenceOrder disjunctions ->
@@ -195,19 +204,28 @@ prettyPrintMetaMap metaMap =
       "StarOrder\n" <> ppSingleDisjunction disjunction (level + 1)
 
   ppDisjunctions disjunctions level =
-    intercalate "\n" $ mapWithIndex (\i disj ->
-      indent (level + 2) <>
-      (if i == (length disjunctions - 1) then "└─ " else "├─ ") <>
-      "Step " <> show (i + 1) <> ": " <> ppDisjunctionContent disj (level + 2)
-    ) disjunctions
+    intercalate "\n" $ mapWithIndex
+      ( \i disj ->
+          indent (level + 2)
+            <> (if i == (length disjunctions - 1) then "└─ " else "├─ ")
+            <> "Step "
+            <> show (i + 1)
+            <> ": "
+            <> ppDisjunctionContent disj (level + 2)
+      )
+      disjunctions
 
   ppSingleDisjunction (Disjunction arr) level =
-    indent (level + 2) <> "└─ Options: " <> ppDisjunctionContent (Disjunction arr) (level + 2)
+    indent (level + 2) <> "└─ Options: " <> ppDisjunctionContent (Disjunction arr)
+      (level + 2)
 
   ppDisjunctionContent (Disjunction arr) level = case arr of
-    [singleItem] ->
+    [ singleItem ] ->
       show singleItem
     multipleItems ->
-      "[\n" <>
-      intercalate ",\n" (map (\item -> indent (level + 2) <> show item) multipleItems) <>
-      "\n" <> indent (level + 1) <> "]"
+      "[\n"
+        <> intercalate ",\n"
+          (map (\item -> indent (level + 2) <> show item) multipleItems)
+        <> "\n"
+        <> indent (level + 1)
+        <> "]"

--- a/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
@@ -1,0 +1,192 @@
+-- | This module defines the meta map structure for TOC trees.
+module FPO.Dto.DocumentDto.MetaTree where
+
+import Prelude
+
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError(..), decodeJson, (.:))
+import Data.Array (intercalate, length, mapWithIndex, (..))
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.Show.Generic (genericShow)
+import Data.String (joinWith)
+import Data.Tuple (Tuple(..))
+import FPO.Dto.DocumentDto.TreeDto (RootTree)
+
+-- | Specifies the kind; e.g., "document", "section", "appendix-section", ...
+type KindName = String
+-- | Specifies the type; e.g., "fpo-maindoc", "section", "supersection", ...
+type TypeName = String
+
+newtype FullTypeName = FullTypeName { kindName :: KindName, typeName :: TypeName }
+
+newtype DisplayTypeName = DisplayTypeName String
+
+derive instance Generic DisplayTypeName _
+derive newtype instance Show DisplayTypeName
+derive newtype instance Eq DisplayTypeName
+
+instance DecodeJson DisplayTypeName where
+  decodeJson json = DisplayTypeName <$> decodeJson json
+
+data ProperTypeMeta = ProperTypeMeta DisplayTypeName (TreeSyntax FullTypeName)
+
+derive instance Generic ProperTypeMeta _
+instance Show ProperTypeMeta where
+  show = genericShow
+
+instance DecodeJson ProperTypeMeta where
+  decodeJson json = do
+    arr <- decodeJson json
+    case arr of
+      [ displayName, treeSyntax ] -> do
+        name <- decodeJson displayName
+        syntax <- decodeJson treeSyntax
+        pure $ ProperTypeMeta (DisplayTypeName name) syntax
+      _ -> Left $ TypeMismatch
+        "Expected array with exactly 2 elements for ProperTypeMeta"
+
+newtype HasEditableHeader = HasEditableHeader Boolean
+
+derive instance Generic HasEditableHeader _
+derive newtype instance Show HasEditableHeader
+derive newtype instance Eq HasEditableHeader
+
+instance DecodeJson HasEditableHeader where
+  decodeJson json = HasEditableHeader <$> decodeJson json
+
+data TreeSyntax a
+  -- | A leaf (terminal) node, which has no children.
+  = LeafSyntax
+  -- | A tree node, which can contain children.
+  | TreeSyntax
+      HasEditableHeader
+      (ChildrenOrder a)
+
+derive instance Generic (TreeSyntax a) _
+instance Show a => Show (TreeSyntax a) where
+  show = genericShow
+
+instance DecodeJson a => DecodeJson (TreeSyntax a) where
+  decodeJson json = do
+    obj <- decodeJson json
+    tag <- obj .: "tag"
+    case tag of
+      "LeafSyntax" -> pure LeafSyntax
+      "TreeSyntax" -> do
+        contents <- obj .: "contents"
+        case contents of
+          [ hasEditableHeader, childrenOrder ] -> do
+            header <- decodeJson hasEditableHeader
+            order <- decodeJson childrenOrder
+            pure $ TreeSyntax (HasEditableHeader header) order
+          _ -> Left $ TypeMismatch
+            "Expected array with exactly 2 elements for TreeSyntax contents"
+      _ -> Left $ UnexpectedValue json
+
+data ChildrenOrder a
+  -- | Children are ordered in a specific sequence.
+  = SequenceOrder (Array (Disjunction a))
+  -- | Children can appear in any order and quantity (e.g., multiple sections).
+  | StarOrder (Disjunction a)
+
+derive instance Generic (ChildrenOrder a) _
+instance Show a => Show (ChildrenOrder a) where
+  show = genericShow
+
+instance DecodeJson a => DecodeJson (ChildrenOrder a) where
+  decodeJson json = do
+    obj <- decodeJson json
+    tag <- obj .: "tag"
+    contents <- obj .: "contents"
+    case tag of
+      "SequenceOrder" -> SequenceOrder <$> decodeJson contents
+      "StarOrder" -> StarOrder <$> decodeJson contents
+      _ -> Left $ UnexpectedValue json
+
+newtype Disjunction a = Disjunction (Array a)
+
+derive instance Generic (Disjunction a) _
+derive newtype instance Show a => Show (Disjunction a)
+derive newtype instance Eq a => Eq (Disjunction a)
+
+instance DecodeJson a => DecodeJson (Disjunction a) where
+  decodeJson json = Disjunction <$> decodeJson json
+
+derive instance Generic FullTypeName _
+derive newtype instance Show FullTypeName
+derive newtype instance Eq FullTypeName
+
+-- Helper instance for FullTypeName
+instance DecodeJson FullTypeName where
+  decodeJson json = do
+    arr <- decodeJson json
+    case arr of
+      [ kindName, typeName ] -> do
+        kind <- decodeJson kindName
+        type_ <- decodeJson typeName
+        pure $ FullTypeName { kindName: kind, typeName: type_ }
+      _ -> Left $ TypeMismatch
+        "Expected array with exactly 2 elements for FullTypeName"
+
+-- | Type alias for the complete meta map
+type MetaMap = Array (Tuple FullTypeName ProperTypeMeta)
+
+-- | Helper function to decode the entire meta map
+decodeMetaMap :: Json -> Either JsonDecodeError MetaMap
+decodeMetaMap json = decodeJson json
+
+newtype DocumentTreeWithMetaMap a = DocumentTreeWithMetaMap
+  { metaMap :: MetaMap
+  , tree :: RootTree a
+  }
+
+-- | This is an extended version of `decodeDocument` that also extracts the `metaMap`,
+-- | see `DocumentTreeWithMetaMap`. It would be wise to, at some point, refactor the
+-- | documentDto system and everything related to `RootTree`. For now, this is a quick
+-- | solution to get the meta map alongside the document tree.
+decodeDocumentWithMetaMap
+  :: forall a
+   . DecodeJson a
+  => Json
+  -> Either JsonDecodeError (DocumentTreeWithMetaMap a)
+decodeDocumentWithMetaMap json = do
+  obj <- decodeJson json
+  revision <- obj .: "revision"
+  root <- revision .: "root"
+  metaMap <- revision .: "metaMap"
+  pure $ DocumentTreeWithMetaMap
+    { metaMap: metaMap
+    , tree: root
+    }
+
+prettyPrintMetaMap :: MetaMap -> String
+prettyPrintMetaMap metaMap =
+  intercalate "\n" $ map ppEntry metaMap
+  where
+  ppEntry (Tuple fullTypeName properTypeMeta) =
+    "FullTypeName: " <> ppFullTypeName fullTypeName <> "\n => ProperTypeMeta: " <>
+      ppProperTypeMeta properTypeMeta
+
+  ppFullTypeName (FullTypeName { kindName: kind, typeName: type_ }) =
+    "(" <> kind <> ", " <> type_ <> ")"
+
+  ppProperTypeMeta (ProperTypeMeta (DisplayTypeName displayName) treeSyntax) =
+    "DisplayTypeName: " <> displayName <> ", TreeSyntax: " <> ppTreeSyntax treeSyntax
+
+  ppTreeSyntax = case _ of
+    LeafSyntax -> "LeafSyntax"
+    TreeSyntax (HasEditableHeader hasEditableHeader) childrenOrder ->
+      "TreeSyntax(HasEditableHeader: " <> show hasEditableHeader
+        <> ", ChildrenOrder: "
+        <> ppChildrenOrder childrenOrder
+        <> ")"
+
+  ppChildrenOrder = case _ of
+    SequenceOrder disjunctions ->
+      "SequenceOrder[" <> intercalate ", " (map ppDisjunction disjunctions) <> "]"
+    StarOrder disjunction ->
+      "StarOrder[" <> ppDisjunction disjunction <> "]"
+
+  ppDisjunction (Disjunction arr) =
+    "[" <> intercalate ", " (map show arr) <> "]"

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -1,3 +1,5 @@
+-- | This module defines the document tree structure with meta information.
+-- | The meta map is not part of this (one layer above).
 module FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
   , Meta(..)
@@ -44,7 +46,7 @@ newtype TreeHeader = TreeHeader
 -- | Note: Altough the label and title are html-escaped strings, they should not
 -- |       contain any html tags except for <span> and </span>. Because there is no convenient
 -- |       way to insert raw html into Halogen rendering, we can drop these tags before
--- |       rendering (using, e.g., `getFullTitle`). This isn't a perfect solution, 
+-- |       rendering (using, e.g., `getFullTitle`). This isn't a perfect solution,
 -- |       but easier than other approaches. We could use `FPO.UI.HTML.rawHtml`, but
 -- |       this would not work for tooltips...
 newtype Meta = Meta


### PR DESCRIPTION
Adds the `MetaMap` and `DocumentTreeWithMetaMap` `DTO`s, loads the associated meta map when opening a document in the editor.

See #625.