### PR TITLE
Solve 3 UI tickets

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -1623,7 +1623,7 @@ editor = connect selectTranslator $ H.mkComponent
           Just _ -> s { mNodePath = Just path }
           Nothing -> s
       pure (Just a)
-    
+
     ReceiveFullTitle mTitle a -> do
       H.modify_ _ { mTitle = mTitle }
       pure (Just a)

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -764,7 +764,7 @@ editor = connect selectTranslator $ H.mkComponent
       H.gets _.mEditor >>= traverse_ \ed -> do
         state <- H.get
         let newSize = change state.fontSize
-        H.modify_ \st -> st { fontSize = newSize }
+        H.modify_ _ { fontSize = newSize }
         -- Set the new font size in the editor
         H.liftEffect $ do
           Editor.setFontSize (show newSize <> "px") ed
@@ -1744,7 +1744,7 @@ editor = connect selectTranslator $ H.mkComponent
                   lm
                   state.commentState.liveMarkers
               }
-          H.modify_ \st -> st
+          H.modify_ _
             { commentState = newCommentState }
         _, _ -> pure unit
       pure (Just a)

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -255,6 +255,7 @@ data Action
 -- We use a query to get the content of the editor
 data Query a
   = EditorResize a
+  | SetDirtyFlag a
   -- | save the current content and send it to splitview
   | SaveSection a
   -- | receive the selected TOC and put its content into the editor
@@ -1624,6 +1625,11 @@ editor = connect selectTranslator $ H.mkComponent
         case s.mNodePath of
           Just _ -> s { mNodePath = Just path }
           Nothing -> s
+      pure (Just a)
+
+    SetDirtyFlag a -> do
+      state <- H.get
+      for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write true r
       pure (Just a)
 
     SaveSection a -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -776,7 +776,7 @@ splitview = connect selectTranslator $ H.mkComponent
       previewShown <- H.gets _.previewShown
       previewRatio <- H.gets _.previewRatio
       -- close preview
-      if state.previewShown then do
+      if previewShown then do
         -- all this, in order for not overlapping the left resizer (to not make it disappear)
         win <- H.liftEffect Web.HTML.window
         totalWidth <- H.liftEffect $ Web.HTML.Window.innerWidth win

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -476,10 +476,10 @@ splitview = connect selectTranslator $ H.mkComponent
                   "%; box-sizing: border-box; min-height: 0; overflow: auto; min-width: 6ch; position: relative;"
           ]
           [ HH.div
-            [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]
-            , HP.style "padding-right: 0.5rem;"
-            ]
-            [ closeButton SwitchPreview ]
+              [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]
+              , HP.style "padding-right: 0.5rem;"
+              ]
+              [ closeButton SwitchPreview ]
           , HH.slot _preview unit Preview.preview
               { renderedHtml: state.renderedHtml
               , isDragging: state.mDragTarget /= Nothing
@@ -771,7 +771,6 @@ splitview = connect selectTranslator $ H.mkComponent
         Just _ -> H.modify_ _ { mSelectedTocEntry = Nothing }
         Nothing -> handleAction TogglePreview
 
-
     -- Toggle the preview area
     TogglePreview -> do
       state <- H.get
@@ -792,7 +791,7 @@ splitview = connect selectTranslator $ H.mkComponent
           , lastExpandedPreviewRatio = oldPreviewRatio
           , previewShown = false
           }
-        -- open preview
+      -- open preview
       else do
         -- restore the last expanded middle ratio, when toggling preview back on
         H.modify_ \st -> st

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1019,7 +1019,8 @@ splitview = connect selectTranslator $ H.mkComponent
               entry = case (findTOCEntry id state.tocEntries) of
                 Nothing -> emptyTOCEntry
                 Just e -> e
-            H.tell _editor 0 (Editor.ChangeSection entry Nothing Nothing)
+            mmTitle <- H.request _toc unit TOC.RequestFullTitle
+            H.tell _editor 0 (Editor.ChangeSection entry Nothing (join mmTitle))
           _ -> do
             pure unit
 
@@ -1089,15 +1090,10 @@ splitview = connect selectTranslator $ H.mkComponent
               (ModifyVersionMapping elementID (Just Nothing) (Just Nothing))
             case (findTOCEntry elementID state.tocEntries) of
               Nothing -> pure unit
