### PR TITLE
721 readonly after safe bug

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -735,13 +735,20 @@ editor = connect selectTranslator $ H.mkComponent
         RenderPDF -> do
           state <- H.get
           H.raise (PostPDF state.currentVersion)
+      H.gets _.mEditor >>= traverse_ \ed ->
+        H.liftEffect $ Editor.focus ed
 
     ShowAllComments -> do
       state <- H.get
       let tocID = maybe (-1) _.id state.mTocEntry
       H.raise $ ShowAllCommentsOutput state.docID tocID
+      H.gets _.mEditor >>= traverse_ \ed ->
+        H.liftEffect $ Editor.focus ed
 
     Save isAutoSave -> do
+      when (not isAutoSave) $
+        H.gets _.mEditor >>= traverse_ \ed ->
+          H.liftEffect $ Editor.focus ed
       state <- H.get
       when (state.compareToElement == Nothing) $ do
         isDirty <- liftEffect $ Ref.read =<< case state.saveState.mDirtyRef of

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -940,14 +940,14 @@ editor = connect selectTranslator $ H.mkComponent
         }
 
     AutoSaveTimer -> do
-      -- restart 2 sec timer after every new input
+      -- restart 5 sec timer after every new input
       -- first kill the maybe running fiber (kinda like a thread)
       debounce <- H.gets _.saveState.mPendingDebounceF
       traverse_ H.kill debounce
 
       -- start a new fiber
       dFib <- H.fork do
-        H.liftAff $ delay (Milliseconds 2000.0)
+        H.liftAff $ delay (Milliseconds 5000.0)
         mMax <- H.gets _.saveState.mPendingMaxWaitF
         traverse_ H.kill mMax
         H.modify_ \st -> st
@@ -962,7 +962,7 @@ editor = connect selectTranslator $ H.mkComponent
       H.modify_ \st -> st
         { saveState = st.saveState { mPendingDebounceF = Just dFib } }
 
-      -- This is a seperate 20 sec timer, which forces to save, in case of a long edit
+      -- This is a seperate 60 sec timer, which forces to save, in case of a long edit
       -- does not reset with new input
       mPendingMaxWaitF <- H.gets _.saveState.mPendingMaxWaitF
       case mPendingMaxWaitF of
@@ -971,7 +971,7 @@ editor = connect selectTranslator $ H.mkComponent
         -- no timer there
         Nothing -> do
           mFib <- H.fork do
-            H.liftAff $ delay (Milliseconds 20000.0)
+            H.liftAff $ delay (Milliseconds 60000.0)
             latestDebounce <- H.gets _.saveState.mPendingDebounceF
             traverse_ H.kill latestDebounce
             H.modify_ \st -> st

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -1745,12 +1745,12 @@ editor = connect selectTranslator $ H.mkComponent
       state <- H.get
       for_ state.mDirtyVersion \r -> H.liftEffect $ Ref.write false r
       pure $ Just a
-  
+
   -- free up the save flags for the next save session
   -- check if there are new requests for saving during saving
   freeSaveFlagsAndMaybeRerun
     :: forall slots
-      . Boolean
+     . Boolean
     -> H.HalogenM State Action slots Output m Unit
   freeSaveFlagsAndMaybeRerun isAutoSave = do
     -- free up the save flags for the next save session

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -787,7 +787,8 @@ editor = connect selectTranslator $ H.mkComponent
               -- check if there are new request for saving during saving
               for_ state.saveState.mIsSaving \r -> H.liftEffect $ Ref.write false r
               when qSaving do
-                for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write false r
+                for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write false
+                  r
                 handleAction $ Save isAutoSave
             Just entry ->
               case state.mContent of
@@ -796,9 +797,12 @@ editor = connect selectTranslator $ H.mkComponent
                   qSaving <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets
                     _.saveState.mQueuedSave
                   -- check if there are new request for saving during saving
