### PR TITLE
Fix pdf sections again

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -925,10 +925,9 @@ splitview = connect selectTranslator $ H.mkComponent
                 (ModifyVersionMapping tocID Nothing (Just Nothing))
               Just _ -> pure unit -- Don't reset comparison data when in comparison mode
           _ -> pure unit
-        -- Always set mSelectedTocEntry and renderedHtml
+        -- Always set renderedHtml
         H.modify_ _
-          { mSelectedTocEntry = Nothing
-          , renderedHtml = Just (Loaded html)
+          { renderedHtml = Just (Loaded html)
           }
         -- Only update previewRatio and previewShown if preview is not already shown
         unless state.previewShown do


### PR DESCRIPTION
This pull request makes a small adjustment to the state update logic in the `Splitview` component. Now, when new HTML is loaded, only the `renderedHtml` field is updated, and the `mSelectedTocEntry` field is no longer reset to `Nothing`.

* State update logic in `Splitview`:
  - Only updates `renderedHtml` when new HTML is loaded, leaving `mSelectedTocEntry` unchanged.