### PR TITLE
701 triple error toasts

### DIFF
--- a/frontend/spago.lock
+++ b/frontend/spago.lock
@@ -31,6 +31,7 @@
             "maybe",
             "newtype",
             "now",
+            "ordered-collections",
             "parsing",
             "partial",
             "prelude",

--- a/frontend/spago.yaml
+++ b/frontend/spago.yaml
@@ -27,6 +27,7 @@ package:
     - maybe
     - newtype
     - now
+    - ordered-collections
     - parsing
     - partial
     - prelude

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -117,7 +117,7 @@ import Web.Event.EventTarget
 import Web.HTML (window)
 import Web.HTML.HTMLElement (offsetWidth, toElement)
 import Web.HTML.Window as Win
-import Web.ResizeObserver as RO
+import Web.ResizeObserver (ResizeObserver, disconnect, observe, resizeObserver)
 import Web.UIEvent.KeyboardEvent.EventTypes (keydown)
 import Web.UIEvent.MouseEvent as ME
 
@@ -175,7 +175,7 @@ type State = FPOState
   , commentState :: CommentState
   , fontSize :: Int
   , mListener :: Maybe (HS.Listener Action)
-  , resizeObserver :: Maybe RO.ResizeObserver
+  , mResizeObserver :: Maybe ResizeObserver
   , mResizeSubscriptionId :: Maybe SubscriptionId
   , showButtonText :: Boolean
   , showButtons :: Boolean
@@ -672,9 +672,9 @@ editor = connect selectTranslator $ H.mkComponent
             width <- offsetWidth element
             HS.notify listener (HandleResize width)
 
-        observer <- H.liftEffect $ RO.resizeObserver callback
-        H.liftEffect $ RO.observe (toElement element) {} observer
-        H.modify_ _ { resizeObserver = Just observer }
+        observer <- H.liftEffect $ resizeObserver callback
+        H.liftEffect $ observe (toElement element) {} observer
+        H.modify_ _ { mResizeObserver = Just observer }
       compareTo <- H.gets _.compareToElement
       case compareTo of
         Nothing
@@ -1408,8 +1408,8 @@ editor = connect selectTranslator $ H.mkComponent
         tgt = Win.toEventTarget win
         beforeunload = EventType "beforeunload"
       -- Cleanup observer and subscription
-      H.liftEffect $ case state.resizeObserver of
-        Just obs -> RO.disconnect obs
+      H.liftEffect $ case state.mResizeObserver of
+        Just obs -> disconnect obs
         Nothing -> pure unit
       case state.mResizeSubscriptionId of
         Just subscription -> H.unsubscribe subscription
@@ -1888,7 +1888,7 @@ initialState { context, input } =
   , commentState: initialCommentState
   , fontSize: 12
   , mListener: Nothing
-  , resizeObserver: Nothing
+  , mResizeObserver: Nothing
   , mResizeSubscriptionId: Nothing
   , showButtonText: true
   , showButtons: true

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -1903,7 +1903,7 @@ makeEditorToolbarButtonWithText enabled asText action biName smallText = HH.butt
 
 addMouseDragListeners :: HTMLElement -> HS.Listener Action -> Effect Unit
 addMouseDragListeners container listener = do
-  downL <- H.liftEffect $ eventListener \ev -> do
+  downL <- eventListener \ev -> do
     case ME.fromEvent ev of
       Just mev -> do
         let
@@ -1913,7 +1913,7 @@ addMouseDragListeners container listener = do
         HS.notify listener (TryStartDrag x y)
       Nothing ->
         pure unit
-  H.liftEffect $ addEventListener (EventType "mousedown") downL true
+  addEventListener (EventType "mousedown") downL true
     (toEventTarget $ toElement container)
 
   moveL <- H.liftEffect $ eventListener \ev -> do
@@ -1924,7 +1924,7 @@ addMouseDragListeners container listener = do
           y = toNumber (ME.clientY mev)
         HS.notify listener (DragMove x y)
       Nothing -> pure unit
-  H.liftEffect $ addEventListener (EventType "mousemove") moveL true
+  addEventListener (EventType "mousemove") moveL true
     (toEventTarget $ toElement container)
 
   upL <- H.liftEffect $ eventListener \_ -> do
