### PR TITLE
Title above editor

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -592,7 +592,6 @@ editor = connect selectTranslator $ H.mkComponent
       -- Do not load content, since no TOC has been selected yet
 
       -- create subscription for later use
-      state <- H.get
       { emitter, listener } <- H.liftEffect HS.create
       -- Subscribe to resize events and store subscription for cleanup
       subscription <- H.subscribe emitter
@@ -625,11 +624,8 @@ editor = connect selectTranslator $ H.mkComponent
           Editor.setTheme "ace/theme/github" editor_
           Session.setMode "ace/mode/custom_mode" session
           Editor.setEnableLiveAutocompletion true editor_
-          case state.compareToElement of
-            Just _ -> do
-              Editor.setReadOnly true editor_
-            Nothing ->
-              Editor.setReadOnly false editor_
+          -- set read only at the start to prevent users to write in not selected entry
+          Editor.setReadOnly true editor_
 
       -- New Ref for keeping track, if the content in editor has changed
       -- 1. since last save

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -528,18 +528,20 @@ editor = connect selectTranslator $ H.mkComponent
                     ]
                 ]
       , HH.div
-        [ HP.classes [ HB.dFlex, HB.justifyContentBetween ]
-        , HP.style "padding: .5rem 1rem; border-bottom: 1px solid rgba(0,0,0,.1);"
-        ]
-        [ HH.h2
-            [ HP.classes [ HH.ClassName "text-truncate" ]
-            , HP.style "font-size: 1rem; margin: 0;"
-            ]
-            [ HH.text $ 
-              case state.mTitle of
-                Just title -> title
-                Nothing -> translate (label :: _ "editor_no_title") state.translator]
-        ]
+          [ HP.classes [ HB.dFlex, HB.justifyContentBetween ]
+          , HP.style "padding: .5rem 1rem; border-bottom: 1px solid rgba(0,0,0,.1);"
+          ]
+          [ HH.h2
+              [ HP.classes [ HH.ClassName "text-truncate" ]
+              , HP.style "font-size: 1rem; margin: 0;"
+              ]
+              [ HH.text $
+                  case state.mTitle of
+                    Just title -> title
+                    Nothing -> translate (label :: _ "editor_no_title")
+                      state.translator
+              ]
+          ]
       , HH.div -- Editor container
 
           [ HP.ref (H.RefLabel "container")

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -538,7 +538,7 @@ editor = connect selectTranslator $ H.mkComponent
             [ HH.text $ 
               case state.mTitle of
                 Just title -> title
-                Nothing -> "No section selected"]
+                Nothing -> translate (label :: _ "editor_no_title") state.translator]
         ]
       , HH.div -- Editor container
 

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -454,6 +454,22 @@ editor = connect selectTranslator $ H.mkComponent
                         (translate (label :: _ "editor_allComments") state.translator)
                     ]
             ]
+      -- show selected TOC title below tool bar
+      , HH.div
+          [ HP.classes [ HB.dFlex, HB.justifyContentBetween ]
+          , HP.style "padding: .5rem 1rem; border-bottom: 1px solid rgba(0,0,0,.1);"
+          ]
+          [ HH.h2
+              [ HP.classes [ HH.ClassName "text-truncate" ]
+              , HP.style "font-size: 1rem; margin: 0;"
+              ]
+              [ HH.text $
+                  case state.mTitle of
+                    Just title -> title
+                    Nothing -> translate (label :: _ "editor_no_title")
+                      state.translator
+              ]
+          ]
       , case state.compareToElement of
           Nothing ->
             if state.isEditorOutdated then
@@ -527,21 +543,6 @@ editor = connect selectTranslator $ H.mkComponent
                         (translate (label :: _ "editor_readonly") state.translator)
                     ]
                 ]
