### PR TITLE
Add meta map to TOC

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -17,7 +17,6 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags as RegexFlags
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -34,7 +33,7 @@ import FPO.Data.Store as Store
 import FPO.Data.Time (defaultFormatter, timeStampsVersions)
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
-import FPO.Dto.DocumentDto.MetaTree (emptyMetaMap, prettyPrintMetaMap)
+import FPO.Dto.DocumentDto.MetaTree (emptyMetaMap)
 import FPO.Dto.DocumentDto.MetaTree as MM
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
@@ -56,7 +55,6 @@ import FPO.Types
   , findTitleTOCEntry
   , tocTreeToDocumentTree
   )
-import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -1251,7 +1249,7 @@ splitview = connect selectTranslator $ H.mkComponent
             { tocEntries = finalTree
             }
 
-          liftEffect $ log $ prettyPrintMetaMap metaMap
+          -- liftEffect $ log $ prettyPrintMetaMap metaMap
 
           H.tell _toc unit (TOC.ReceiveTOCs finalTree metaMap)
 

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -17,6 +17,7 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags as RegexFlags
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
+import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -33,7 +34,7 @@ import FPO.Data.Store as Store
 import FPO.Data.Time (defaultFormatter, timeStampsVersions)
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
-import FPO.Dto.DocumentDto.MetaTree (emptyMetaMap)
+import FPO.Dto.DocumentDto.MetaTree (emptyMetaMap, prettyPrintMetaMap)
 import FPO.Dto.DocumentDto.MetaTree as MM
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
@@ -55,6 +56,7 @@ import FPO.Types
   , findTitleTOCEntry
   , tocTreeToDocumentTree
   )
+import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -1248,6 +1250,9 @@ splitview = connect selectTranslator $ H.mkComponent
           H.modify_ _
             { tocEntries = finalTree
             }
+
+          liftEffect $ log $ prettyPrintMetaMap metaMap
+
           H.tell _toc unit (TOC.ReceiveTOCs finalTree metaMap)
 
       handleAction UpdateVersionMapping

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -33,6 +33,7 @@ import FPO.Data.Store as Store
 import FPO.Data.Time (defaultFormatter, timeStampsVersions)
 import FPO.Dto.DocumentDto.DocumentHeader (DocumentID)
 import FPO.Dto.DocumentDto.DocumentTree as DT
+import FPO.Dto.DocumentDto.MetaTree (emptyMetaMap)
 import FPO.Dto.DocumentDto.MetaTree as MM
 import FPO.Dto.DocumentDto.TreeDto
   ( Edge(..)
@@ -617,7 +618,7 @@ splitview = connect selectTranslator $ H.mkComponent
       H.tell _comment unit (Comment.ReceiveTimeFormatter timeFormatter)
       H.tell _commentOverview unit
         (CommentOverview.ReceiveTimeFormatter timeFormatter)
-      H.tell _toc unit (TOC.ReceiveTOCs Empty)
+      H.tell _toc unit (TOC.ReceiveTOCs Empty emptyMetaMap)
       -- Load the initial TOC entries into the editor
       -- TODO: Shoult use Get instead, but I (Eddy) don't understand GET
       -- or rather, we don't use commit anymore in the API
@@ -665,7 +666,7 @@ splitview = connect selectTranslator $ H.mkComponent
         ("/docs/" <> show s.docID <> "/tree/latest")
       case maybeTree of
         Left err -> updateStore $ Store.AddError err
-        Right (MM.DocumentTreeWithMetaMap { tree {-, metaMap -} }) -> do
+        Right (MM.DocumentTreeWithMetaMap { tree, metaMap }) -> do
           let
             finalTree = documentTreeToTOCTree tree
             vMapping = map
@@ -678,7 +679,7 @@ splitview = connect selectTranslator $ H.mkComponent
             { tocEntries = finalTree
             , versionMapping = vMapping
             }
-          H.tell _toc unit (TOC.ReceiveTOCs finalTree)
+          H.tell _toc unit (TOC.ReceiveTOCs finalTree metaMap)
 
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
@@ -1241,17 +1242,15 @@ splitview = connect selectTranslator $ H.mkComponent
       --       the server.
       case maybeTree of
         Left err -> updateStore $ Store.AddError err
-        Right (MM.DocumentTreeWithMetaMap { tree {-, metaMap -} }) -> do
+        Right (MM.DocumentTreeWithMetaMap { tree, metaMap }) -> do
           let
             finalTree = documentTreeToTOCTree tree
           H.modify_ _
             { tocEntries = finalTree
             }
-          H.tell _toc unit (TOC.ReceiveTOCs finalTree)
+          H.tell _toc unit (TOC.ReceiveTOCs finalTree metaMap)
 
-      newTOCTree <- _.tocEntries <$> H.get
       handleAction UpdateVersionMapping
-      H.tell _toc unit (TOC.ReceiveTOCs newTOCTree)
 
 -- findCommentSection :: TOCTree -> Int -> Int -> Maybe CommentSection
 -- findCommentSection tocEntries tocID markerID = do

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -37,6 +37,7 @@ module FPO.Data.Request
   , postJson
   , postRenderHtml
   , postString
+  , postText
   , putIgnore
   , putJson
   , removeUser
@@ -80,6 +81,7 @@ import FPO.Dto.GroupDto
   , GroupOverview
   , toGroupOverview
   )