@@ -1932,7 +1932,7 @@ addMouseDragListeners container listener = do
     HS.notify listener SelectComment
     -- stop dragging the comment dragger
     HS.notify listener EndDrag
-  H.liftEffect $ addEventListener (EventType "mouseup") upL true
+  addEventListener (EventType "mouseup") upL true
     (toEventTarget $ toElement container)
 
 addBeforeUnloadListener

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -838,7 +838,7 @@ editor = connect selectTranslator $ H.mkComponent
       -- handle errors in pos and decodeJson
       case response of
         -- if error, try to Save again (Maybe ParentID is lost?)
-        Left err -> updateStore $ Store.AddError err
+        Left err -> Store.addError err
 
         -- extract and insert new parentID into newContent
         Right { content: updatedContent, typ: typ, html } -> do
@@ -1413,7 +1413,7 @@ editor = connect selectTranslator $ H.mkComponent
               )
 
         case loadedContent of
-          Left err -> updateStore $ Store.AddError err
+          Left err -> Store.addError err
           Right wrapper -> do
             let
               content = ContentDto.getWrapperContent wrapper

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -643,6 +643,13 @@ editor = connect selectTranslator $ H.mkComponent
         H.liftEffect $ observe (toElement el) {} observer
         H.modify_ _ { mResizeObserver = Just observer }
 
+      -- If a comparison element is loaded, also load the current content in the primary editor
+      compareTo <- H.gets _.compareToElement
+      case compareTo of
+        Nothing -> pure unit
+        Just { tocEntry: tocEntry, revID: revID } -> handleAction
+          (ChangeToSection tocEntry revID Nothing)
+
       -- New Ref for keeping track, if the content in editor has changed
       -- 1. since last save
       -- 2. since opening version

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -176,7 +176,7 @@ type State = FPOState
   , fontSize :: Int
   , mListener :: Maybe (HS.Listener Action)
   , resizeObserver :: Maybe RO.ResizeObserver
-  , resizeSubscription :: Maybe SubscriptionId
+  , mResizeSubscriptionId :: Maybe SubscriptionId
   , showButtonText :: Boolean
   , showButtons :: Boolean
   -- for autosave
@@ -597,9 +597,8 @@ editor = connect selectTranslator $ H.mkComponent
     Init -> do
       -- Do not load content, since no TOC has been selected yet
 
-      -- create subscription for later use
-      { emitter, listener } <- H.liftEffect HS.create
       -- Subscribe to resize events and store subscription for cleanup
+      { emitter, listener } <- H.liftEffect HS.create
       subscription <- H.subscribe emitter
       H.getHTMLElementRef (H.RefLabel "container") >>= traverse_ \el -> do
         editor_ <- H.liftEffect $ Ace.editNode el Ace.ace
@@ -607,7 +606,7 @@ editor = connect selectTranslator $ H.mkComponent
         H.modify_ _
           { mEditor = Just editor_
           , mListener = Just listener
-          , resizeSubscription = Just subscription
+          , mResizeSubscriptionId = Just subscription
           }
         fontSize <- H.gets _.fontSize
 
@@ -1412,7 +1411,7 @@ editor = connect selectTranslator $ H.mkComponent
       H.liftEffect $ case state.resizeObserver of
         Just obs -> RO.disconnect obs
         Nothing -> pure unit
-      case state.resizeSubscription of
+      case state.mResizeSubscriptionId of
         Just subscription -> H.unsubscribe subscription
         Nothing -> pure unit
       case state.saveState.mBeforeUnloadL of
@@ -1890,7 +1889,7 @@ initialState { context, input } =
   , fontSize: 12
   , mListener: Nothing
   , resizeObserver: Nothing
-  , resizeSubscription: Nothing
+  , mResizeSubscriptionId: Nothing
   , showButtonText: true
   , showButtons: true
   , saveState: initialSaveState

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -676,7 +676,7 @@ splitview = connect selectTranslator $ H.mkComponent
       maybeTree <- Request.getJson MM.decodeDocumentWithMetaMap
         ("/docs/" <> show s.docID <> "/tree/latest")
       case maybeTree of
