### PR TITLE
added manualSave flag and prevent leaving the merge mode/discard in b…

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -1447,9 +1447,10 @@ editor = connect selectTranslator $ H.mkComponent
     Finalize -> do
       -- Save in case, the user changes the page (via Navbar)
       state <- H.get
-      when state.isOnMerge $
+      if state.isOnMerge then
         handleAction ConfirmDiscardAction
-      handleAction $ Save true
+      else
+        handleAction $ Save true
       win <- H.liftEffect window
       let
         tgt = Win.toEventTarget win

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -814,7 +814,10 @@ editor = connect selectTranslator $ H.mkComponent
           _.saveState.mManualSaveRef
         -- Only save, when dirty flag is true or we are in older version
         -- TODO: Add another flag instead of using isEditorOutdated
-        if ((not isSaving) && (isDirty || (not isManualSaved) || state.isEditorOutdated)) then do
+        if
+          ( (not isSaving) &&
+              (isDirty || (not isManualSaved) || state.isEditorOutdated)
+          ) then do
           -- mIsSaving := true, mDirtyRef := false
           for_ state.saveState.mIsSaving \r -> H.liftEffect $ Ref.write true r
           for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
@@ -881,9 +884,10 @@ editor = connect selectTranslator $ H.mkComponent
             for_ state.saveState.mManualSaveRef \r -> H.liftEffect $ Ref.write true r
         -- Users want to have a visual indicator, that they have saved. So when manual saving without any changes since
         -- last Save, just show the notification
-        else when (not isAutoSave && isManualSaved && isJust state.mTocEntry) $
-          updateStore $ Store.AddSuccess
-            (translate (label :: _ "editor_already_saved") state.translator)
+        else when (not isAutoSave && isManualSaved && isJust state.mTocEntry)
+          $ updateStore
+          $ Store.AddSuccess
+              (translate (label :: _ "editor_already_saved") state.translator)
 
     Upload newEntry newWrapper isAutoSave -> do
       state <- H.get
@@ -947,6 +951,7 @@ editor = connect selectTranslator $ H.mkComponent
                     true -> H.raise Merged
                   pure unit
                 "draftCreated" -> --should not happen here. just copy autosave case in case
+
                   setIsOnMerge true
                 "conflict" -> do --raise something to update version
                   setIsOnMerge true
@@ -963,6 +968,7 @@ editor = connect selectTranslator $ H.mkComponent
                     true -> H.raise Merged
                   pure unit
                 "draftCreated" -> --should not happen here. just copy autosave case in case
+
                   setIsOnMerge true
                 "conflict" -> do --raise something to update version
                   setIsOnMerge true
@@ -1579,7 +1585,8 @@ editor = connect selectTranslator $ H.mkComponent
               -- reset Ref, because loading new content is considered
               -- changing the existing content, which would set the flag
               for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
-              for_ state.saveState.mManualSaveRef \r -> H.liftEffect $ Ref.write true r
+              for_ state.saveState.mManualSaveRef \r -> H.liftEffect $ Ref.write true
+                r
 
               -- Reset Undo history
               undoMgr <- Session.getUndoManager session
@@ -1837,16 +1844,15 @@ editor = connect selectTranslator $ H.mkComponent
     when qSaving do
       for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write false r
       handleAction $ Save (not isManualSaved)
-  
+
   setIsOnMerge
     :: forall slots
-    . Boolean
+     . Boolean
     -> H.HalogenM State Action slots Output m Unit
   setIsOnMerge flag = do
     H.modify_ _ { isOnMerge = flag }
     mRef <- H.gets _.saveState.mIsOnMergeRef
     for_ mRef \r -> H.liftEffect $ Ref.write flag r
-
 
 -- | Change listener for the editor.
 --

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -814,13 +814,16 @@ editor = connect selectTranslator $ H.mkComponent
         -- TODO: Add another flag instead of using isEditorOutdated
         if
           ( (not isSaving) &&
-              (isDirty || (not state.saveState.isManualSaved) || state.isEditorOutdated)
+              ( isDirty || (not state.saveState.isManualSaved) ||
+                  state.isEditorOutdated
+              )
           ) then do
           -- mIsSaving := true, mDirtyRef := false
           for_ state.saveState.mIsSaving \r -> H.liftEffect $ Ref.write true r
           for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
-          when (not isAutoSave) $
-            handleAction $ SetManualSavedFlag true
+          when (not isAutoSave)
+            $ handleAction
+            $ SetManualSavedFlag true
           allLines <- H.gets _.mEditor >>= traverse \ed -> do
             H.liftEffect $ Editor.getSession ed
               >>= Session.getDocument