-              Just entry -> H.tell _editor 0
-                (Editor.ChangeSection entry Nothing Nothing)
+              Just entry -> do
+                mmTitle <- H.request _toc unit TOC.RequestFullTitle
+                H.tell _editor 0 (Editor.ChangeSection entry Nothing (join mmTitle))
           _ -> pure unit
-
-      Editor.RequestFullTitle -> do
-        handleAction GET
-        mmTitle <- H.request _toc unit TOC.RequestFullTitle
-        H.tell _editor 0 (Editor.ReceiveFullTitle (join mmTitle))
-        H.tell _editor 1 (Editor.ReceiveFullTitle (join mmTitle))
 
     DeleteDraft -> do
       handleAction UpdateMSelectedTocEntry
@@ -1180,6 +1176,8 @@ splitview = connect selectTranslator $ H.mkComponent
         updateTree $ reorderTocEntries from to s.tocEntries
         H.tell _editor 0 Editor.SetDirtyFlag
         H.tell _editor 0 Editor.SaveSection
+        mmTitle <- H.request _toc unit TOC.RequestFullTitle
+        H.tell _editor 0 $ Editor.ReceiveFullTitle (join mmTitle)
 
       TOC.RenameNode _ -> do
         -- s <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1259,6 +1259,8 @@ splitview = connect selectTranslator $ H.mkComponent
       TOC.ReorderItems { from, to } -> do
         s <- H.get
         updateTree $ reorderTocEntries from to s.tocEntries
+        H.tell _editor 0 Editor.SetDirtyFlag
+        H.tell _editor 0 Editor.SaveSection
 
       TOC.RenameNode _ -> do
         -- s <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -623,8 +623,8 @@ splitview = connect selectTranslator $ H.mkComponent
     -- (Or until the browser detects the mouse is released)
     StartResize which mouse -> do
       case which of
-        ResizeLeft -> H.modify_ \st -> st { sidebarShown = true }
-        ResizeRight -> H.modify_ \st -> st { previewShown = true }
+        ResizeLeft -> H.modify_ _ { sidebarShown = true }
+        ResizeRight -> H.modify_ _ { previewShown = true }
       win <- H.liftEffect Web.HTML.window
       intWidth <- H.liftEffect $ Web.HTML.Window.innerWidth win
       let
@@ -641,7 +641,7 @@ splitview = connect selectTranslator $ H.mkComponent
 
     -- Stop resizing, when mouse is released (is detected by browser)
     StopResize _ -> do
-      H.modify_ \st -> st { mDragTarget = Nothing }
+      H.modify_ _ { mDragTarget = Nothing }
 
     -- While mouse is hold down, resizer move to position of mouse
     -- (with certain rules)
@@ -723,7 +723,7 @@ splitview = connect selectTranslator $ H.mkComponent
             state.tocEntries
       H.modify_ _ { versionMapping = newVersionMapping }
 
-    ToggleComment -> H.modify_ \st -> st { commentShown = false }
+    ToggleComment -> H.modify_ _ { commentShown = false }
 
     ToggleCommentOverview shown docID tocID -> do
       sidebarShown <- H.gets _.sidebarShown
@@ -739,15 +739,15 @@ splitview = connect selectTranslator $ H.mkComponent
             }
         H.tell _comment unit (Comment.Overview docID tocID)
       else
-        H.modify_ \st -> st { commentOverviewShown = false }
+        H.modify_ _ { commentOverviewShown = false }
 
     -- Toggle the sidebar
     -- Add logic in calculating the middle ratio
     -- to restore the last expanded middle ratio, when toggling preview back on
     ToggleSidebar -> do
-      state <- H.get
+      sidebarShown <- H.gets _.sidebarShown
       -- close sidebar
