### PR TITLE
WIP: Allow renaming in frontend

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -259,6 +259,10 @@ data Query a
   -- | receive the selected TOC and put its content into the editor
   | ChangeSection TOCEntry (Maybe Int) (Maybe String) a
   | ContinueChangeSection (Array FirstComment) a
+  -- | Open and edit a raw string outside the TOCEntry structure.
+  --   This is used to make the editor available for editing
+  --   the section names (headings) of non-leaf nodes.
+  | ChangeToNode String Path a
   -- | Update the position of a node in the editor, if existing.
   | UpdateNodePosition Path a
   | UpdateComment CommentSection a
@@ -435,13 +439,13 @@ editor = connect selectTranslator $ H.mkComponent
                           true ->
                             (translate (label :: _ "editor_merge") state.translator)
                     , makeEditorToolbarButtonWithText
-                        true
+                        fullFeatures
                         state.showButtonText
                         (Render RenderHTML)
                         "bi-file-richtext"
                         (translate (label :: _ "editor_preview") state.translator)
                     , makeEditorToolbarButtonWithText
-                        true
+                        fullFeatures
                         state.showButtonText
                         (Render RenderPDF)
                         "bi-filetype-pdf"
@@ -811,7 +815,14 @@ editor = connect selectTranslator $ H.mkComponent
             contentLines = intercalate "\n" (fromMaybe [] allLines)
 
           case state.mTocEntry of
-            Nothing -> pure unit
+            Nothing -> do
+              -- No leaf entity was selected, so if a nodePath is set,
+              -- we can emit an event to rename the node.
+              case state.mNodePath of
+                Nothing -> do
+                  pure unit -- Nothing to do
+                Just path -> do
+                  H.raise $ RenamedNode contentLines path
             Just entry ->
               case state.mContent of
                 Nothing -> pure unit
@@ -934,7 +945,7 @@ editor = connect selectTranslator $ H.mkComponent
 
           -- mDirtyRef := false
           for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
-          --update title 
+          --update title
           H.raise RequestFullTitle
           pure unit
 
@@ -1565,11 +1576,35 @@ editor = connect selectTranslator $ H.mkComponent
       handleAction (ContinueChangeToSection fCs)
       pure (Just a)
 
+    ChangeToNode title path a -> do
+      -- Change the editor to a raw string outside the TOCEntry structure.
+      H.modify_ _ { mTocEntry = Nothing, mNodePath = Just path }
+      state <- H.get
+      H.gets _.mEditor >>= traverse_ \ed -> do
+        -- Set the content of the editor
+        H.liftEffect $ do
+          session <- Editor.getSession ed
+          document <- Session.getDocument session
+          Document.setValue title document
+          Editor.setReadOnly false ed
+
+          -- Reset Undo history
+          undoMgr <- Session.getUndoManager session
+          UndoMgr.reset undoMgr
+
+          -- Clear annotations
+          Session.clearAnnotations session
+
+      -- reset Ref, because loading new content is considered
+      -- changing the existing content, which would set the flag
+      for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
+      pure (Just a)
+
     UpdateNodePosition path a -> do
-      H.modify_ \state ->
-        case state.mNodePath of
-          Just _ -> state { mNodePath = Just path }
-          Nothing -> state
+      H.modify_ \s ->
+        case s.mNodePath of
+          Just _ -> s { mNodePath = Just path }
+          Nothing -> s
       pure (Just a)
 
     SaveSection a -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1601,27 +1601,27 @@ changeNodeHeading path newName (RootTree { children, header }) =
       children
   in
     RootTree { children: newChildren, header }
