### PR TITLE
backend/html: Footnotes in Documents + Table CSS improvement

### DIFF
--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -279,7 +279,7 @@ classStyle TableContainer = do
         display flex
         justifyContent center
 classStyle Table = do
-    let cellPadding = padding (px 12) (px 12) (px 12) (px 12)
+    let cellPadding = padding (px 2) (px 12) (px 2) (px 12)
         cellBorder = border (px 1) solid Color.tableCellBorder
 
     toClassSelector Table ? do


### PR DESCRIPTION
## Fixes
- Footnotes are now also rendered on document-level (for SimpleBlocks)
- Small improvement of the Flagged logic

# CSS
- smaller table cell padding for non ToC tables

Closes #724 