-      if state.sidebarShown then
+      if sidebarShown then
         H.modify_ \st -> st
           { sidebarRatio = 0.0
           , lastExpandedSidebarRatio = st.sidebarRatio
@@ -773,7 +773,8 @@ splitview = connect selectTranslator $ H.mkComponent
 
     -- Toggle the preview area
     TogglePreview -> do
-      state <- H.get
+      previewShown <- H.gets _.previewShown
+      previewRatio <- H.gets _.previewRatio
       -- close preview
       if state.previewShown then do
         -- all this, in order for not overlapping the left resizer (to not make it disappear)
@@ -785,8 +786,8 @@ splitview = connect selectTranslator $ H.mkComponent
           -- Also resizer size is not in sidebarRatio
           resizerWidth = 16.0
           resizerRatio = resizerWidth / w
-          oldPreviewRatio = state.previewRatio
-        H.modify_ \st -> st
+          oldPreviewRatio = previewRatio
+        H.modify_ _
           { previewRatio = resizerRatio
           , lastExpandedPreviewRatio = oldPreviewRatio
           , previewShown = false
@@ -804,8 +805,9 @@ splitview = connect selectTranslator $ H.mkComponent
       H.tell _editor 0 (Editor.EditorResize)
 
     ModifyVersionMapping tocID vID cData -> do
-      state <- H.get
-      when (not state.previewShown) $
+      previewShown <- H.gets _.previewShown
+      versionMapping <- H.gets _.versionMapping
+      when (not previewShown) $
         H.modify_ \st -> st
           { previewRatio = st.lastExpandedPreviewRatio
           , previewShown = true
@@ -827,7 +829,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 , comparisonData: newComparisonData v.comparisonData
                 }
             )
-            state.versionMapping
+            versionMapping
       H.modify_ _ { versionMapping = newVersionMapping }
 
     SetComparison elementID mVID -> do
@@ -852,7 +854,7 @@ splitview = connect selectTranslator $ H.mkComponent
     HandleComment output -> case output of
 
       Comment.CloseCommentSection -> do
-        H.modify_ \st -> st { commentShown = false }
+        H.modify_ _ { commentShown = false }
 
       -- behaviour for old versions still to discuss. for now will simply fail if old element version selected.
       Comment.UpdateComment newCommentSection -> do
@@ -871,7 +873,7 @@ splitview = connect selectTranslator $ H.mkComponent
 
       CommentOverview.JumpToCommentSection tocID markerID -> do
         docID <- H.gets _.docID
-        H.modify_ \st -> st { commentShown = true }
+        H.modify_ _ { commentShown = true }
         H.tell _comment unit
           (Comment.SelectedCommentSection docID tocID markerID)
         H.tell _editor 0 (Editor.SelectCommentSection markerID)
@@ -879,8 +881,8 @@ splitview = connect selectTranslator $ H.mkComponent
     HandleEditor output -> case output of
 
       Editor.AddComment docID tocID -> do
-        state <- H.get
-        if state.sidebarShown then
+        sidebarShown <- H.gets _.sidebarShown
+        if sidebarShown then
           H.modify_ _ { commentShown = true }
         else
           H.modify_ \st -> st
@@ -905,15 +907,15 @@ splitview = connect selectTranslator $ H.mkComponent
               Just _ -> pure unit -- Don't reset comparison data when in comparison mode
           _ -> pure unit
         if state.previewShown then do
-          H.modify_ \st -> st
+          H.modify_ _
             { mSelectedTocEntry = Nothing
             , renderedHtml = Just (Loaded html)
             }
         else do
-          H.modify_ \st -> st
+          H.modify_ _
             { mSelectedTocEntry = Nothing
             , renderedHtml = Just (Loaded html)
-            , previewRatio = st.lastExpandedPreviewRatio
+            , previewRatio = state.lastExpandedPreviewRatio
             , previewShown = true
             }
 
@@ -990,8 +992,8 @@ splitview = connect selectTranslator $ H.mkComponent
         if state.sidebarShown then
           H.modify_ _ { commentShown = true }
         else
-          H.modify_ \st -> st
-            { sidebarRatio = st.lastExpandedSidebarRatio
+          H.modify_ _
+            { sidebarRatio = state.lastExpandedSidebarRatio
             , sidebarShown = true
             , commentShown = true
             }

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -906,16 +906,15 @@ splitview = connect selectTranslator $ H.mkComponent
                 (ModifyVersionMapping tocID Nothing (Just Nothing))
               Just _ -> pure unit -- Don't reset comparison data when in comparison mode
           _ -> pure unit
-        if state.previewShown then do
-          H.modify_ _
-            { mSelectedTocEntry = Nothing
-            , renderedHtml = Just (Loaded html)
-            }
-        else do
-          H.modify_ _
-            { mSelectedTocEntry = Nothing
-            , renderedHtml = Just (Loaded html)
-            , previewRatio = state.lastExpandedPreviewRatio
+        -- Always set mSelectedTocEntry and renderedHtml
+        H.modify_ _
+          { mSelectedTocEntry = Nothing
+          , renderedHtml = Just (Loaded html)
+          }
+        -- Only update previewRatio and previewShown if preview is not already shown
+        unless state.previewShown do
+          H.modify_ \st -> st
+            { previewRatio = state.lastExpandedPreviewRatio
             , previewShown = true
             }
 

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -307,12 +307,7 @@ splitview = connect selectTranslator $ H.mkComponent
             <>
               -- Preview Section
               case state.mSelectedTocEntry of
-                Nothing
-                -> renderPreview state
-                Just (SelNode _ _)
-                -> renderPreview state
-                Just (SelLeaf tocID)
-                ->
+                Just (SelLeaf tocID) ->
                   let
                     versionEntry = fromMaybe
                       { elementID: -1, versionID: Nothing, comparisonData: Nothing }
@@ -321,6 +316,7 @@ splitview = connect selectTranslator $ H.mkComponent
                     case versionEntry.comparisonData of
                       Nothing -> renderPreview state
                       Just cData -> renderSecondEditor state (Just cData)
+                _ -> renderPreview state
         )
 
   -- Render both TOC and Comment but make them visable depending of the flags
@@ -358,23 +354,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 else
                   "display: none;"
         ]
-        [ HH.button
-            [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
-            , HP.style
-                "position: absolute; \
-                \top: 0.5rem; \
-                \right: 0.5rem; \
-                \background-color: #fdecea; \
-                \color: #b71c1c; \
-                \padding: 0.2rem 0.4rem; \
-                \font-size: 0.75rem; \
-                \line-height: 1; \
-                \border: 1px solid #f5c6cb; \
-                \border-radius: 0.2rem; \
-                \z-index: 10;"
-            , HE.onClick \_ -> ToggleComment
-            ]
-            [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
+        [ closeButton ToggleComment
         , HH.h4
             [ HP.style
                 "margin-top: 0.5rem; margin-bottom: 1rem; margin-left: 0.5rem; font-weight: bold; color: black;"
@@ -398,23 +378,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 else
                   "display: none;"
         ]
-        [ HH.button
-            [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
-            , HP.style
-                "position: absolute; \
-                \top: 0.5rem; \
-                \right: 0.5rem; \
-                \background-color: #fdecea; \
-                \color: #b71c1c; \
-                \padding: 0.2rem 0.4rem; \
-                \font-size: 0.75rem; \
-                \line-height: 1; \
-                \border: 1px solid #f5c6cb; \
-                \border-radius: 0.2rem; \
-                \z-index: 10;"
-            , HE.onClick \_ -> ToggleCommentOverview false (-1) (-1)
-            ]
-            [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
+        [ closeButton $ ToggleCommentOverview false (-1) (-1)
         , HH.h4
             [ HP.style
                 "margin-top: 0.5rem; margin-bottom: 1rem; margin-left: 0.5rem; font-weight: bold; color: black;"
@@ -496,31 +460,6 @@ splitview = connect selectTranslator $ H.mkComponent
           [ HH.text if state.previewShown then "⟩" else "⟨" ]
       ]
 
-  rightSwitchPreviewButton :: H.ComponentHTML Action Slots m
-  rightSwitchPreviewButton =
-    HH.div
-      [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]
-      , HP.style "padding-right: 0.5rem;"
-      ]
-      [ HH.button
-          [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
-          , HP.style
-              "position: absolute; \
-              \top: 0.5rem; \
-              \right: 0.5rem; \
-              \background-color: #fdecea; \
-              \color: #b71c1c; \
-              \padding: 0.2rem 0.4rem; \
-              \font-size: 0.75rem; \
-              \line-height: 1; \
-              \border: 1px solid #f5c6cb; \
-              \border-radius: 0.2rem; \
-              \z-index: 10;"
-          , HE.onClick \_ -> SwitchPreview
-          ]
-          [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
-      ]
-
   renderPreview :: State -> Array (H.ComponentHTML Action Slots m)
   renderPreview state =
     [ -- Right Resizer
@@ -536,7 +475,11 @@ splitview = connect selectTranslator $ H.mkComponent
                 <>
                   "%; box-sizing: border-box; min-height: 0; overflow: auto; min-width: 6ch; position: relative;"
           ]
-          [ rightSwitchPreviewButton
+          [ HH.div
+            [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]
+            , HP.style "padding-right: 0.5rem;"
+            ]
+            [ closeButton SwitchPreview ]
           , HH.slot _preview unit Preview.preview
               { renderedHtml: state.renderedHtml
               , isDragging: state.mDragTarget /= Nothing
@@ -561,11 +504,35 @@ splitview = connect selectTranslator $ H.mkComponent
               <>
                 "%; box-sizing: border-box; min-height: 0; overflow: auto; min-width: 6ch; position: relative;"
         ]
-        [ rightSwitchPreviewButton
+        [ HH.div
+            [ HP.classes [ HB.dFlex, HB.alignItemsCenter ]
+            , HP.style "padding-right: 0.5rem;"
+            ]
+            [ closeButton SwitchPreview ]
         , HH.slot_ _editor 1 Editor.editor
             { docID: state.docID, elementData: cData }
         ]
     ]
+
+  closeButton :: Action -> H.ComponentHTML Action Slots m
+  closeButton action =
+    HH.button
+      [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
+      , HP.style
+          "position: absolute; \
+          \top: 0.5rem; \
+          \right: 0.5rem; \
+          \background-color: #fdecea; \
+          \color: #b71c1c; \
+          \padding: 0.2rem 0.4rem; \
+          \font-size: 0.75rem; \
+          \line-height: 1; \
+          \border: 1px solid #f5c6cb; \
+          \border-radius: 0.2rem; \
+          \z-index: 10;"
+      , HE.onClick \_ -> action
+      ]
+      [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]
 
   handleAction :: Action -> H.HalogenM State Action Slots Output m Unit
   handleAction = case _ of


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the `Editor` and `Splitview` components, focusing on code simplification, UI consistency, and enhanced preview/compare functionality. Key changes include the introduction of a unified close button component, streamlined state updates, and improved handling of preview and comparison editor switching.

**UI Consistency and Code Simplification:**

* Replaced repeated inline close button code with a reusable `closeButton` function in `Splitview`, ensuring a consistent look and reducing duplication. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL360-R357) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL400-R381) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL549-R482) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL595-R519) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL609-R535)
* Refactored state updates to use the shorthand `H.modify_ _ { ... }` syntax instead of lambda expressions, simplifying code throughout both `Editor` and `Splitview`. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL767-R767) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1740-R1747) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL707-R627) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL725-R644) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL807-R726) [[6]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL823-R750) [[7]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL946-R857) [[8]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL965-R885)