@@ -878,14 +881,19 @@ editor = connect selectTranslator $ H.mkComponent
                   handleAction $ Upload entry newWrapper isAutoSave
         else if (isSaving && (isDirty || not state.saveState.isManualSaved)) then do
           for_ state.saveState.mQueuedSave \r -> H.liftEffect $ Ref.write true r
-          when (not isAutoSave) $
-            handleAction $ SetManualSavedFlag true
+          when (not isAutoSave)
+            $ handleAction
+            $ SetManualSavedFlag true
         -- Users want to have a visual indicator, that they have saved. So when manual saving without any changes since
         -- last Save, just show the notification
-        else when (not isAutoSave && state.saveState.isManualSaved && isJust state.mTocEntry)
-          $ updateStore
-          $ Store.AddSuccess
-              (translate (label :: _ "editor_already_saved") state.translator)
+        else
+          when
+            ( not isAutoSave && state.saveState.isManualSaved && isJust
+                state.mTocEntry
+            )
+            $ updateStore
+            $ Store.AddSuccess
+                (translate (label :: _ "editor_already_saved") state.translator)
 
     Upload newEntry newWrapper isAutoSave -> do
       state <- H.get
@@ -979,7 +987,7 @@ editor = connect selectTranslator $ H.mkComponent
       freeSaveFlagsAndMaybeRerun
 
     SetManualSavedFlag flag ->
-      H.modify_ \st -> st { saveState = st.saveState { isManualSaved = flag }}
+      H.modify_ \st -> st { saveState = st.saveState { isManualSaved = flag } }
 
     SavedIcon -> do
       mSavedIconF <- H.gets _.saveState.mSavedIconF

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -153,7 +153,7 @@ type SaveState =
     -- only save when there are new changes in editor
     mDirtyRef :: Maybe (Ref Boolean)
   , mManualSaveRef :: Maybe (Ref Boolean)
-  -- copy of isOneMerge state label only used for beforeUnload
+  -- copy of isOnMerge state label only used for beforeUnload
   , mIsOnMergeRef :: Maybe (Ref Boolean)
   -- Prevent to have multiple saving processes at the same time
   , mIsSaving :: Maybe (Ref Boolean)
@@ -2114,8 +2114,8 @@ addBeforeUnloadListener dref mref oref listener = do
 
   beforeUnloadListener <- H.liftEffect $ eventListener \ev -> do
     isDirty <- traverse Ref.read (Just dref)
-    isOneMerge <- traverse Ref.read (Just oref)
-    case isOneMerge, isDirty of
+    isOnMerge <- traverse Ref.read (Just oref)
+    case isOnMerge, isDirty of
       -- Prevent the tab from closing in a certain way
       Just true, _ -> do
         preventDefault ev

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1207,7 +1207,8 @@ splitview = connect selectTranslator $ H.mkComponent
         isOnMerge <- H.request _editor 0 Editor.IsOnMerge
         when (not $ fromMaybe false isOnMerge) $ do
           H.tell _editor 0 (Editor.ChangeToNode heading path)
-          H.tell _toc unit $ TOC.UpdateMSelectedTocEntry (SelNode path heading) (Just heading)
+          H.tell _toc unit $ TOC.UpdateMSelectedTocEntry (SelNode path heading)
+            (Just heading)
 
       TOC.AddNode path node -> do
         s <- H.get

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1173,7 +1173,7 @@ splitview = connect selectTranslator $ H.mkComponent
               _ -> Nothing
         -- check to avoid weird merge/save race conditions
         isOnMerge <- H.request _editor 0 Editor.IsOnMerge
-        if (fromMaybe false isOnMerge) then do
+        if (fromMaybe false isOnMerge) then
           H.tell _editor 0 Editor.PreventChangeSection
         else do
           H.modify_ _ { pendingUpdateElementID = currentElementID }
@@ -1205,7 +1205,9 @@ splitview = connect selectTranslator $ H.mkComponent
 
       TOC.ChangeToNode path heading -> do
         isOnMerge <- H.request _editor 0 Editor.IsOnMerge
-        when (not $ fromMaybe false isOnMerge) $ do
+        if (fromMaybe false isOnMerge) then
+          H.tell _editor 0 Editor.PreventChangeSection
+        else do
           H.tell _editor 0 (Editor.ChangeToNode heading path)
           H.tell _toc unit $ TOC.UpdateMSelectedTocEntry (SelNode path heading)
             (Just heading)

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -191,6 +191,7 @@ data Query a
   | RequestUpToDateVersion (Maybe Version -> a)
   | RequestFullTitle (Maybe String -> a)
   | SelectFirstEntry a
