### PR TITLE
Update TOC labels after TOC change

### DIFF
--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -55,7 +55,7 @@ import FPO.Dto.DocumentDto.TreeDto
   , getShortTitle
   , modifyNodeRootTree
   )
-import FPO.Dto.PostTextDto (PostTextDto(..), createPostTextDto)
+import FPO.Dto.PostTextDto (PostTextDto, createPostTextDto)
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Translations.Translator (fromFpoTranslator)
 import FPO.Translations.Util (FPOState)

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -12,20 +12,7 @@ module FPO.Components.TOC
   , tocview
   ) where
 
-import Data.Array
-  ( concat
-  , cons
-  , drop
-  , head
-  , last
-  , length
-  , mapWithIndex
-  , snoc
-  , tail
-  , take
-  , uncons
-  , unsnoc
-  )
+import Data.Array (concat, cons, drop, head, last, length, mapWithIndex, snoc, tail, take, uncons, unsnoc)
 import Data.Date (Date)
 import Data.DateTime (DateTime, adjust)
 import Data.Either (Either(..))
@@ -42,20 +29,8 @@ import FPO.Data.Time (dateToDatetime, formatAbsoluteTimeDetailed)
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.DocumentDto.TreeDto
-  ( Edge(..)
-  , Meta(..)
-  , Result(..)
-  , RootTree(..)
-  , Tree(..)
-  , TreeHeader(..)
-  , findRootTree
-  , getContent
-  , getFullTitle
-  , getShortTitle
-  , modifyNodeRootTree
-  )
-import FPO.Dto.PostTextDto (PostTextDto(..))
+import FPO.Dto.DocumentDto.TreeDto (Edge(..), Meta(..), Result(..), RootTree(..), Tree(..), TreeHeader(..), findRootTree, getContent, getFullTitle, getShortTitle, modifyNodeRootTree)
+import FPO.Dto.PostTextDto (PostTextDto(..), createPostTextDto)
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Translations.Translator (fromFpoTranslator)
 import FPO.Translations.Util (FPOState)
@@ -71,33 +46,7 @@ import Halogen.Store.Monad (class MonadStore)
 import Halogen.Store.Select (selectEq)
 import Halogen.Themes.Bootstrap5 as HB
 import Parsing (runParserT)
-import Prelude
-  ( class Eq
-  , Unit
-  , bind
-  , const
-  , discard
-  , identity
-  , map
-  , negate
-  , not
-  , pure
-  , show
-  , unit
-  , when
-  , ($)
-  , (&&)
-  , (+)
-  , (-)
-  , (/=)
-  , (<)
-  , (<<<)
-  , (<>)
-  , (==)
-  , (>)
-  , (>=)
-  , (||)
-  )
+import Prelude (class Eq, Unit, bind, const, discard, identity, map, negate, not, pure, show, unit, when, ($), (&&), (+), (-), (/=), (<), (<<<), (<>), (==), (>), (>=), (||))
 import Simple.I18n.Translator (label, translate)
 import Web.Event.Event (preventDefault)
 import Web.HTML.Event.DragEvent (DragEvent, toEvent)
@@ -528,8 +477,8 @@ tocview = connect (selectEq identity) $ H.mkComponent
       s <- H.get
       gotRes <- postJson PostTextDto.decodePostTextDto
         ("/docs/" <> show s.docID <> "/text")
