### PR TITLE
Add hotflix for opening new section

### DIFF
--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -83,11 +83,16 @@ instance decodeJsonContentWrapper :: DecodeJson ContentWrapper where
     case mEle of
       -- Normal Content
       Just ele -> do
-        rev <- ele .: "revision"
-        con <- decodeJson (fromObject rev)
-        coms <- rev .: "commentAnchors"
+        mRev <- ele .:? "revision"
         html <- obj .: "html"
-        pure $ Wrapper { content: con, comments: coms, html }
+        case mRev of
+          Nothing -> do
+            -- TODO: How to handle this case?
+            pure $ Wrapper { content: Content { content: "", parent: -1}, comments: [], html }
+          Just rev -> do
+            con <- decodeJson (fromObject rev)
+            coms <- rev .: "commentAnchors"
+            pure $ Wrapper { content: con, comments: coms, html }
       -- Draft
       Nothing -> do
         con <- decodeJson (fromObject obj)

--- a/frontend/src/FPO/Dto/ContentDto.purs
+++ b/frontend/src/FPO/Dto/ContentDto.purs
@@ -88,7 +88,8 @@ instance decodeJsonContentWrapper :: DecodeJson ContentWrapper where
         case mRev of
           Nothing -> do
             -- TODO: How to handle this case?
-            pure $ Wrapper { content: Content { content: "", parent: -1}, comments: [], html }
+            pure $ Wrapper
+              { content: Content { content: "", parent: -1 }, comments: [], html }
           Just rev -> do
             con <- decodeJson (fromObject rev)
             coms <- rev .: "commentAnchors"


### PR DESCRIPTION
Fixes the error in the frontend, but it's a bad, bad hotfix. See #630 
If the revision for the text element is missing, I just make up some data because the `ContentWrapper` does not allow for missing revision data. This shouldn't cause any problems when the user creates sections and edits them immediately, but I'm not sure what can go wrong in the meantime (i.e., before the user fills the content wrapper with useful data).