**Preview and Compare Functionality:**

* Added a new `SwitchPreview` action to allow toggling between compare editor and preview modes, improving navigation and user experience. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR111) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL549-R482) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR767-R779)
* Enhanced logic for rendering the preview and compare editors, ensuring correct display based on the selected TOC entry and comparison state. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL309-R310) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR319) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL898-R810) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL921-R832)

**Editor Actions and State Handling:**

* Added new `ReceiveFullTitle` and `SetDirtyFlag` actions to the `Editor` component, improving title handling and dirty state management. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR257-R258) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1627-R1635)
* Removed the unused `RequestFullTitle` output and associated dead code from the `Editor`. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL209) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL957-L958) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL275) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1755-L1758)

**General Improvements:**

* Improved handling of sidebar and preview toggling, ensuring state is updated correctly and UI responds as expected. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL823-R750) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR767-R779) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL860-L884)
* Minor logic fixes for comment section handling and sidebar visibility. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL807-R726) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL946-R857) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL965-R885)

These changes collectively improve code maintainability, UI consistency, and the overall user experience in the editor and splitview components.This pull request refactors and cleans up the handling of editor state and preview toggling in the `Editor` and `Splitview` components. The changes improve modularity by introducing reusable UI elements, streamline the logic for toggling and switching previews, and clarify the flow for updating editor titles and dirty state. Additionally, several redundant or misplaced actions are removed or relocated for better maintainability.

