### PR TITLE
Allow only valid drag-and-drop ops

### DIFF
--- a/frontend/src/FPO/Util.purs
+++ b/frontend/src/FPO/Util.purs
@@ -20,6 +20,8 @@ isPrefixOf :: forall a. Eq a => Array a -> Array a -> Boolean
 isPrefixOf prefix arr =
   take (length prefix) arr == prefix
 
+-- | Checks if the first array is a proper prefix of the second array,
+-- | that is, the first array is non-empty and not equal to the second array.
 isRealPrefixOf :: forall a. Eq a => Array a -> Array a -> Boolean
 isRealPrefixOf prefix arr =
   let


### PR DESCRIPTION
This pull request enhances the drag-and-drop functionality in the Table of Contents (TOC) component by making drag operations type-aware and more robust. It introduces type checks during drag-and-drop, refines how draggable areas and drop zones are managed, and improves code clarity and safety regarding allowed children and tree structure. Additionally, several utility functions and comments have been added to clarify intent and prevent potential issues.

**Drag-and-drop improvements:**

* The `dragState` now tracks the type (`Disjunction MM.FullTypeName`) of the dragged item, not just its path, allowing for type-aware drag-and-drop operations. The `Action` type and related event handlers (`StartDrag`, `HighlightDropZone`) were updated accordingly. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL163-R164) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL202-R210) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL561-R586)
* Drop zones now only accept items if their type matches the allowed `Disjunction` for that section, using the new `isAtLeastAsGeneral` function to check compatibility. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL561-R586) [[2]](diffhunk://#diff-bc14511e6a574980a58a43b4844a0ae55a194f8b543d2c11f8980eaa5b9d0b17R155-R161)
* The `addEndDropZone` function now requires and uses the allowed `Disjunction` for its parent, ensuring only valid drops are permitted. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL925-R957) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL1096-R1146) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL1108-R1157)

**MetaMap and type utilities:**

* Added `getDisjunction` to retrieve the allowed `Disjunction` for a given type with `StarOrder` syntax, and improved documentation for MetaMap helpers.
* Improved imports and type annotations for clarity and correctness, including explicit handling of `Maybe` and array utilities. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL34-R34) [[2]](diffhunk://#diff-bc14511e6a574980a58a43b4844a0ae55a194f8b543d2c11f8980eaa5b9d0b17L18-R19) [[3]](diffhunk://#diff-bc14511e6a574980a58a43b4844a0ae55a194f8b543d2c11f8980eaa5b9d0b17L29-R30)

**UI and code clarity:**

* Drag handles and draggable properties are now only shown when the parent section allows for child reordering or insertion, based on the allowed `Disjunction`. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR1029-R1054) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL886-R911) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL956-R987)
* Added comments and a TODO regarding potential infinite recursion in node creation due to malformed meta maps, highlighting the need for cycle detection.

These changes make the TOC's drag-and-drop experience more reliable, type-safe, and maintainable, while clarifying the underlying logic for future development.

See #625