### PR TITLE
Repair PDF download

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -936,6 +936,7 @@ splitview = connect selectTranslator $ H.mkComponent
             }
 
       Editor.PostPDF _ -> do
+        handleAction UpdateMSelectedTocEntry
         state <- H.get
         upToDateVersion <- H.request _toc unit TOC.RequestUpToDateVersion
         let

--- a/frontend/test/Test/Components/Splitview.purs
+++ b/frontend/test/Test/Components/Splitview.purs
@@ -15,6 +15,9 @@ import FPO.Translations.Translator (fromFpoTranslator, translator)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
+shouldBeNear :: forall m. MonadThrow Error m => Number -> Number -> m Unit
+shouldBeNear expected actual = (abs (expected - actual) < 0.0001) `shouldEqual` true
+
 defaultState =
   { docID: 0
   , translator: fromFpoTranslator translator
@@ -348,5 +351,3 @@ resizeFromRightTest =
 
         sidebarClosed `shouldEqual` true
 
-shouldBeNear :: forall m. MonadThrow Error m => Number -> Number -> m Unit
-shouldBeNear expected actual = (abs (expected - actual) < 0.0001) `shouldEqual` true


### PR DESCRIPTION
This pull request introduces a minor update to the Splitview component and its associated test suite. The main change is the addition of an action handler in the Splitview editor logic, along with a small refactor to the test helper function.

**Splitview Component Update:**

* Added a call to `handleAction UpdateMSelectedTocEntry` in the `Editor.PostPDF` branch of the Splitview component logic to ensure the selected TOC entry is updated when handling post-PDF actions.

**Test Suite Refactor:**

* Moved the definition of the `shouldBeNear` helper function to the top of the test file for better organization and visibility. No functional changes were made to the helper itself. [[1]](diffhunk://#diff-8c95a46ec9722d42d9948f1ed3a71375618108591ce235c377d053aa8e7085f4R18-R20) [[2]](diffhunk://#diff-8c95a46ec9722d42d9948f1ed3a71375618108591ce235c377d053aa8e7085f4L351-L352)