### PR TITLE
766 toc title is not automatically updating

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -270,7 +270,7 @@ data Query a
   -- | Open and edit a raw string outside the TOCEntry structure.
   --   This is used to make the editor available for editing
   --   the section names (headings) of non-leaf nodes.
-  | ChangeToNode String Path a
+  | ChangeToNode String Path (Maybe String) a
   -- | Update the position of a node in the editor, if existing.
   | UpdateNodePosition Path a
   | UpdateComment CommentSection a
@@ -1633,16 +1633,21 @@ editor = connect selectTranslator $ H.mkComponent
       handleAction (ContinueChangeToSection fCs true)
       pure (Just a)
 
-    ChangeToNode title path a -> do
+    ChangeToNode heading path mTitle a -> do
       -- Change the editor to a raw string outside the TOCEntry structure.
-      H.modify_ _ { mTocEntry = Nothing, mNodePath = Just path }
+      H.modify_ _
+        { mTocEntry = Nothing
+        , mNodePath = Just path
+        , mTitle = mTitle
+        , isLoading = true
+        }
       state <- H.get
       H.gets _.mEditor >>= traverse_ \ed -> do
         -- Set the content of the editor
         H.liftEffect $ do
           session <- Editor.getSession ed
           document <- Session.getDocument session
-          Document.setValue title document
+          Document.setValue heading document
           Editor.setReadOnly false ed
 
           -- Reset Undo history
@@ -1655,6 +1660,7 @@ editor = connect selectTranslator $ H.mkComponent
       -- reset Ref, because loading new content is considered
       -- changing the existing content, which would set the flag
       for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
+      H.modify_ _ { isLoading = false }
       pure (Just a)
 
     UpdateNodePosition path a -> do

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -216,6 +216,7 @@ data Output
   | RaiseMergeMode
   | Merged
   | RaiseUpdateVersion (Maybe Int)
+  | UpdateFullTitle
 
 data Action
   = Init
@@ -910,6 +911,7 @@ editor = connect selectTranslator $ H.mkComponent
 
           H.modify_ _ { mContent = Just updatedContent, html = html }
           H.raise $ ClickedQuery html
+          H.raise UpdateFullTitle
 
           -- Show saved icon or toast
           case isAutoSave, state.isEditorOutdated of

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1124,7 +1124,7 @@ splitview = connect selectTranslator $ H.mkComponent
                 mmTitle <- H.request _toc unit TOC.RequestFullTitle
                 H.tell _editor 0 (Editor.ChangeSection entry Nothing (join mmTitle))
           _ -> pure unit
-      
+
       Editor.UpdateFullTitle -> do
         handleAction GET
         mmTitle <- H.request _toc unit TOC.RequestFullTitle

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1124,6 +1124,11 @@ splitview = connect selectTranslator $ H.mkComponent
                 mmTitle <- H.request _toc unit TOC.RequestFullTitle
                 H.tell _editor 0 (Editor.ChangeSection entry Nothing (join mmTitle))
           _ -> pure unit
+      
+      Editor.UpdateFullTitle -> do
+        handleAction GET
+        mmTitle <- H.request _toc unit TOC.RequestFullTitle
+        H.tell _editor 0 $ Editor.ReceiveFullTitle (join mmTitle)
 
     DeleteDraft -> do
       handleAction UpdateMSelectedTocEntry

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1205,8 +1205,8 @@ splitview = connect selectTranslator $ H.mkComponent
       TOC.UpdateNodePosition path -> do
         H.tell _editor 0 (Editor.UpdateNodePosition path)
 
-      TOC.ChangeToNode path heading -> do
-        H.tell _editor 0 (Editor.ChangeToNode heading path)
+      TOC.ChangeToNode path heading mTitle -> do
+        H.tell _editor 0 (Editor.ChangeToNode heading path mTitle)
 
       TOC.AddNode path node -> do
         s <- H.get

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -120,7 +120,7 @@ data Output
   = ChangeToLeaf Int (Maybe String)
   -- | Opens the editor for some non-leaf node. Used to rename sections
   --   (i.e., changing the heading).
-  | ChangeToNode Path String
+  | ChangeToNode Path String (Maybe String)
   -- | Used to tell the editor to update the path of the selected node
   --   during title renaming.
   | UpdateNodePosition Path
@@ -158,7 +158,7 @@ data Action
   | Receive (Connected Store.Store Input)
   | DoNothing
   | JumpToLeafSection Int Path String
-  | JumpToNodeSection Path String
+  | JumpToNodeSection Path String String
   | ToggleAddMenu Path
   | ToggleHistoryMenu Path Int
   | ToggleHistoryMenuOff Path
@@ -507,9 +507,9 @@ tocview = connect (selectEq identity) $ H.mkComponent
           state { mSelectedTocEntry = Just $ SelLeaf id, mTitle = Just title }
         H.raise (ChangeToLeaf id (Just title))
 
-    JumpToNodeSection path title -> do
-      H.modify_ _ { mSelectedTocEntry = Just $ SelNode path title }
-      H.raise (ChangeToNode path title)
+    JumpToNodeSection path heading title -> do
+      H.modify_ _ { mSelectedTocEntry = Just $ SelNode path heading }
+      H.raise (ChangeToNode path heading (Just title))
 
     ToggleAddMenu path -> do
       H.modify_ \state ->
@@ -958,6 +958,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
                         ( if canBeRenamed then
                             [ HE.onClick \_ -> JumpToNodeSection path
                                 (getHeading header)
+                                (getFullTitle meta)
                             ]
                           else
                             []

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -845,7 +845,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
         Just entry -> do
           let
             leafId = entry.id
-            mTitle = findLeafTitle leafId state.tocEntries
+            mTitle = getFullTitle <$> findLeafMeta leafId state.tocEntries
           H.modify_ \st ->
             st
               { mSelectedTocEntry = Just (SelLeaf leafId)


### PR DESCRIPTION
Fixes #766 

This pull request updates the editor and TOC components to improve how section titles and headings are managed and synchronized across views. The main changes add support for passing and updating the full title of nodes, ensuring that both the heading and full title are correctly handled during editing and navigation.

**Editor and TOC synchronization improvements:**

* Added an `UpdateFullTitle` output to the `Editor` component, allowing the editor to request and receive the latest full title for a node. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR219) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR914) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1128-R1132)
* Updated the `ChangeToNode` query and output in both `Editor` and `TOC` components to accept an optional full title (`Maybe String`), enabling more accurate title editing and display. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL272-R273) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1634-R1650) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL123-R123) [[4]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL1203-R1209)
* Modified the handling of node selection in the TOC component so that both heading and full title are passed when jumping to a node section, improving consistency in the editor view. [[1]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL161-R161) [[2]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aL510-R512) [[3]](diffhunk://#diff-b12c2a6961f469033b27f4f7006071d14cae547b6525a1ab44d6ce80c3aed50aR961)
* Changed the retrieval of leaf titles in the TOC to use `getFullTitle` from leaf metadata, ensuring the editor receives the most complete title information.

**Editor usability enhancements:**

* Ensured that the editor sets the loading state appropriately when changing nodes and resets it after loading new content, improving feedback during editing operations. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1634-R1650) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1663)