-      , HH.div
-          [ HP.classes [ HB.dFlex, HB.justifyContentBetween ]
-          , HP.style "padding: .5rem 1rem; border-bottom: 1px solid rgba(0,0,0,.1);"
-          ]
-          [ HH.h2
-              [ HP.classes [ HH.ClassName "text-truncate" ]
-              , HP.style "font-size: 1rem; margin: 0;"
-              ]
-              [ HH.text $
-                  case state.mTitle of
-                    Just title -> title
-                    Nothing -> translate (label :: _ "editor_no_title")
-                      state.translator
-              ]
-          ]
       , HH.div -- Editor container
 
           [ HP.ref (H.RefLabel "container")

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1139,6 +1139,12 @@ splitview = connect selectTranslator $ H.mkComponent
               Just entry -> H.tell _editor 0 (Editor.ChangeSection entry Nothing Nothing)
           _ -> pure unit
 
+      Editor.RequestFullTitle -> do
+        handleAction GET
+        mmTitle <- H.request _toc unit TOC.RequestFullTitle
+        H.tell _editor 0 (Editor.ReceiveFullTitle (join mmTitle))
+        H.tell _editor 1 (Editor.ReceiveFullTitle (join mmTitle))
+
     DeleteDraft -> do
       handleAction UpdateMSelectedTocEntry
       state <- H.get
@@ -1258,12 +1264,6 @@ splitview = connect selectTranslator $ H.mkComponent
       newTOCTree <- _.tocEntries <$> H.get
       handleAction UpdateVersionMapping
       H.tell _toc unit (TOC.ReceiveTOCs newTOCTree)
-
--- findCommentSection :: TOCTree -> Int -> Int -> Maybe CommentSection
--- findCommentSection tocEntries tocID markerID = do
---   tocEntry <- findTOCEntry tocID tocEntries
---   marker <- find (\m -> m.id == markerID) tocEntry.markers
---   marker.mCommentSection
 
 {- ------------------ Tree traversal and mutation function ------------------ -}
 {- --------------------- TODO: Move to seperate module  --------------------- -}

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1121,7 +1121,8 @@ splitview = connect selectTranslator $ H.mkComponent
                     Nothing -> emptyTOCEntry
                     Just e -> e
                 mmTitle <- H.request _toc unit TOC.RequestFullTitle
-                H.tell _editor 1 (Editor.ChangeSection entry version.identifier (join mmTitle))
+                H.tell _editor 1
+                  (Editor.ChangeSection entry version.identifier (join mmTitle))
               _ -> pure unit
           _ -> do
             pure unit
@@ -1136,7 +1137,8 @@ splitview = connect selectTranslator $ H.mkComponent
               (ModifyVersionMapping elementID (Just Nothing) (Just Nothing))
             case (findTOCEntry elementID state.tocEntries) of
               Nothing -> pure unit
-              Just entry -> H.tell _editor 0 (Editor.ChangeSection entry Nothing Nothing)
+              Just entry -> H.tell _editor 0
+                (Editor.ChangeSection entry Nothing Nothing)
           _ -> pure unit
 
       Editor.RequestFullTitle -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -675,7 +675,6 @@ splitview = connect selectTranslator $ H.mkComponent
                   { elementID: elem.id, versionID: Nothing, comparisonData: Nothing }
               )
               finalTree
-          -- H.liftEffect $ log (MM.prettyPrintMetaMap metaMap)
           H.modify_ _
             { tocEntries = finalTree
             , versionMapping = vMapping

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -361,7 +361,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 \z-index: 10;"
             , HE.onClick \_ -> ToggleComment
             ]
-            [ HH.text "x" ]
+            [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
         , HH.h4
             [ HP.style
                 "margin-top: 0.5rem; margin-bottom: 1rem; margin-left: 0.5rem; font-weight: bold; color: black;"
@@ -401,7 +401,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 \z-index: 10;"
             , HE.onClick \_ -> ToggleCommentOverview false (-1) (-1)
             ]
-            [ HH.text "x" ]
+            [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
         , HH.h4
             [ HP.style
                 "margin-top: 0.5rem; margin-bottom: 1rem; margin-left: 0.5rem; font-weight: bold; color: black;"
@@ -550,7 +550,7 @@ splitview = connect selectTranslator $ H.mkComponent
                       \z-index: 10;"
                   , HE.onClick \_ -> TogglePreview
                   ]
-                  [ HH.text "x" ]
+                  [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
               ]
           , HH.slot _preview unit Preview.preview
               { renderedHtml: state.renderedHtml

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -17,6 +17,7 @@ import Data.Array
   , cons
   , drop
   , head
+  , index
   , last
   , length
   , mapWithIndex
@@ -25,7 +26,6 @@ import Data.Array
   , take
   , uncons
   , unsnoc
-  , index 
   )
 import Data.Date (Date)
 import Data.DateTime (DateTime, adjust)
@@ -34,6 +34,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Days(..), Minutes)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
+import Effect.Console (log)
 import Effect.Now (getTimezoneOffset, nowDateTime)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Data.Navigate (class Navigate)
@@ -92,19 +93,17 @@ import Prelude
   , (-)
   , (/=)
   , (<)
+  , (<$>)
   , (<<<)
   , (<>)
   , (==)
   , (>)
   , (>=)
   , (||)
-  , (<$>)
   )
 import Simple.I18n.Translator (label, translate)
 import Web.Event.Event (preventDefault)
 import Web.HTML.Event.DragEvent (DragEvent, toEvent)
