### PR TITLE
Change revision id bug

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -181,6 +181,7 @@ type State = FPOState
   , modalData :: Maybe { elementID :: Int, versionID :: Maybe Int }
   -- obtained from TOC
   , upToDateVersion :: Maybe Version
+  , pendingUpdateElementID :: Maybe Int
   )
 
 type ElemVersion =
@@ -242,6 +243,7 @@ splitview = connect selectTranslator $ H.mkComponent
     , dirtyVersion: false
     , modalData: Nothing
     , upToDateVersion: Nothing
+    , pendingUpdateElementID: Nothing
     }
 
   render :: State -> H.ComponentHTML Action Slots m
@@ -1068,10 +1070,19 @@ splitview = connect selectTranslator $ H.mkComponent
             pure unit
 
       Editor.RaiseUpdateVersion mVID -> do
-        handleAction UpdateMSelectedTocEntry
         state <- H.get
-        case state.mSelectedTocEntry of
-          Just (SelLeaf elementID) -> do
+        let
+          targetElementID =
+            case state.pendingUpdateElementID of
+              Just id -> Just id
+              Nothing ->
+                case state.mSelectedTocEntry of
+                  Just (SelLeaf id) -> Just id
+                  _ -> Nothing
+        case targetElementID of
+          Just elementID -> do
+            H.modify_ _ { pendingUpdateElementID = Nothing }
+
             handleAction
               (ModifyVersionMapping elementID (Just mVID) Nothing)
             case (findTOCEntry elementID state.tocEntries) of
@@ -1085,9 +1096,10 @@ splitview = connect selectTranslator $ H.mkComponent
       Editor.Merged -> do
         handleAction UpdateMSelectedTocEntry
         state <- H.get
-        handleAction DeleteDraft
         case state.mSelectedTocEntry of
           Just (SelLeaf elementID) -> do
+            H.modify_ _ { pendingUpdateElementID = Just elementID }
+            handleAction DeleteDraft
             handleAction
               (ModifyVersionMapping elementID (Just Nothing) (Just Nothing))
             case (findTOCEntry elementID state.tocEntries) of
@@ -1137,6 +1149,13 @@ splitview = connect selectTranslator $ H.mkComponent
         handleAction (SetComparison elementID vID)
 
       TOC.ChangeToLeaf selectedId mTitle -> do
+        stateBefore <- H.get
+        let
+          currentElementID =
+            case stateBefore.mSelectedTocEntry of
+              Just (SelLeaf id) -> Just id
+              _ -> Nothing
+        H.modify_ _ { pendingUpdateElementID = currentElementID }
         -- check to avoid weird merge/save race conditions
         isOnMerge <- H.request _editor 0 Editor.IsOnMerge
         when (not $ fromMaybe false isOnMerge) $

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1087,6 +1087,7 @@ splitview = connect selectTranslator $ H.mkComponent
             pure unit
 
       Editor.RaiseUpdateVersion mVID -> do
+        handleAction UpdateMSelectedTocEntry
         state <- H.get
         let
           targetElementID =
@@ -1113,10 +1114,10 @@ splitview = connect selectTranslator $ H.mkComponent
       Editor.Merged -> do
         handleAction UpdateMSelectedTocEntry
         state <- H.get
+        handleAction DeleteDraft
         case state.mSelectedTocEntry of
           Just (SelLeaf elementID) -> do
             H.modify_ _ { pendingUpdateElementID = Just elementID }
-            handleAction DeleteDraft
             handleAction
               (ModifyVersionMapping elementID (Just Nothing) (Just Nothing))
             case (findTOCEntry elementID state.tocEntries) of

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1033,7 +1033,7 @@ splitview = connect selectTranslator $ H.mkComponent
           Just (SelLeaf id) -> do
             _ <- Request.deleteIgnore
               ("/docs/" <> show state.docID <> "/text/" <> show id <> "/draft")
-            handleAction (ModifyVersionMapping id (Just Nothing) Nothing)
+            handleAction (ModifyVersionMapping id (Just Nothing) (Just Nothing))
             let
               -- Nothing case should never occur
               entry = case (findTOCEntry id state.tocEntries) of

--- a/frontend/test/Test/Components/Splitview.purs
+++ b/frontend/test/Test/Components/Splitview.purs
@@ -42,6 +42,7 @@ defaultState =
   , dirtyVersion: false
   , modalData: Nothing
   , upToDateVersion: Nothing
+  , pendingUpdateElementID: Nothing
   } :: State
 
 resizeFromLeftTest :: Spec Unit


### PR DESCRIPTION
This pull request introduces logic to track and manage a `pendingUpdateElementID` within the `Splitview` component's state. This new state field helps coordinate updates and deletion actions related to document elements, aiming to prevent race conditions and ensure the correct element is targeted during version updates and merges. The changes also update initial state definitions and relevant test setups.

State management improvements:

* Added a new `pendingUpdateElementID` field to the `State` type and initialized it in both the component and test default state, allowing the UI to keep track of which element is pending an update. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR186) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR250) [[3]](diffhunk://#diff-8c95a46ec9722d42d9948f1ed3a71375618108591ce235c377d053aa8e7085f4R48)

Update and merge workflow enhancements:

* Modified the handling of version updates and merges to utilize `pendingUpdateElementID`, ensuring that actions target the correct element even if the selection changes during asynchronous operations. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1088-R1102) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1105-R1119) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1169-R1175)

Bug fix:

* Updated the call to `ModifyVersionMapping` after deleting a draft to provide the correct argument structure, preventing potential issues with version mapping updates.