-        Left err -> updateStore $ Store.AddError err
+        Left err -> Store.addError err
         Right (MM.DocumentTreeWithMetaMap { tree, metaMap }) -> do
           let
             finalTree = documentTreeToTOCTree tree
@@ -1292,7 +1292,7 @@ splitview = connect selectTranslator $ H.mkComponent
       --       or action to handle receiving a new tree and meta map from
       --       the server.
       case maybeTree of
-        Left err -> updateStore $ Store.AddError err
+        Left err -> Store.addError err
         Right (MM.DocumentTreeWithMetaMap { tree, metaMap }) -> do
           let
             finalTree = documentTreeToTOCTree tree

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -207,7 +207,7 @@ handleAppError
 handleAppError err = do
   s <- getStore
   when s.handleRequestError $ do
-    _ <- Store.addError err
+    Store.addError err
     case err of
       NetworkError _ -> pure unit -- Let component handle this
       AuthError _ -> navigate Login

--- a/frontend/src/FPO/Data/Request.purs
+++ b/frontend/src/FPO/Data/Request.purs
@@ -207,7 +207,7 @@ handleAppError
 handleAppError err = do
   s <- getStore
   when s.handleRequestError $ do
-    updateStore $ Store.AddError err
+    _ <- Store.addError err
     case err of
       NetworkError _ -> pure unit -- Let component handle this
       AuthError _ -> navigate Login

--- a/frontend/src/FPO/Data/Store.purs
+++ b/frontend/src/FPO/Data/Store.purs
@@ -5,6 +5,7 @@
 module FPO.Data.Store
   ( Action(..)
   , Store
+  , addError
   , loadLanguage
   , preventErrorHandlingLocally
   , reduce
@@ -13,9 +14,15 @@ module FPO.Data.Store
 
 import Prelude
 
-import Data.Maybe (Maybe)
+import Data.DateTime.Instant (Instant, unInstant)
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Time.Duration (Milliseconds(..))
 import Effect (Effect)
-import FPO.Data.AppError (AppError)
+import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Now (now)
+import FPO.Data.AppError (AppError(..))
 import FPO.Data.AppToast (AppToast(..), AppToastWithId)
 import FPO.Data.Route (Route)
 import FPO.Translations.Translator (FPOTranslator)
@@ -34,6 +41,8 @@ type Store =
   , toasts :: Array AppToastWithId
   , totalToasts :: Int
   , handleRequestError :: Boolean
+  , errorCooldowns ::
+      Map String Instant -- ^ Track when errors were last shown to prevent spam
   }
 
 data Action
@@ -43,6 +52,7 @@ data Action
   | SetLanguage String
   | SetTranslator FPOTranslator
   | AddError AppError
+  | AddErrorWithCooldown AppError Instant -- ^ Add error with timestamp for cooldown tracking
   | AddWarning String
   | AddSuccess String
   | AddInfo String
@@ -64,6 +74,36 @@ preventErrorHandlingLocally action = do
   result <- action
   updateStore $ SetHandleRequestError originalSetting
   pure result
+
+-- | Add an error with cooldown checking to prevent spam
+addError
+  :: forall m
+   . MonadStore Action Store m
+  => MonadEffect m
+  => AppError
+  -> m Unit
+addError error = do
+  currentTime <- liftEffect now
+  store <- getStore
+  if isErrorOnCooldown error currentTime store.errorCooldowns then pure unit
+  else updateStore $ AddErrorWithCooldown error currentTime
+
+-- | Check if an error is on cooldown (1 second for auth errors, 500ms for others)
+isErrorOnCooldown :: AppError -> Instant -> Map String Instant -> Boolean
+isErrorOnCooldown error currentTime cooldowns =
+  case Map.lookup (show error) cooldowns of
+    Nothing -> false
+    Just lastShown ->
+      let
+        cooldownMs = case error of
+          AuthError _ -> 1000.0 -- 1 second for auth errors
+          _ -> 500.0 -- 500ms for other errors
+        -- Simple time difference calculation in milliseconds
+        Milliseconds currentMs = unInstant currentTime
+        Milliseconds lastMs = unInstant lastShown
+        timeDiffMs = currentMs - lastMs
+      in
+        timeDiffMs < cooldownMs
 
 -- | Update the store based on the action.
 reduce :: Store -> Action -> Store