-
-import Effect.Console (log)
 
 type Input = DH.DocumentID
 
@@ -1453,7 +1452,7 @@ findMetaByPath path (RootTree { children }) = go path children
   where
   go :: Array Int -> Array (Edge TOCEntry) -> Maybe Meta
   go p cs = case uncons p of
-    Nothing -> Nothing 
+    Nothing -> Nothing
     Just { head: i, tail: rest } ->
       case index cs i of
         Nothing -> Nothing
@@ -1461,5 +1460,5 @@ findMetaByPath path (RootTree { children }) = go path children
           case rest, t of
             [], Leaf { meta } -> Just meta
             [], Node { meta } -> Just meta
-            _,  Node { children: nChildren } -> go rest nChildren
-            _,  Leaf _ -> Nothing
+            _, Node { children: nChildren } -> go rest nChildren
+            _, Leaf _ -> Nothing

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1118,7 +1118,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
           ]
       , HE.onClick $ const $ RequestDeleteSection { kind, path, title }
       ]
-      [ HH.text "-" ]
+      [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-dash" ] ] [] ]
 
   -- Creates a history button for a paragraph.
   historyButton
@@ -1408,7 +1408,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
                 ]
             , HE.onClick \_ -> ToggleAddMenu currentPath
             ]
-            [ HH.text "+" ]
+            [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-plus" ] ] [] ]
       )
         <>
           ( singletonIf renderDeleteBtn $ deleteSectionButton currentPath kind title

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -34,7 +34,6 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Days(..), Minutes)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import Effect.Now (getTimezoneOffset, nowDateTime)
 import FPO.Components.Modals.DeleteModal (deleteConfirmationModal)
 import FPO.Data.Navigate (class Navigate)
@@ -723,7 +722,6 @@ tocview = connect (selectEq identity) $ H.mkComponent
             getFullTitle <$> findLeafMeta leafId entries
           Just (SelNode path _) ->
             getFullTitle <$> findMetaByPath path entries
-      H.liftEffect $ log $ show newMTitle
       H.modify_ _
         { searchData = sData, mTitle = newMTitle }
       case state.mSelectedTocEntry of

--- a/frontend/src/FPO/Translations/Components/Editor.purs
+++ b/frontend/src/FPO/Translations/Components/Editor.purs
@@ -22,6 +22,7 @@ type EditorLabels =
       ::: "editor_mergingInfo"
       ::: "editor_mergingInfoText"
       ::: "editor_mergingNow"
+      ::: "editor_no_title"
       ::: "editor_oldVersion"
       ::: "editor_pdf"
       ::: "editor_preview"
@@ -73,6 +74,7 @@ enEditor = fromRecord
         "If you do not wish to save your currently opened version, you can click on \"Discard\" to discard them and open the current version."
   , editor_mergingNow:
       "Copy over desired changes from the right and finish by clicking on \"Merge\""
+  , editor_no_title: "No section selected."
   , editor_oldVersion: "You are editing an old version"
   , editor_pdf: "Export PDF"
   , editor_preview: "Preview"
@@ -128,6 +130,7 @@ deEditor = fromRecord
         "Falls sie wünschen, ihre aktuellen änderungen zu verwerfen, so könne sie auf \"Verwerfen\" klicken um sie zu verwerfen und zur aktuellen Version zurückzukehren."
   , editor_mergingNow:
       "Bitte übernehmen sie gewünschten Änderungen der rechten Seite und klicken sie danach auf \"Vereinen\""
+  , editor_no_title: "Kein Abschnitt ausgewählt."
   , editor_oldVersion: "Sie bearbeiten eine alte Version"
   , editor_pdf: "PDF exportieren"
   , editor_preview: "Vorschau"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -170,6 +170,7 @@ type Labels =
       ::: "editor_mergingInfo"
       ::: "editor_mergingInfoText"
       ::: "editor_mergingNow"
+      ::: "editor_no_title"
       ::: "editor_oldVersion"
       ::: "editor_pdf"
       ::: "editor_preview"


### PR DESCRIPTION
This PR puts the section name from TOC above the editor. During the presentation, I noticed, that some users are confused and try to write in the not selected editor. This change should make it more clear. Also added pseudo-auto update on preview and TOC.