+import FPO.Dto.PostTextDto as PT
 import FPO.Dto.UserDto
   ( FullUserDto
   , UserID
@@ -600,6 +602,18 @@ getUserDocuments userID = do
   case result of
     Left err -> pure $ Left err
     Right dq -> pure $ Right $ DQ.getDocuments dq
+
+postText
+  :: forall st act slots msg m
+   . MonadAff m
+  => MonadStore Store.Action Store.Store m
+  => Navigate m
+  => DH.DocumentID
+  -> PT.PostTextDto
+  -> H.HalogenM st act slots msg m (Either AppError PT.PostTextDto)
+postText docID pt = postJson PT.decodePostTextDto
+  ("/docs/" <> show docID <> "/text")
+  (PT.encodePostTextDto pt)
 
 addGroup
   :: forall st act slots msg m

--- a/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
@@ -5,12 +5,14 @@ import Prelude
 
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError(..), decodeJson, (.:))
-import Data.Array (intercalate, length, mapWithIndex, (..))
+import Data.Array (find, intercalate, length, mapWithIndex, (..))
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
+import Data.Maybe (Maybe)
 import Data.Show.Generic (genericShow)
 import Data.String (joinWith)
 import Data.Tuple (Tuple(..))
+import FPO.Dto.Document.TreeDto (TreeHeader)
 import FPO.Dto.DocumentDto.TreeDto (RootTree)
 
 -- | Specifies the kind; e.g., "document", "section", "appendix-section", ...
@@ -131,6 +133,19 @@ instance DecodeJson FullTypeName where
 
 -- | Type alias for the complete meta map
 type MetaMap = Array (Tuple FullTypeName ProperTypeMeta)
+
+-- | An empty meta map.
+emptyMetaMap :: MetaMap
+emptyMetaMap = []
+
+-- | Lookup a `ProperTypeMeta` in the `MetaMap` using a `TreeHeader`.
+lookupWithHeader :: TreeHeader -> MetaMap -> Maybe ProperTypeMeta
+lookupWithHeader header metaMap = do
+  let kind = header.headerKind
+  let type_ = header.headerType
+  let fullTypeName = FullTypeName { kindName: kind, typeName: type_ }
+  Tuple _ properTypeMeta <- find (\(Tuple name _) -> name == fullTypeName) metaMap
+  pure properTypeMeta
 
 -- | Helper function to decode the entire meta map
 decodeMetaMap :: Json -> Either JsonDecodeError MetaMap

