### PR TITLE
resize after entering the merge mode

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -551,8 +551,7 @@ editor = connect selectTranslator $ H.mkComponent
       , HH.div -- Editor container
 
           [ HP.ref (H.RefLabel "container")
-          , HP.classes [ HB.flexGrow1 ]
-          , HP.style "min-height: 0; flex-grow: 1; flex-basis: 0"
+          , HP.style "flex:1 1 0; min-height:0; position:relative;"
           ]
           [ -- Add overlay when right side
             case state.compareToElement of
@@ -1569,6 +1568,8 @@ editor = connect selectTranslator $ H.mkComponent
 
     ReceiveUpToDateUpdate mVersion a -> do
       H.modify_ _ { upToDateVersion = mVersion }
+      -- there is a new container above the editor. Resize editor to be able to scroll all the way down
+      handleAction Resize
       pure (Just a)
 
     EditorResize a -> do

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -600,8 +600,9 @@ editor = connect selectTranslator $ H.mkComponent
       { emitter, listener } <- H.liftEffect HS.create
       -- Subscribe to resize events and store subscription for cleanup
       subscription <- H.subscribe emitter
-      let onSave :: Effect Unit
-          onSave = HS.notify listener (Save false)
+      let
+        onSave :: Effect Unit
+        onSave = HS.notify listener (Save false)
       H.getHTMLElementRef (H.RefLabel "container") >>= traverse_ \el -> do
         editor_ <- H.liftEffect $ Ace.editNode el Ace.ace
 

--- a/frontend/src/FPO/Components/Editor/Keybindings.purs
+++ b/frontend/src/FPO/Components/Editor/Keybindings.purs
@@ -43,8 +43,8 @@ underscore editor_ = do
     -- Otherwise, surround the selection with bold tags
     surroundSelection "<_" ">" editor_
 
-keyBinding :: Types.Editor -> Event -> Effect Unit
-keyBinding editor_ event = do
+keyBinding :: Effect Unit -> Types.Editor -> Event -> Effect Unit
+keyBinding onSave editor_ event = do
   let keyboardEvent = fromEvent event :: Maybe KeyboardEvent
   case keyboardEvent of
     Nothing -> pure unit
@@ -69,6 +69,9 @@ keyBinding editor_ event = do
             preventDefault event
             Editor.redo editor_
             Editor.focus editor_
+          "s" -> do
+            preventDefault event
+            onSave
           _ -> pure unit
       else pure unit
   pure unit

--- a/frontend/src/FPO/Translations/Components/Editor.purs
+++ b/frontend/src/FPO/Translations/Components/Editor.purs
@@ -9,6 +9,7 @@ import Simple.I18n.Translation (Translation, fromRecord)
 
 type EditorLabels =
   ( "editor_allComments"
+      ::: "editor_already_saved"
       ::: "editor_changeVersion"
       ::: "editor_comment"
       ::: "editor_compareVersion"
@@ -41,6 +42,7 @@ type EditorLabels =
 enEditor :: Translation EditorLabels
 enEditor = fromRecord
   { editor_allComments: "All comments"
+  , editor_already_saved: "Already Saved"
   , editor_changeVersion: "Change Version"
   , editor_confirmSwitch: "Switching Version"
   , editor_comment: "Comment"
@@ -94,6 +96,7 @@ enEditor = fromRecord
 deEditor :: Translation EditorLabels
 deEditor = fromRecord
   { editor_allComments: "Alle Kommentare"
+  , editor_already_saved: "Bereits gespeichert"
   , editor_changeVersion: "Version Wechseln"
   , editor_confirmSwitch: "Version Wechseln"
   , editor_comment: "Kommentar"

--- a/frontend/src/FPO/Translations/Labels.purs
+++ b/frontend/src/FPO/Translations/Labels.purs
@@ -157,6 +157,7 @@ type Labels =
 
       -- | Editor Page
       ::: "editor_allComments"
+      ::: "editor_already_saved"
       ::: "editor_changeVersion"
       ::: "editor_comment"
       ::: "editor_compareVersion"


### PR DESCRIPTION
This pull request introduces several improvements to the editor component, focusing on user experience enhancements for saving actions, keyboard shortcuts, and visual feedback. The main changes include adding a keyboard shortcut for saving, providing a notification when the user manually saves without changes, and refining the handling of save and resize actions. Translation keys and labels have also been updated to support the new notification.

**Editor UX and Save Functionality Improvements:**

* Added support for saving via keyboard shortcut (Ctrl+S or Cmd+S) by updating the `keyBinding` function to accept an `onSave` callback, which is triggered when the user presses "s" with the appropriate modifier keys. [[1]](diffhunk://#diff-9f37b616c41f39a48093f2df0d71782793fdd2a961100b02343d85b951224905L46-R47) [[2]](diffhunk://#diff-9f37b616c41f39a48093f2df0d71782793fdd2a961100b02343d85b951224905R72-R74) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR603-R605) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL616-R618)
* Implemented a visual notification when the user manually saves without any changes since the last save, providing immediate feedback that the content is already up to date. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL807-R809) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR862-R866)

**Editor State and Event Handling:**

* Changed the logic for manual section saves to use auto-save behavior, ensuring consistency in save actions.
* Improved editor resizing behavior by triggering a resize when a new container is added above the editor, ensuring proper scrolling and layout.
* Updated the editor container styling for better layout and responsiveness.

**Translations and Labels:**

* Added a new translation key and labels for the "Already Saved" notification in both English and German, updating the relevant translation files and type definitions. [[1]](diffhunk://#diff-d472d6ddde1d7dba017de9d3b1da9db02d9eccb5ff63df1e1fa201e18a25f11cR12) [[2]](diffhunk://#diff-d472d6ddde1d7dba017de9d3b1da9db02d9eccb5ff63df1e1fa201e18a25f11cR45) [[3]](diffhunk://#diff-d472d6ddde1d7dba017de9d3b1da9db02d9eccb5ff63df1e1fa201e18a25f11cR99) [[4]](diffhunk://#diff-7f5e0ef632ca90af84db5c21f87e4b781455cfcf131722ffa67a5e526fa39a0bR160)