### PR TITLE
dockerfile: Force x86 build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,7 @@
 # |             BASE             |
 # +------------------------------+
 
-FROM --platform=x86_64 debian:bookworm-slim  AS base
+FROM --platform=x86_64 debian:bookworm-slim AS base
 
 # install dependencies needed by both build and final
 RUN apt-get update && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,11 @@
+# check=skip=FromPlatformFlagConstDisallowed
+# We skip this because the image does not build currently for arm64
+#
 # +------------------------------+
 # |             BASE             |
 # +------------------------------+
 
-FROM debian:bookworm-slim AS base
+FROM --platform=x86_64 debian:bookworm-slim  AS base
 
 # install dependencies needed by both build and final
 RUN apt-get update && \


### PR DESCRIPTION
It does not compile currently for arm64, so just force the other platform for now.