### PR TITLE
Inline heading buttons for better space

### DIFF
--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1274,7 +1274,7 @@ tocview = connect (selectEq identity) $ H.mkComponent
     searchData
     state =
     HH.div
-      [ HP.classes [ HB.positionRelative ] ] $
+      [ HP.classes [ HB.positionRelative, HB.dInlineFlex ] ] $
       [ historyButton path elementID
       ]
         <>


### PR DESCRIPTION
Fixes #709 

This pull request makes a small visual adjustment to the table of contents component. The change adds an inline-flex display style to the container, which will affect the layout and alignment of its child elements.

* Updated the container in `TOC.purs` to use both `positionRelative` and `dInlineFlex` classes, improving the layout of the table of contents component.