**Editor State and Title Management:**
- Removed the `RequestFullTitle` output and action from `Editor.purs`, consolidating title update logic and ensuring the editor receives title updates directly from the parent component. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL209) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL275) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL957-L958) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1755-L1758)
- Added `ReceiveFullTitle` and `SetDirtyFlag` as new queries/actions in `Editor.purs`, allowing the parent to explicitly set the editor's title and dirty state. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR257-R258) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1627-R1635)

**Preview and Compare View Logic:**
- Improved logic for switching between preview, compare, and editor views in `Splitview`, including the new `SwitchPreview` action and its handler. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR111) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR767-R778)
- Simplified the logic for rendering the preview area, ensuring correct behavior when toggling or switching views. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL309-R310) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR319) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL860-L884) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL999-R918)

**UI Button Refactoring:**
- Replaced repeated close button code with a reusable `closeButton` function for comment, comment overview, and preview panels in `Splitview.purs`, improving code maintainability and consistency. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL360-R357) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL400-R381) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL549-R482) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL595-R519) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL609-R535)

**Editor-TOC Communication Improvements:**
- Streamlined the process for updating the editor with the current title after TOC operations (such as reordering), ensuring the editor's state is always up to date. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1103-R1023) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1173-R1096) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1177-R1180)

**Miscellaneous Refactoring:**
- Minor cleanups and improved variable naming for clarity and consistency, especially in state management and event handling.