-                  for_ state.saveState.mIsSaving \r -> H.liftEffect $ Ref.write false r
+                  for_ state.saveState.mIsSaving \r -> H.liftEffect $ Ref.write false
+                    r
                   when qSaving do
-                    for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write false r
+                    for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write
+                      false
+                      r
                     handleAction $ Save isAutoSave
                   pure unit
                 Just content -> do

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -751,8 +751,10 @@ editor = connect selectTranslator $ H.mkComponent
           H.liftEffect $ Editor.focus ed
       state <- H.get
       when (state.compareToElement == Nothing) $ do
-        isSaving <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets _.saveState.mIsSaving
-        isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets _.saveState.mDirtyRef
+        isSaving <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets
+          _.saveState.mIsSaving
+        isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets
+          _.saveState.mDirtyRef
         -- Only save, when dirty flag is true or we are in older version
         -- TODO: Add another flag instead of using isEditorOutdated
         if ((not isSaving) && (isDirty || state.isEditorOutdated)) then do
@@ -946,9 +948,11 @@ editor = connect selectTranslator $ H.mkComponent
               , mPendingMaxWaitF = Nothing
               }
           }
-        isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets _.saveState.mDirtyRef
+        isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets
+          _.saveState.mDirtyRef
         when isDirty $ handleAction AutoSave
-      H.modify_ \st -> st{ saveState = st.saveState { mPendingDebounceF = Just dFib } }
+      H.modify_ \st -> st
+        { saveState = st.saveState { mPendingDebounceF = Just dFib } }
 
       -- This is a seperate 20 sec timer, which forces to save, in case of a long edit
       -- does not reset with new input
@@ -968,9 +972,11 @@ editor = connect selectTranslator $ H.mkComponent
                   , mPendingMaxWaitF = Nothing
                   }
               }
-            isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets _.saveState.mDirtyRef
+            isDirty <- maybe (pure false) (H.liftEffect <<< Ref.read) =<< H.gets
+              _.saveState.mDirtyRef
             when isDirty $ handleAction AutoSave
-          H.modify_ \st -> st{ saveState = st.saveState { mPendingMaxWaitF = Just mFib } }
+          H.modify_ \st -> st
+            { saveState = st.saveState { mPendingMaxWaitF = Just mFib } }
 
     AutoSave -> do
       mDeb <- H.gets _.saveState.mPendingDebounceF
@@ -1528,9 +1534,9 @@ editor = connect selectTranslator $ H.mkComponent
             H.modify_ \st -> st
               { commentState = st.commentState { liveMarkers = newLiveMarkers }
               , saveState = st.saveState
-                { mPendingDebounceF = Nothing
-                , mPendingMaxWaitF = Nothing
-                } 
+                  { mPendingDebounceF = Nothing
+                  , mPendingMaxWaitF = Nothing
+                  }
               }
             -- lastly show html in preview
             when showHtml $ do
@@ -1990,7 +1996,7 @@ addBeforeUnloadListener dref listener = do
         preventDefault ev
         HS.notify listener (Save true)
       _ -> pure unit
-  
+
   sref <- H.liftEffect $ Ref.new false
   H.modify_ \st -> st
     { saveState = st.saveState


### PR DESCRIPTION
This pull request introduces significant improvements to the editor's save logic, focusing on preventing concurrent saves, handling queued save requests, and refining auto-save timing. The changes enhance reliability and user experience by ensuring saves are not duplicated and that all changes are correctly persisted, even during rapid editing.

**Save logic and concurrency improvements:**

* Added new flags to `SaveState` (`mIsSaving`, `mQueuedSave`) to prevent multiple simultaneous saves and to queue save requests that occur during an ongoing save. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL154-R158) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1887-R1888) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR2025-R2032)
* Updated save handling: Before starting a save, the editor checks if a save is already in progress and sets flags accordingly. If a save is requested while another is in progress, it is queued and executed after the current save finishes. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR741-R766) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR784-R789) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL806-R828) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1749-R1765) [[5]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL898-R920)