@@ -102,6 +142,13 @@ reduce store = case _ of
     { toasts = store.toasts <> [ { id: store.totalToasts + 1, toast: Error error } ]
     , totalToasts = store.totalToasts + 1
     }
+  AddErrorWithCooldown error currentTime ->
+    if isErrorOnCooldown error currentTime store.errorCooldowns then store -- Don't show toast if error is on cooldown
+    else store
+      { toasts = store.toasts <> [ { id: store.totalToasts + 1, toast: Error error } ]
+      , totalToasts = store.totalToasts + 1
+      , errorCooldowns = Map.insert (show error) currentTime store.errorCooldowns
+      }
   SetToasts toasts -> store { toasts = toasts }
   SetHandleRequestError b -> store { handleRequestError = b }
 

--- a/frontend/src/FPO/Data/Store.purs
+++ b/frontend/src/FPO/Data/Store.purs
@@ -143,8 +143,7 @@ reduce store = case _ of
     , totalToasts = store.totalToasts + 1
     }
   AddErrorWithCooldown error currentTime ->
-    if isErrorOnCooldown error currentTime store.errorCooldowns then store -- Don't show toast if error is on cooldown
-    else store
+    store
       { toasts = store.toasts <> [ { id: store.totalToasts + 1, toast: Error error } ]
       , totalToasts = store.totalToasts + 1
       , errorCooldowns = Map.insert (show error) currentTime store.errorCooldowns

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -9,6 +9,7 @@ module Main where
 
 import Data.Either (hush)
 import Data.Function (const)
+import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Effect (Effect)
 import Effect.Aff (launchAff_)
@@ -216,6 +217,7 @@ main = HA.runHalogenAff do
       , translator: FPOTranslator translator
       , language: defaultLang
       , toasts: []
+      , errorCooldowns: Map.empty
       , totalToasts: 0
       , handleRequestError: true
       } :: Store.Store

--- a/frontend/src/FPO/Main.purs
+++ b/frontend/src/FPO/Main.purs
@@ -204,9 +204,6 @@ component =
 main :: Effect Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
-  -- Load logged in user from the localstorage
-  -- response <- getString "/get-user" -- TODO wait for backend to support this
-  -- let user = handleInitialResponse response
   savedLang <- H.liftEffect loadLanguage
   browserLang <- H.liftEffect detectBrowserLanguage
   let defaultLang = fromMaybe browserLang savedLang :: String

--- a/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
+++ b/frontend/src/FPO/Page/Admin/Group/DocOverview.purs
@@ -484,7 +484,7 @@ component =
 
         createResponse <- createNewDocument dto
         case createResponse of
-          Left err -> updateStore $ Store.AddError $ DataError $
+          Left err -> Store.addError $ DataError $
             "Failed to create document: " <> show err
           Right h -> do
             H.modify_ _ { modalState = NoModal, newDocumentName = "" }

--- a/frontend/src/FPO/Page/Admin/Users.purs
+++ b/frontend/src/FPO/Page/Admin/Users.purs
@@ -181,7 +181,7 @@ component =
       response <- postString "/register" (encodeJson state.createUserDto) -- could be a postIgnore
       case response of
         Left err -> do
-          updateStore $ Store.AddError $ ServerError
+          Store.addError $ ServerError
             ( ( translate (label :: _ "admin_users_failedToCreateUser")
                   state.translator
               ) <> ": " <> (show err)

--- a/frontend/src/FPO/Page/Profile.purs
+++ b/frontend/src/FPO/Page/Profile.purs
@@ -684,4 +684,4 @@ handleAppError
   => AppError
   -> H.HalogenM State act slots msg m Unit
 handleAppError appError = do
-  updateStore $ Store.AddError appError
+  Store.addError appError

--- a/frontend/src/FPO/Page/ResetPassword.purs
+++ b/frontend/src/FPO/Page/ResetPassword.purs
@@ -257,7 +257,7 @@ component =
           )
         case response of
           Left _ -> pure unit
-          Right (Left msg) -> updateStore $ Store.AddError $ ServerError msg
+          Right (Left msg) -> Store.addError $ ServerError msg
           Right (Right _) -> do
             updateStore $ Store.AddSuccess $ translate
               (label :: _ "common_passwordUpdated")