--- a/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
@@ -12,13 +12,11 @@ import Data.Array
   , intercalate
   , length
   , mapWithIndex
-  , (!!)
   , (..)
-  , (:)
   )
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
-import Data.Maybe (Maybe(..), fromJust, fromMaybe)
+import Data.Maybe (Maybe, fromMaybe)
 import Data.Show.Generic (genericShow)
 import Data.String (joinWith)
 import Data.Tuple (Tuple(..))
@@ -214,13 +212,12 @@ getMandatoryChildren propertyTypeMeta metaMap = case getTreeSyntax propertyTypeM
   TreeSyntax _ co -> case co of
     StarOrder _ -> []
     SequenceOrder disjunctions ->
-      catMaybes $ map (findMandatoryInDisjunction metaMap) disjunctions
+      catMaybes $ map findMandatoryInDisjunction disjunctions
   where
   findMandatoryInDisjunction
-    :: MetaMap
-    -> Disjunction FullTypeName
+    :: Disjunction FullTypeName
     -> Maybe (Tuple FullTypeName ProperTypeMeta)
-  findMandatoryInDisjunction metaMap (Disjunction arr) = do
+  findMandatoryInDisjunction (Disjunction arr) = do
     head arr >>= flip findDefinition metaMap
 
 -- | Helper function to decode the entire meta map

--- a/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/MetaMap.purs
@@ -5,15 +5,14 @@ import Prelude
 
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError(..), decodeJson, (.:))
-import Data.Array (find, intercalate, length, mapWithIndex, (..))
+import Data.Array (catMaybes, find, intercalate, length, mapWithIndex, (..))
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe, fromMaybe)
 import Data.Show.Generic (genericShow)
 import Data.String (joinWith)
 import Data.Tuple (Tuple(..))
-import FPO.Dto.Document.TreeDto (TreeHeader)
-import FPO.Dto.DocumentDto.TreeDto (RootTree)
+import FPO.Dto.DocumentDto.TreeDto (RootTree, TreeHeader(..))
 
 -- | Specifies the kind; e.g., "document", "section", "appendix-section", ...
 type KindName = String
@@ -21,6 +20,12 @@ type KindName = String
 type TypeName = String
 
 newtype FullTypeName = FullTypeName { kindName :: KindName, typeName :: TypeName }
+
+getKindName :: FullTypeName -> KindName
+getKindName (FullTypeName { kindName: kind }) = kind
+
+getTypeName :: FullTypeName -> TypeName
+getTypeName (FullTypeName { typeName: type_ }) = type_
 
 newtype DisplayTypeName = DisplayTypeName String
 
@@ -32,6 +37,17 @@ instance DecodeJson DisplayTypeName where
   decodeJson json = DisplayTypeName <$> decodeJson json
 
 data ProperTypeMeta = ProperTypeMeta DisplayTypeName (TreeSyntax FullTypeName)
+
+isLeaf :: ProperTypeMeta -> Boolean
+isLeaf (ProperTypeMeta _ syntax) = case syntax of
+  LeafSyntax -> true
+  TreeSyntax _ _ -> false
+
+getDisplayNameAsString :: ProperTypeMeta -> String
+getDisplayNameAsString (ProperTypeMeta (DisplayTypeName name) _) = name
+
+getTreeSyntax :: ProperTypeMeta -> TreeSyntax FullTypeName
+getTreeSyntax (ProperTypeMeta _ syntax) = syntax
 
 derive instance Generic ProperTypeMeta _
 instance Show ProperTypeMeta where
@@ -49,6 +65,9 @@ instance DecodeJson ProperTypeMeta where
         "Expected array with exactly 2 elements for ProperTypeMeta"
 
 newtype HasEditableHeader = HasEditableHeader Boolean
+
+isEditable :: HasEditableHeader -> Boolean
+isEditable (HasEditableHeader b) = b
 
 derive instance Generic HasEditableHeader _
 derive newtype instance Show HasEditableHeader