**Auto-save and timer refinements:**

* Increased auto-save debounce timer from 2 seconds to 5 seconds, and the maximum wait timer from 20 seconds to 60 seconds, improving responsiveness and reducing unnecessary saves.
* Ensured that timers are properly cleaned up and reset after saves and when updating markers, preventing timer leaks and redundant auto-saves. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL924-L970) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1538-R1548)

**Editor focus and user experience:**

* Ensured the editor regains focus after certain actions (e.g., saving, rendering PDF, showing comments) for smoother user interaction.

**State management and consistency:**

* Updated state transitions to ensure that the editor's current version and content are correctly updated after certain actions, maintaining consistency.

**Code cleanup:**

* Removed unused imports and replaced deprecated code patterns with safer alternatives (e.g., using `maybe` and `traverse_` for safer effect handling).

Let me know if you'd like a deeper explanation of any of these changes!This pull request refactors and improves the editor's save logic to prevent overlapping save operations, better manage save state, and ensure the editor regains focus after key actions. The changes introduce new flags to track saving status and pending save requests, refine auto-save timers, and enhance user feedback. Overall, these updates make the saving process more robust and user-friendly.

**Save Logic and State Management Improvements**
* Added new fields to `SaveState`: `mIsSaving` (tracks if a save is in progress) and `mQSaving` (tracks if a new save is requested during an ongoing save), with all related logic for setting and checking these flags. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL154-R158) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1874-R1875) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR2012-R2019)
* Updated save actions to check `mIsSaving` before starting a new save, and to handle queued save requests via `mQSaving` after a save completes. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR741-R766) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR784-R785) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL807-R827) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL898-R924)

**Auto-Save Timer and Debounce Handling**
* Refactored auto-save debounce and max-wait timers to be more robust: timers are killed and reset appropriately, and state updates are now safer and clearer. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL924-L970) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1542-R1552)

**Editor Focus and User Feedback**
* Ensured the editor regains focus after manual saves and comment actions for improved user experience.
* Improved user feedback by showing a "already saved" notification when attempting to save with no changes.

**Miscellaneous Fixes**
* Updated state management to ensure `currentVersion` is set when loading a new entry.
* Cleaned up imports by removing unused `liftEffect`.This pull request improves the editor's save and auto-save logic by introducing a new `mIsSaving` flag to prevent overlapping save operations, refactoring timer management for auto-save, and ensuring editor focus during key actions. These changes make saving more robust and prevent issues like double saves or lingering timers.

**Save and auto-save logic improvements:**

* Added a new `mIsSaving` flag to `SaveState` and related logic to prevent concurrent save operations and ensure that only one save happens at a time. (`frontend/src/FPO/Components/Editor/Editor.purs`) [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR155) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1862) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1999-R2004)
* Updated save and auto-save handlers to check and set `mIsSaving`, and reset it after saving completes, improving reliability and preventing double saves. (`frontend/src/FPO/Components/Editor/Editor.purs`) [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR738-R763) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL898-R910)

**Auto-save timer management:**

* Refactored debounce and max-wait timer handling for auto-save, ensuring timers are properly killed and reset after input or save actions, reducing potential for orphaned timers. (`frontend/src/FPO/Components/Editor/Editor.purs`) [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL924-L970) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1530-R1540)

**Editor focus and state updates:**

* Ensured the editor is focused after actions like saving, rendering PDF, or showing comments, improving user experience. (`frontend/src/FPO/Components/Editor/Editor.purs`)
* Minor bugfix: ensured `currentVersion` is updated when setting a new TOC entry. (`frontend/src/FPO/Components/Editor/Editor.purs`)

**Code cleanup:**

* Removed unused import `liftEffect` and replaced with more idiomatic usage of `H.liftEffect`. (`frontend/src/FPO/Components/Editor/Editor.purs`)