### PR TITLE
backend/html: fixed x-overflow being cut off

### DIFF
--- a/backend/src/Language/Ltml/HTML/CSS/Classes.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/Classes.hs
@@ -244,8 +244,7 @@ classStyle CenteredBox =
         marginTop (em 2)
         marginBottom (em 2)
         display inlineGrid
-        alignItems center
-        justifyContent center
+        justifyItems center
         width (pct 100)
 classStyle ErrorBox =
     toClassSelector ErrorBox ? do
@@ -276,8 +275,8 @@ classStyle Anchor =
         scrollMarginTop (em 2)
 classStyle TableContainer = do
     toClassSelector TableContainer ? do
-        display flex
-        justifyContent center
+        display grid
+        justifyItems center
 classStyle Table = do
     let cellPadding = padding (px 2) (px 12) (px 2) (px 12)
         cellBorder = border (px 1) solid Color.tableCellBorder

--- a/backend/src/Language/Ltml/HTML/CSS/CustomClay.hs
+++ b/backend/src/Language/Ltml/HTML/CSS/CustomClay.hs
@@ -24,6 +24,7 @@ module Language.Ltml.HTML.CSS.CustomClay
     , gap
     , scrollMarginTop
     , tableLayout
+    , justifyItems
     ) where
 
 import Clay hiding (a, b, s)
@@ -91,3 +92,6 @@ scrollMarginTop s = "scroll-margin-top" -: unPlain (unValue $ value s)
 
 tableLayout :: Position -> Css
 tableLayout arg = "table-layout" -: unPlain (unValue $ value arg)
+
+justifyItems :: JustifyContentValue -> Css
+justifyItems arg = "justify-items" -: unPlain (unValue $ value arg)


### PR DESCRIPTION
Now tables and error boxes are centered and overflow to the right without cutoff.
This leads to overflowing items having no right-padding (or margin), which indicates the overflow.

Closes #726