### PR TITLE
Show conflict error on duplicate group name in frontend

### DIFF
--- a/backend/src/Server/Handlers/GroupHandlers.hs
+++ b/backend/src/Server/Handlers/GroupHandlers.hs
@@ -60,7 +60,7 @@ createGroupHandler (Authenticated token@Auth.Token {..}) (Group.GroupCreate {..}
             liftIO $ Session.run (Sessions.checkGroupNameExistence groupCreateName) conn
         case eBool of
             Left _ -> throwError errDatabaseAccessFailed
-            Right True -> throwError $ err409 {errBody = "A group with that name exists already."}
+            Right True -> throwError $ err409 {errBody = "\"A group with that name exists already.\""}
             Right False -> do
                 eGroupID <-
                     liftIO $

--- a/frontend/src/FPO/Data/AppError.purs
+++ b/frontend/src/FPO/Data/AppError.purs
@@ -17,6 +17,7 @@ data AppError
   | DataError String
   | AccessDeniedError
   | MethodNotAllowedError String String
+  | ConflictError String
 
 type ErrorId = Int
 type AppErrorWithId = { errorId :: ErrorId, error :: AppError }
@@ -34,6 +35,7 @@ instance Show AppError where
       <> " (method: "
       <> method
       <> ")"
+    ConflictError _ -> "ConflictError"
 
 -- | Prints an error message based on the type of error.
 -- | The error message is prefixed with the provided string.
@@ -64,3 +66,8 @@ showToastError err translator = case err of
       <> " (method: "
       <> method
       <> ")"
+  ConflictError url -> (translate (label :: _ "error_conflictError") translator) <>
+    ( if url == "/groups" then
+        ((": ") <> (translate (label :: _ "error_conflictError_groups") translator))
+      else ""
+    )

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -180,6 +180,9 @@ handleRequest' url requestAction = do
         StatusCode 405 -> do
           handleAppError (MethodNotAllowedError url "Unknown")
           pure $ Left $ MethodNotAllowedError url "Unknown"
+        StatusCode 409 -> do
+          handleAppError (ConflictError url)
+          pure $ Left $ ConflictError url
         StatusCode code | code >= 500 && code < 600 -> do
           handleAppError (ServerError $ "Server error (status: " <> show code <> ")")
           pure $ Left $ ServerError $ "Server error (status: " <> show code <> ")"
@@ -213,6 +216,7 @@ handleAppError err = do
       DataError _ -> pure unit -- Let component handle this
       AccessDeniedError -> pure unit -- Let component handle this
       MethodNotAllowedError _ _ -> pure unit -- Let component handle this
+      ConflictError _ -> pure unit -- Let component handle this
 
 -- | Wrapper specifically for JSON responses with decode step
 handleJsonRequest'

--- a/frontend/src/FPO/Translations/Errors.purs
+++ b/frontend/src/FPO/Translations/Errors.purs
@@ -9,6 +9,8 @@ import Simple.I18n.Translation (Translation, fromRecord)
 type ErrorLabels =
   ( "error_accessDeniedError"
       ::: "error_authError"
+      ::: "error_conflictError"
+      ::: "error_conflictError_groups"
       ::: "error_connectionFailed"
       ::: "error_dataError"
       ::: "error_invalidCredentials"
@@ -24,6 +26,8 @@ enErrors :: Translation ErrorLabels
 enErrors = fromRecord
   { error_accessDeniedError: "Access denied"
   , error_authError: "Authentication error: "
+  , error_conflictError: "Conflict error"
+  , error_conflictError_groups: "A group with this name already exists"
   , error_connectionFailed: "Connection failed"
   , error_dataError: "Data error: "
   , error_methodNotAllowedError: "Method not allowed: "
@@ -38,6 +42,8 @@ deErrors :: Translation ErrorLabels
 deErrors = fromRecord
   { error_accessDeniedError: "Zugriff verweigert"
   , error_authError: "Authentifizierungsfehler: "
+  , error_conflictError: "Konfliktfehler"
+  , error_conflictError_groups: "Eine Gruppe mit diesem Namen existiert bereits"
   , error_connectionFailed: "Verbindungsfehler"
   , error_dataError: "Datenfehler: "
   , error_methodNotAllowedError: "Methode nicht erlaubt: "

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -186,6 +186,8 @@ type Labels =
       -- | Errors 
       ::: "error_accessDeniedError"
       ::: "error_authError"
+      ::: "error_conflictError"
+      ::: "error_conflictError_groups"
       ::: "error_connectionFailed"
       ::: "error_dataError"
       ::: "error_invalidCredentials"


### PR DESCRIPTION
Closes #649 

This pull request introduces improved handling of conflict errors (HTTP 409) when creating groups, ensuring that users receive clear and localized feedback if a group name already exists. The changes span both backend and frontend, adding a new error type, updating error handling logic, and providing translations for the new error messages.

**Backend: Conflict Detection**

- Improved the error message for group name conflicts by wrapping it in quotes for consistency and clarity.

**Frontend: Error Handling and Display**

- Added a new `ConflictError` type to `AppError`, updated error handling to recognize HTTP 409 responses as conflict errors, and ensured that these errors are handled gracefully in the UI logic. [[1]](diffhunk://#diff-1ec6931e4fa7e5df5bbab733eeb00a3da6729d14a77b76e71e8405af34689e58R20) [[2]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R183-R185) [[3]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4R219)
- Updated the error display logic to show a specific, localized message when a conflict occurs during group creation, using the new translation keys.

**Frontend: Internationalization**

- Added new translation keys and messages for conflict errors in both English and German, ensuring users receive appropriate feedback in their language. [[1]](diffhunk://#diff-3db53bc67253ff62fb271b95c5b405a81f0691ad62d5a4a3f69921a16e8de8e5R12-R13) [[2]](diffhunk://#diff-3db53bc67253ff62fb271b95c5b405a81f0691ad62d5a4a3f69921a16e8de8e5R29-R30) [[3]](diffhunk://#diff-3db53bc67253ff62fb271b95c5b405a81f0691ad62d5a4a3f69921a16e8de8e5R45-R46) [[4]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR189-R190)