+  | UpdateMSelectedTocEntry SelectedEntity (Maybe String) a
 
 type SearchData =
   { elementID :: Int
@@ -503,12 +504,9 @@ tocview = connect (selectEq identity) $ H.mkComponent
       handleAction (ToggleHistoryMenuOff path)
       mSelectedTocEntry <- H.gets _.mSelectedTocEntry
       when (mSelectedTocEntry /= Just (SelLeaf id)) do
-        H.modify_ \state ->
-          state { mSelectedTocEntry = Just $ SelLeaf id, mTitle = Just title }
         H.raise (ChangeToLeaf id (Just title))
 
     JumpToNodeSection path title -> do
-      H.modify_ _ { mSelectedTocEntry = Just $ SelNode path title }
       H.raise (ChangeToNode path title)
 
     ToggleAddMenu path -> do
@@ -853,6 +851,10 @@ tocview = connect (selectEq identity) $ H.mkComponent
               }
           H.raise (ChangeToLeaf leafId mTitle)
           pure (Just a)
+    
+    UpdateMSelectedTocEntry entry mTitle a -> do
+      H.modify_ _ { mSelectedTocEntry = Just entry, mTitle = mTitle }
+      pure (Just a)
 
   rootTreeToHTML
     :: forall slots

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -851,7 +851,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
               }
           H.raise (ChangeToLeaf leafId mTitle)
           pure (Just a)
-    
+
     UpdateMSelectedTocEntry entry mTitle a -> do
       H.modify_ _ { mSelectedTocEntry = Just entry, mTitle = mTitle }
       pure (Just a)

--- a/frontend/src/FPO/Translations/Components/Editor.purs
+++ b/frontend/src/FPO/Translations/Components/Editor.purs
@@ -77,7 +77,7 @@ enEditor = fromRecord
       <>
         "If you do not wish to save your currently opened version, you can click on \"Discard\" to discard them and open the current version."
   , editor_mergingNow:
-      "Copy over desired changes from the right and finish by clicking on \"Merge\""
+      "Copy over desired changes from the right and finish by clicking on \"Merge\". Leaving this window now will discard all your previous changes."
   , editor_no_title: "No section selected."
   , editor_oldVersion: "You are editing an old version"
   , editor_pdf: "Export PDF"


### PR DESCRIPTION
Fixes #708  

This pull request implements several improvements to the editor's save and merge handling, as well as better coordination between the editor and table of contents (TOC) components. The changes focus on more robust tracking of manual save state, preventing accidental data loss during merge operations, and ensuring UI state consistency when navigating sections. Additionally, new mechanisms are introduced to prevent section changes during an active merge, and to synchronize the selected section across components.

**Editor Save & Merge State Enhancements:**

* Introduced new references in `SaveState` (`mManualSaveRef`, `mIsOnMergeRef`) to track manual save status and merge mode, and updated their initialization and usage throughout the editor logic. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR155-R157) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1974-R1975)
* Improved save logic to distinguish between auto and manual saves, including updating manual save flags, and ensuring notifications are shown appropriately when the user attempts to save without changes. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR813-R822) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR878-L874) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1582) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1670)
* Added a `setIsOnMerge` helper to synchronize the merge state flag and its reference, ensuring consistent behavior when entering or exiting merge mode. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL932-R975) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1819-R1849)
* Updated the before-unload listener and change listeners to use the new refs, preventing tab close or section change during unsaved or merging states. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR702-R713) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1862-R1865) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1874) [[4]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR2098-R2127)
* Modified the merge warning and discard logic to ensure that users are prompted to confirm discarding changes if they attempt to navigate away during a merge. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1433-R1446) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1524)

**Section Navigation & TOC Coordination:**

* Added `PreventChangeSection` query to block section changes during an active merge, and wired it into the splitview component's navigation logic. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR285) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1174-R1179) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1207-R1210)
* Improved synchronization of section selection between the editor and TOC by introducing the `UpdateMSelectedTocEntry` query, ensuring both components reflect the current selection after navigation or merge operations. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1195) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR194) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR855-R858) [[4]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL506-L511)

**User Experience Improvements:**

* Updated the English translation for the merge view to clarify that leaving the window will discard changes, making the behavior more explicit to users.

These changes collectively make the editor more resilient to data loss, provide better feedback to users, and ensure that navigation and state transitions are handled safely during complex editing and merging workflows.…ackground in most cases