### PR TITLE
Save backend

### DIFF
--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -130,8 +130,9 @@ updateTextRevision rev text commentAnchors = do
         Statements.deleteCommentAnchorsExcept
     textRevision <- statement (rev, text) Statements.updateTextRevision
     textRevision $
-        const $
-            mapM (`statement` Statements.putCommentAnchor) ((rev,) <$> commentAnchors)
+        \newRev ->
+            mapM (`statement` Statements.
+            putCommentAnchor) ((newRev,) <$> commentAnchors)
 
 createTextRevision
     :: UserID

--- a/backend/src/Docs/Hasql/Transactions.hs
+++ b/backend/src/Docs/Hasql/Transactions.hs
@@ -131,8 +131,7 @@ updateTextRevision rev text commentAnchors = do
     textRevision <- statement (rev, text) Statements.updateTextRevision
     textRevision $
         \newRev ->
-            mapM (`statement` Statements.
-            putCommentAnchor) ((newRev,) <$> commentAnchors)
+            mapM (`statement` Statements.putCommentAnchor) ((newRev,) <$> commentAnchors)
 
 createTextRevision
     :: UserID


### PR DESCRIPTION
A backend fix, suggested by ChatGPT for the save bug.

This pull request makes a small but important fix to the handling of comment anchors when updating a text revision. The change ensures that the latest revision ID is used when associating comment anchors, which helps maintain data consistency.

- Bug fix:
  * In `updateTextRevision` in `Docs/Hasql/Transactions.hs`, updated the function to use the new revision ID (`newRev`) when inserting comment anchors, instead of the original revision ID (`rev`).