@@ -108,6 +127,12 @@ instance DecodeJson a => DecodeJson (ChildrenOrder a) where
 
 newtype Disjunction a = Disjunction (Array a)
 
+getAllowedItems :: ∀ a. Disjunction a -> Array a
+getAllowedItems (Disjunction arr) = arr
+
+instance Functor Disjunction where
+  map f (Disjunction arr) = Disjunction (map f arr)
+
 derive instance Generic (Disjunction a) _
 derive newtype instance Show a => Show (Disjunction a)
 derive newtype instance Eq a => Eq (Disjunction a)
@@ -140,12 +165,36 @@ emptyMetaMap = []
 
 -- | Lookup a `ProperTypeMeta` in the `MetaMap` using a `TreeHeader`.
 lookupWithHeader :: TreeHeader -> MetaMap -> Maybe ProperTypeMeta
-lookupWithHeader header metaMap = do
+lookupWithHeader (TreeHeader header) metaMap = do
   let kind = header.headerKind
   let type_ = header.headerType
   let fullTypeName = FullTypeName { kindName: kind, typeName: type_ }
+  lookupWithFullTypeName fullTypeName metaMap
+
+-- | Lookup a `ProperTypeMeta` in the `MetaMap` using a `FullTypeName`.
+lookupWithFullTypeName :: FullTypeName -> MetaMap -> Maybe ProperTypeMeta
+lookupWithFullTypeName fullTypeName metaMap = do
   Tuple _ properTypeMeta <- find (\(Tuple name _) -> name == fullTypeName) metaMap
   pure properTypeMeta
+
+findDefinition :: FullTypeName -> MetaMap -> Maybe (Tuple FullTypeName ProperTypeMeta)
+findDefinition fullTypeName metaMap =
+  find (\(Tuple name _) -> name == fullTypeName) metaMap
+
+-- | For a given `TreeHeader`, find all allowed child types based on the `MetaMap`.
+-- | Returns an array of tuples containing the `FullTypeName` and corresponding `ProperTypeMeta`.
+findAllowedChildren
+  :: TreeHeader -> MetaMap -> Array (Tuple FullTypeName ProperTypeMeta)
+findAllowedChildren header metaMap = fromMaybe [] $ do
+  propertyTypeMeta <- lookupWithHeader header metaMap
+  let treeSyntax = getTreeSyntax propertyTypeMeta
+  case treeSyntax of
+    LeafSyntax -> pure []
+    TreeSyntax _ co -> case co of
+      StarOrder d ->
+        pure $ catMaybes $ map (flip findDefinition metaMap) $
+          getAllowedItems d
+      SequenceOrder _ -> pure []
 
 -- | Helper function to decode the entire meta map
 decodeMetaMap :: Json -> Either JsonDecodeError MetaMap

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -17,6 +17,7 @@ module FPO.Dto.DocumentDto.TreeDto
   , getShortTitle
   , modifyNodeRootTree
   , replaceNodeRootTree
+  , unspecifiedMeta
   ) where
 
 import Prelude
@@ -66,6 +67,9 @@ getContentOr b = fromMaybe b <<< getContent
 
 errorMeta :: Meta
 errorMeta = Meta { label: Nothing, title: Error $ Just "(error)" }
+
+unspecifiedMeta :: Meta
+unspecifiedMeta = Meta { label: Nothing, title: Error $ Just "(unspecified)" }
 
 -- | Returns the full title of the node, including the label if it exists.
 -- | Removes HTML tags.


### PR DESCRIPTION
Connects the meta map to TOC.

We can now add leaf nodes according to the meta map rules. Non-leaf nodes are implemented, but do not work properly (yet).

Exactly the kinds of (sub)sections one can add to some inner node are now present in the list that expands then pressing the "+" button. For entities that do not allow any (more) children, the "+"-button is not shown.

See #625