### PR TITLE
Backend: Fix Foreign Key Constraint Violation

### DIFF
--- a/backend/migrations/005_comments.up.sql
+++ b/backend/migrations/005_comments.up.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS doc_comment_replies (
 
 CREATE TABLE IF NOT EXISTS doc_comment_anchors (
     comment BIGINT NOT NULL REFERENCES doc_comments (id),
-    revision BIGINT NOT NULL REFERENCES doc_text_revisions (id),
+    revision BIGINT NOT NULL REFERENCES doc_text_revisions (id) ON UPDATE CASCADE,
     start_col BIGINT NOT NULL,
     start_row BIGINT NOT NULL,
     end_col BIGINT NOT NULL,


### PR DESCRIPTION
This PR fixes a foreign key violation when squashing commits with comment anchors.

When squashing a commit with a new commit, the existing commit is updated and gets a new id.
If there are comment anchors referencing the old commit id, this results in a foreign key constraint violation.
Thus, errors like follows are returned from the api:

```
Database error: QueryError "WITH updated AS (UPDATE doc_text_revisions SET id = nextval('doc_revision_seq'), creation_ts = now(), content = $2 :: text WHERE id = $1 :: int8 RETURNING id :: int8, creation_ts :: timestamptz, author :: uuid, content :: text), updated_anchors AS (UPDATE doc_comment_anchors SET comment = updated.id FROM updated WHERE doc_comment_anchors.comment = $1 :: int8) SELECT updated.id :: int8, updated.creation_ts :: timestamptz, updated.author :: uuid, users.name :: text, updated.content :: text FROM updated JOIN users ON users.id = updated.author" ["240","\"\\167 Zugang zum Masterstudium\\n\\nDer Zugang zum Studiengang\""] (ResultError (ServerError "23503" "update or delete on table \"doc_text_revisions\" violates foreign key constraint \"doc_comment_anchors_revision_fkey\" on table \"doc_comment_anchors\"" (Just "Key (id)=(240) is still referenced from table \"doc_comment_anchors\".") Nothing Nothing))
```

With this PR, the reference is now updated accordingly.