### PR DESCRIPTION
Fixes #701 

This pull request introduces several improvements and refactorings to the frontend editor and store logic, with a focus on error handling, event listener management, and code clarity. The most significant changes are the addition of error cooldown logic to prevent error toast spam, refactoring of event listener setup and cleanup in the editor, and unification of error handling across components.

**Error handling improvements:**

* Added an `addError` function to `FPO.Data.Store` that tracks error toast cooldowns using timestamps, preventing repeated error notifications within a short time window. This includes new state (`errorCooldowns`) and logic for cooldown duration based on error type. [[1]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR8) [[2]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bL16-R25) [[3]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR44-R45) [[4]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR55) [[5]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR78-R107) [[6]](diffhunk://#diff-0238397e13f64a5fe55ea778ba462a046499c86fb0038aaa4322463341873d1bR145-R150) [[7]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2R12) [[8]](diffhunk://#diff-930d714883789837fb104ec3f1dcb56ac8d724301ecf1188622a0a88d4984ae2R220)
* Refactored all usages of `updateStore $ Store.AddError err` to use the new `Store.addError err` function in editor and splitview components, ensuring consistent error handling and cooldown application. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL898-R841) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1473-R1416) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL679-R679) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1295-R1295) [[5]](diffhunk://#diff-d7f03635c925b1828e4440fa40cd137d0ec28fe220c7bb29b69fc62f10ab3da4L210-R210)

**Editor event listener and state management:**

* Refactored the editor's resize observer and before-unload event listener setup and cleanup, renaming state fields for clarity (e.g., `resizeObserver` → `mResizeObserver`, `resizeSubscription` → `mResizeSubscriptionId`, `mBeforeUnloadL` → `mBeforeUnloadListener`). Added helper functions `addMouseDragListeners` and `addBeforeUnloadListener` to encapsulate event logic, improving readability and maintainability. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL156-R156) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL178-R179) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL612-R611) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL638-R670) [[5]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1419-R1368) [[6]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1880-R1823) [[7]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1901-R1845) [[8]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1903-R1966)

**Dependency and import updates:**

* Added the `ordered-collections` package to `spago.yaml` and updated imports in `Editor.purs` to reflect usage of new types and functions for event and observer handling. [[1]](diffhunk://#diff-0d2d8962d684e9e4c6458487765e39d1a7d278904a0a940089964439912ee397R30) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL117-R120)

These changes collectively improve error notification UX, make event handling in the editor more robust and maintainable, and lay groundwork for further frontend enhancements.Fixes #701 

This pull request refactors and improves the `Editor` component in several ways, focusing on code clarity, maintainability, and separation of concerns. Key changes include renaming state fields for consistency, extracting event listener logic into reusable helper functions, and improving resource cleanup. The changes also streamline the initialization and teardown logic for event listeners and observers.

**Refactoring and Code Organization:**

* Renamed several state fields for clarity and consistency, such as `resizeObserver` → `mResizeObserver`, `resizeSubscription` → `mResizeSubscriptionId`, and `mBeforeUnloadL` → `mBeforeUnloadListener` in both type definitions and initial state. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL156-R156) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL178-R179) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1412-R1361) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1871-R1814) [[5]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1892-R1836)
* Updated imports to use specific types from `Web.HTML` and `Web.ResizeObserver`, improving type clarity.

**Event Listener Management:**

* Extracted mouse drag event listener logic into a new helper function `addMouseDragListeners`, simplifying the main initialization code and improving reusability. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL636-R668) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1894-R1957)
* Moved the "beforeunload" event listener logic into a new helper function `addBeforeUnloadListener`, encapsulating the logic for preventing tab closure with unsaved changes. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL636-R668) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1894-R1957)

**Initialization and Cleanup Improvements:**

* Adjusted the order of initialization steps in the `Init` action handler, ensuring editor setup, resize observer, and event listeners are registered in a logical and maintainable sequence. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL598-R609) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL636-R668)
* Updated cleanup logic in the component's finalizer to use the new state field names and ensure all observers and event listeners are properly removed.

**Minor Cleanup:**

* Removed commented-out code from `frontend/src/FPO/Main.purs` for clarity.