-        ( PostTextDto.encodePostTextDto
-            (PostTextDto { identifier: 0, kind: "section", type_: "section" }) -- TODO: choose type_ according to (still missing) meta map!
+        ( PostTextDto.encodePostTextDto -- TODO: choose type_ according to (still missing) meta map!
+            (createPostTextDto { kind: "section", type_: "section" })
         )
       case gotRes of
         Left _ -> pure unit -- TODO error handling
@@ -539,7 +488,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
               Leaf
                 { meta: Meta
                     { label: Nothing
-                    , title: Success $ Just "New Subsection"
+                    , title: Success $ Just "New Subsection (Meta)"
                     }
                 , node:
                     { id: PostTextDto.getID dto
@@ -556,11 +505,11 @@ tocview = connect (selectEq identity) $ H.mkComponent
         newEntry = Node
           { meta: Meta
               { label: Nothing
-              , title: Success $ Just "New Section"
+              , title: Success $ Just "New Section (Meta)"
               }
           , children: []
           , header: TreeHeader
-              { headerKind: "section", headerType: "section", heading: "" }
+              { headerKind: "section", headerType: "supersection", heading: "New Section" }
           }
       H.raise (AddNode path newEntry)
 

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -12,7 +12,20 @@ module FPO.Components.TOC
   , tocview
   ) where
 
-import Data.Array (concat, cons, drop, head, last, length, mapWithIndex, snoc, tail, take, uncons, unsnoc)
+import Data.Array
+  ( concat
+  , cons
+  , drop
+  , head
+  , last
+  , length
+  , mapWithIndex
+  , snoc
+  , tail
+  , take
+  , uncons
+  , unsnoc
+  )
 import Data.Date (Date)
 import Data.DateTime (DateTime, adjust)
 import Data.Either (Either(..))
@@ -29,7 +42,19 @@ import FPO.Data.Time (dateToDatetime, formatAbsoluteTimeDetailed)
 import FPO.Dto.DocumentDto.DocDate as DD
 import FPO.Dto.DocumentDto.DocumentHeader as DH
 import FPO.Dto.DocumentDto.TextElement as TE
-import FPO.Dto.DocumentDto.TreeDto (Edge(..), Meta(..), Result(..), RootTree(..), Tree(..), TreeHeader(..), findRootTree, getContent, getFullTitle, getShortTitle, modifyNodeRootTree)
+import FPO.Dto.DocumentDto.TreeDto
+  ( Edge(..)
+  , Meta(..)
+  , Result(..)
+  , RootTree(..)
+  , Tree(..)
+  , TreeHeader(..)
+  , findRootTree
+  , getContent
+  , getFullTitle
+  , getShortTitle
+  , modifyNodeRootTree
+  )
 import FPO.Dto.PostTextDto (PostTextDto(..), createPostTextDto)
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Translations.Translator (fromFpoTranslator)
@@ -46,7 +71,33 @@ import Halogen.Store.Monad (class MonadStore)
 import Halogen.Store.Select (selectEq)
 import Halogen.Themes.Bootstrap5 as HB
 import Parsing (runParserT)
-import Prelude (class Eq, Unit, bind, const, discard, identity, map, negate, not, pure, show, unit, when, ($), (&&), (+), (-), (/=), (<), (<<<), (<>), (==), (>), (>=), (||))
+import Prelude
+  ( class Eq
+  , Unit
+  , bind
+  , const
+  , discard
+  , identity
+  , map
+  , negate
+  , not
+  , pure
+  , show
+  , unit
+  , when
+  , ($)
+  , (&&)
+  , (+)
+  , (-)
+  , (/=)
+  , (<)
+  , (<<<)
+  , (<>)
+  , (==)
+  , (>)
+  , (>=)
+  , (||)
+  )
 import Simple.I18n.Translator (label, translate)
 import Web.Event.Event (preventDefault)
 import Web.HTML.Event.DragEvent (DragEvent, toEvent)
@@ -509,7 +560,10 @@ tocview = connect (selectEq identity) $ H.mkComponent
               }
           , children: []
           , header: TreeHeader
-              { headerKind: "section", headerType: "supersection", heading: "New Section" }
+              { headerKind: "section"
+              , headerType: "supersection"
+              , heading: "New Section"
+              }
           }
       H.raise (AddNode path newEntry)
 

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -55,7 +55,7 @@ import FPO.Dto.DocumentDto.TreeDto
   , getShortTitle
   , modifyNodeRootTree
   )
-import FPO.Dto.PostTextDto (PostTextDto, createPostTextDto)
+import FPO.Dto.PostTextDto (createPostTextDto)
 import FPO.Dto.PostTextDto as PostTextDto
 import FPO.Translations.Translator (fromFpoTranslator)
 import FPO.Translations.Util (FPOState)

--- a/frontend/src/FPO/Dto/PostTextDto.purs
+++ b/frontend/src/FPO/Dto/PostTextDto.purs
@@ -32,6 +32,14 @@ instance showPostTextDto :: Show PostTextDto where
   show (PostTextDto { identifier, kind }) =
     "PostTextDto { identifier: " <> show identifier <> ", kind: " <> kind <> " }"
 
+-- | Create a new PostTextDto where the identifier is not relevant.
+-- | TODO: It would be smart to differentiate between a `PostTextDto` (without id)
+-- |       and a `GetTextDto` (with id), but for simplicity we just use this one type.
+-- |       The POST requests do not care about the identifier field.
+createPostTextDto :: { kind :: String, type_ :: String } -> PostTextDto
+createPostTextDto { kind, type_ } =
+  PostTextDto { identifier: 0, kind, type_ }
+
 decodePostTextDto :: Json -> Either JsonDecodeError PostTextDto
 decodePostTextDto json = decodeJson json
 


### PR DESCRIPTION
This PR retrieves the new TOC labels from the backend after adding new entries. This is needed, for example, for properly showing the label (§ xy). This is also done when rearranging/shuffling sections or deleting sections. Not super ideal because these kinds of requests take some time, so changing stuff in the TOC might introduce some lag, but time will tell. Otherwise, we could easily predict changes locally.

Also, we now use hardcoded supersection type when adding new internal TOC nodes. 