-  where
-  changeNodeHeading' :: Path -> String -> Tree TOCEntry -> Tree TOCEntry
-  changeNodeHeading' path newName tree = case path of
-    [] -> case tree of
-      Node r -> Node r { header = updateHeading newName r.header }
-      leaf -> leaf
-    _ -> case tree of
-      Node { meta, children, header } ->
-        case uncons path of
-          Just { head: index, tail } ->
-            let
-              newChildren = mapWithIndex
-                ( \ix (Edge child) ->
-                    if ix == index then Edge $ changeNodeHeading' tail newName child
-                    else Edge child
-                )
-                children
-            in
-              Node { meta, children: newChildren, header }
-          Nothing -> Node { meta, children, header }
-      leaf -> leaf
+
+changeNodeHeading' :: Path -> String -> Tree TOCEntry -> Tree TOCEntry
+changeNodeHeading' path newName tree = case path of
+  [] -> case tree of
+    Node r -> Node r { header = updateHeading newName r.header }
+    leaf -> leaf
+  _ -> case tree of
+    Node { meta, children, header } ->
+      case uncons path of
+        Just { head: index, tail } ->
+          let
+            newChildren = mapWithIndex
+              ( \ix (Edge child) ->
+                  if ix == index then Edge $ changeNodeHeading' tail newName child
+                  else Edge child
+              )
+              children
+          in
+            Node { meta, children: newChildren, header }
+        Nothing -> Node { meta, children, header }
+    leaf -> leaf
 
 stripHtmlTags :: String -> String
 stripHtmlTags input =

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -67,7 +67,6 @@ import FPO.Types
   , tocTreeToDocumentTree
   )
 import FPO.UI.Modals.DirtyVersionModal (dirtyVersionModal)
-import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -28,7 +28,6 @@ import Data.String.Regex as Regex
 import Data.String.Regex.Flags as RegexFlags
 import Effect.Aff (Milliseconds(..), delay)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import FPO.Components.Comment as Comment
 import FPO.Components.CommentOverview as CommentOverview
@@ -1077,7 +1076,6 @@ splitview = connect selectTranslator $ H.mkComponent
 
       Editor.RenamedNode newName path -> do
         s <- H.get
-        liftEffect $ log $ "Renaming node at path " <> show path <> " to " <> newName
         updateTree $ changeNodeHeading path newName s.tocEntries
 
       Editor.ShowAllCommentsOutput docID tocID -> do

--- a/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
+++ b/frontend/src/FPO/Dto/DocumentDto/TreeDto.purs
@@ -14,10 +14,12 @@ module FPO.Dto.DocumentDto.TreeDto
   , getContentOr
   , getEdgeTree
   , getFullTitle
+  , getHeading
   , getShortTitle
   , modifyNodeRootTree
   , replaceNodeRootTree
   , unspecifiedMeta
+  , updateHeading
   ) where
 
 import Prelude
@@ -39,6 +41,14 @@ newtype TreeHeader = TreeHeader
   , heading :: String
   }
 
+-- | Updates the heading of a `TreeHeader`.
+updateHeading :: String -> TreeHeader -> TreeHeader
+updateHeading newHeading (TreeHeader header) =
+  TreeHeader $ header { heading = newHeading }
+
+getHeading :: TreeHeader -> String
+getHeading (TreeHeader header) = header.heading
+
 -- | Metadata for a tree node. `title` is a html-escaped string that represents
 -- | the title of the node. `label` is an optional html-escaped string that
 -- | represents the label of the node (e.g. "§x", etc.).
@@ -50,6 +60,8 @@ newtype TreeHeader = TreeHeader
 -- |       rendering (using, e.g., `getFullTitle`). This isn't a perfect solution,
 -- |       but easier than other approaches. We could use `FPO.UI.HTML.rawHtml`, but
 -- |       this would not work for tooltips...
+-- |       TODO: This workaround causes a bug where some special characters are not rendered
+-- |             correctly, see issue #656.
 newtype Meta = Meta
   { label :: Maybe String
   , title :: Result (Maybe String)


### PR DESCRIPTION
This pull request introduces a new feature that allows users to rename section headings (non-leaf nodes) in the editor, for nodes that have an editable header. 

See #625 