These changes collectively improve the reliability, maintainability, and user experience of the editor and splitview components.This pull request introduces several improvements and refactorings to the splitview and editor components, focusing on better state management, UI consistency, and code reuse. The most notable changes include a unified close button component, enhanced preview/compare switching logic, improved dirty state tracking, and streamlined event handling.

**UI Consistency and Code Reuse:**
- Introduced a reusable `closeButton` function to replace repeated close button code in the splitview, ensuring consistent appearance and behavior across comment, comment overview, and preview panels. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL360-R357) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL400-R381) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL549-R482) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL595-R519) [[5]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL609-R535)

**Preview and Compare Logic Improvements:**
- Added a new `SwitchPreview` action and logic to switch between preview and compare editor modes more intuitively, including updating how state transitions occur when toggling preview/compare. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR111) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR767-R778)
- Refactored the logic for rendering the preview and compare editor, ensuring correct rendering based on the selected TOC entry and comparison data. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL309-R310) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR319)

**State and Dirty Flag Management:**
- Added a `SetDirtyFlag` action to the editor, with logic to set the dirty state via a mutable reference, and invoked this action when TOC items are reordered. This helps track unsaved changes more reliably. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR258) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1630-R1634) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1181-R1182)

**Event Handling and State Updates:**
- Improved event handling for editor queries and preview toggling, ensuring state updates (such as `mSelectedTocEntry` and `renderedHtml`) are handled correctly when receiving new HTML from the editor, and the preview panel is shown or hidden as needed. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL985-L989) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL999-R918)

**Component Structure and Refactoring:**
- Moved the right resizer logic into its own function (`rightResizer`), simplifying the preview rendering code.

These changes collectively improve maintainability, user experience, and code clarity across the editor and splitview components.This pull request introduces a mechanism to mark the editor as "dirty" whenever changes are made to the Table of Contents (TOC), ensuring that unsaved changes are tracked and prompting the editor to save when necessary. The main changes add a new `SetDirtyFlag` action and update the TOC reordering logic to trigger this action alongside saving.

**Editor state management:**

* Added a new `SetDirtyFlag` action to the `Query` type in `Editor.purs` to track unsaved changes in the editor.
* Implemented handling for the `SetDirtyFlag` action in the editor component, updating the `mDirtyRef` to `true` when triggered.

**TOC interaction logic:**

* Updated the TOC reordering logic in `Splitview.purs` to send both `SetDirtyFlag` and `SaveSection` actions to the editor after reordering items, ensuring the editor is marked as dirty and the changes are saved.