### PR TITLE
790 swap editor content on merge

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -443,7 +443,7 @@ editor = connect selectTranslator $ H.mkComponent
                     Just _ -> HH.text ""
                     Nothing ->
                       makeEditorToolbarButton
-                        fullFeatures
+                        (state.currentVersion == "latest")
                         (translate (label :: _ "editor_comment") state.translator)
                         ( if (isJust state.commentState.reAnchor) then
                             [ H.ClassName "icon-orange" ]

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -203,6 +203,8 @@ type State = FPOState
   , mDirtyVersion :: Maybe (Ref Boolean)
   -- Determines whether the user is on the merge view.
   , isOnMerge :: Boolean
+  -- previous isOnMerge flag for ContinueToChange
+  , loadedIsOnMerge :: Boolean
   -- obtained from TOC. Used when merging. Set to the version details of the Version loaded into the right editor.
   , upToDateVersion :: Maybe Version
   , isLoading :: Boolean
@@ -219,7 +221,7 @@ data Output
   | SelectedCommentSection Int Int
   | ShowAllCommentsOutput Int Int
   | RaiseDiscard
-  | RaiseMergeMode
+  | RaiseMergeMode String
   | Merged
   | RaiseUpdateVersion (Maybe Int)
   | UpdateFullTitle
@@ -230,7 +232,7 @@ data Action
   = Init
   | DoNothing
   | Comment
-  | ChangeToSection TOCEntry (Maybe Int) (Maybe String)
+  | ChangeToSection TOCEntry (Maybe Int) (Maybe String) Boolean
   | ContinueChangeToSection (Array FirstComment) Boolean Boolean
   | SelectComment
   | Font (Types.Editor -> Effect Unit)
@@ -293,6 +295,7 @@ data Query a
   | PreventChangeSection a
   | UpdateCommentProblem Boolean a
   | SetReAnchor (Maybe CommentSection) a
+  | SetContent String a
 
 -- | UpdateCompareToElement ElementData a
 
@@ -674,81 +677,74 @@ editor = connect selectTranslator $ H.mkComponent
   handleAction :: Action -> forall slots. H.HalogenM State Action slots Output m Unit
   handleAction = case _ of
     Init -> do
-      -- Subscribe to resize events and store subscription for cleanup
-      { emitter, listener } <- H.liftEffect HS.create
-      subscription <- H.subscribe emitter
+      compareToElement <- H.gets _.compareToElement
 
-      -- Setup editor functionality (keydown listeners, Ace editor stuff, etc.)
-      let
-        onSave :: Effect Unit
-        onSave = HS.notify listener (Save false)
       H.getHTMLElementRef (H.RefLabel "container") >>= traverse_ \el -> do
         editor_ <- H.liftEffect $ Ace.editNode el Ace.ace
-
-        H.modify_ _
-          { mEditor = Just editor_
-          , mListener = Just listener
-          , mResizeSubscriptionId = Just subscription
-          }
+        H.modify_ _ { mEditor = Just editor_ }
         fontSize <- H.gets _.fontSize
 
-        H.liftEffect $ do
-          Editor.setFontSize (show fontSize <> "px") editor_
-          eventListen <- eventListener (keyBinding onSave editor_)
-          container <- Editor.getContainer editor_
-          addEventListener keydown eventListen true
-            (toEventTarget $ toElement container)
-          session <- Editor.getSession editor_
+        -- setting for both instances and later add more specif settings
+        H.liftEffect $ setupAce editor_ fontSize
 
-          -- Set line break
-          Editor.resize (Just true) editor_
-          Session.setUseWrapMode true session
+        when (compareToElement == Nothing) do
 
-          -- remove the gray margin line
-          Editor.setShowPrintMargin false editor_
+          -- Subscribe to resize events and store subscription for cleanup
+          { emitter, listener } <- H.liftEffect HS.create
+          subscription <- H.subscribe emitter
 
-          -- Set the editor's theme and mode
-          Editor.setTheme "ace/theme/github" editor_
-          Session.setMode "ace/mode/custom_mode" session
-          Editor.setEnableLiveAutocompletion true editor_
-          -- set read only at the start to prevent users to write in not selected entry
-          Editor.setReadOnly true editor_
+          -- Setup editor functionality (keydown listeners, Ace editor stuff, etc.)
+          let
+            onSave :: Effect Unit
+            onSave = HS.notify listener (Save false)
 
-        -- Setup ResizeObserver for the container element
-        let
-          callback _ _ = do
-            -- Get the current width directly from the element
-            width <- offsetWidth el
-            HS.notify listener (HandleResize width)
+          H.modify_ _
+            { mListener = Just listener
+            , mResizeSubscriptionId = Just subscription
+            }
 
-        observer <- H.liftEffect $ resizeObserver callback
-        H.liftEffect $ observe (toElement el) {} observer
-        H.modify_ _ { mResizeObserver = Just observer }
+          H.liftEffect $ do
+            eventListen <- eventListener (keyBinding onSave editor_)
+            container <- Editor.getContainer editor_
+            addEventListener keydown eventListen true
+              (toEventTarget $ toElement container)
+
+            -- Set the editor's theme and mode
+            Editor.setEnableLiveAutocompletion true editor_
+
+          -- Setup ResizeObserver for the container element
+          let
+            callback _ _ = do
+              -- Get the current width directly from the element
+              width <- offsetWidth el
+              HS.notify listener (HandleResize width)
+
+          observer <- H.liftEffect $ resizeObserver callback
+          H.liftEffect $ observe (toElement el) {} observer
+          H.modify_ _ { mResizeObserver = Just observer }
+
+          -- New Ref for keeping track, if the content in editor has changed
+          -- 1. since last save
+          -- 2. since opening version
+          dirtyRef <- H.liftEffect $ Ref.new false
+          isOnMergeRef <- H.liftEffect $ Ref.new false
+          versionRef <- H.liftEffect $ Ref.new false
+          H.modify_ _ { mDirtyVersion = Just versionRef }
+
+          -- create eventListener for preventing the tab from closing
+          -- when content has not been saved (Not changing through Navbar)
+          addBeforeUnloadListener dirtyRef isOnMergeRef listener
+
+          -- add and start Editor listeners
+          H.liftEffect $ addChangeListenerWithRef editor_ dirtyRef versionRef listener
+          container <- H.liftEffect $ Editor.getContainer editor_
+          H.liftEffect $ addMouseDragListeners container listener
 
       -- If a comparison element is loaded, also load the current content in the primary editor
-      compareTo <- H.gets _.compareToElement
-      case compareTo of
+      case compareToElement of
         Nothing -> pure unit
         Just { tocEntry: tocEntry, revID: revID } -> handleAction
-          (ChangeToSection tocEntry revID Nothing)
-
-      -- New Ref for keeping track, if the content in editor has changed
-      -- 1. since last save
-      -- 2. since opening version
-      dirtyRef <- H.liftEffect $ Ref.new false
-      isOnMergeRef <- H.liftEffect $ Ref.new false
-      versionRef <- H.liftEffect $ Ref.new false
-      H.modify_ _ { mDirtyVersion = Just versionRef }
-
-      -- create eventListener for preventing the tab from closing
-      -- when content has not been saved (Not changing through Navbar)
-      addBeforeUnloadListener dirtyRef isOnMergeRef listener
-
-      -- add and start Editor listeners
-      H.gets _.mEditor >>= traverse_ \ed -> do
-        H.liftEffect $ addChangeListenerWithRef ed dirtyRef versionRef listener
-        container <- H.liftEffect $ Editor.getContainer ed
-        H.liftEffect $ addMouseDragListeners container listener
+          (ChangeToSection tocEntry revID Nothing false)
 
     DoNothing -> do
       pure unit
@@ -968,10 +964,6 @@ editor = connect selectTranslator $ H.mkComponent
         -- not updating the received comment anchors, as we send those same anchors to backend
         Right { content: updatedContent, typ: typ, html } -> do
 
-          H.modify_ _ { mContent = Just updatedContent, html = html }
-          H.raise $ ClickedQuery html
-          H.raise UpdateFullTitle
-
           -- Show saved icon or toast
           case isAutoSave, state.isEditorOutdated of
             -- auto save interaction
@@ -990,36 +982,45 @@ editor = connect selectTranslator $ H.mkComponent
                 (translate (label :: _ "editor_save_success") state.translator)
               case typ of
                 "noConflict" -> do
-                  setIsOnMerge false
+                  --setIsOnMerge false
                   case state.isOnMerge of
                     false -> pure unit
                     true -> H.raise Merged
                   pure unit
                 "draftCreated" -> --should not happen here. just copy autosave case in case
-
-                  setIsOnMerge true
+                  pure unit
+                  --setIsOnMerge true
                 "conflict" -> do --raise something to update version
                   setIsOnMerge true
-                  H.raise RaiseMergeMode
+                  H.raise $ RaiseMergeMode $ ContentDto.getContentText $ ContentDto.getWrapperContent newWrapper
+                  handleAction $ ChangeToSection newEntry Nothing state.mTitle true
                 _ -> pure unit
             -- manuell saving, draft mode => publish
             false, true -> do
               case typ of
                 --happends if parent was updated due to merge view being present.
                 "noConflict" -> do
-                  setIsOnMerge false
+                  --setIsOnMerge false
                   case state.isOnMerge of
                     false -> pure unit
                     true -> H.raise Merged
                   pure unit
                 "draftCreated" -> --should not happen here. just copy autosave case in case
-
-                  setIsOnMerge true
+                  pure unit
+                  --setIsOnMerge true
                 "conflict" -> do --raise something to update version
                   setIsOnMerge true
-                  H.raise RaiseMergeMode
+                  H.raise $ RaiseMergeMode $ ContentDto.getContentText $ ContentDto.getWrapperContent newWrapper
+                  handleAction $ ChangeToSection newEntry Nothing state.mTitle true
                   pure unit
                 _ -> pure unit
+
+          when (typ /= "conflict" ) do
+            H.modify_ _ { mContent = Just updatedContent, html = html }
+            H.raise UpdateFullTitle
+            isOnMerge' <- H.gets _.isOnMerge
+            when (not isOnMerge') $
+              H.raise $ ClickedQuery html
 
           pure unit
 
@@ -1566,14 +1567,14 @@ editor = connect selectTranslator $ H.mkComponent
       for_ state.saveState.mPendingDebounceF H.kill
       for_ state.saveState.mPendingMaxWaitF H.kill
 
-    ChangeToSection entry rev mTitle -> do
+    ChangeToSection entry rev mTitle isOnMerge -> do
       state <- H.get
       let
         version = case rev of
           Nothing -> "latest"
           Just v -> show v
       -- Prevent of loading the same Section from backend again
-      when (Just entry /= state.mTocEntry || version /= state.currentVersion) do
+      when (map _.id state.mTocEntry /= Just entry.id || version /= state.currentVersion || state.loadedIsOnMerge /= isOnMerge) do
         -- Get the content from server here
         -- We need Aff for that and thus cannot go inside Eff
         -- TODO: After creating a new Leaf, we get Nothing in loadedContent
@@ -1582,26 +1583,29 @@ editor = connect selectTranslator $ H.mkComponent
         H.modify_ _ { isLoading = true }
 
         --first we look whether a draft to load is present. The right editor does not load drafts
-        loadedDraftContent <- case state.compareToElement of
-          Nothing ->
+        loadedDraftContent <- case state.compareToElement, isOnMerge of
+          Nothing, false ->
             preventErrorHandlingLocally $ Request.getJson
               ContentDto.decodeContentWrapper
               ( "/docs/" <> show state.docID <> "/text/" <> show entry.id
                   <> "/draft"
               )
-          Just _ -> pure $ Left $ NotFoundError "No Draft Found"
+          _ , _ -> pure $ Left $ NotFoundError "No Draft Found"
+        
+        let 
+          draftLoaded = case loadedDraftContent of
+            Right _ -> true
+            Left _ -> false
 
         -- check, if draft is present. Otherwise get from version
         loadedContent <- case loadedDraftContent of
           Right res -> do
-            H.modify_ _
-              { isEditorOutdated = true
-              }
+            -- H.modify_ _
+            --   { isEditorOutdated = true
+            --   }
             pure (Right res)
           Left _ -> do
-            H.modify_ _
-              { isEditorOutdated = false
-              }
+            -- H.modify_ _ { isEditorOutdated = isOnMerge }
             Request.getJson
               ContentDto.decodeContentWrapper
               ( "/docs/" <> show state.docID <> "/text/" <> show entry.id
@@ -1624,9 +1628,9 @@ editor = connect selectTranslator $ H.mkComponent
               , mTitle = mTitle
               , mContent = Just content
               , html = html
-              , isOnMerge = false
+              , loadedIsOnMerge = isOnMerge
               }
-            for_ state.saveState.mIsOnMergeRef \r -> H.liftEffect $ Ref.write false r
+            setIsOnMerge isOnMerge
 
             -- Only secondary Editor has ElementData
             -- Only first Editor gets to load the comments
@@ -1647,7 +1651,7 @@ editor = connect selectTranslator $ H.mkComponent
                     , oldMarkerAnnoPos = empty
                     , markers = markers
                     }
-                , isEditorOutdated = version /= "latest"
+                , isEditorOutdated = version /= "latest" || isOnMerge || draftLoaded
                 }
               -- Get comments information from Comment Child
               H.raise (RequestComments state.docID entry.id markerIDs)
@@ -1661,35 +1665,34 @@ editor = connect selectTranslator $ H.mkComponent
     -- After getting information from from Comment
     ContinueChangeToSection fCs showHtml commentProblem -> do
       state <- H.get
-      case state.mListener of
-        Nothing -> pure unit
-        Just listener -> do
-          -- Put the content of the section into the editor and update markers
-          H.gets _.mEditor >>= traverse_ \ed -> do
-            let
-              commentState = state.commentState
-              filMarkers = updateMarkers fCs commentState.markers
-              content = case state.mContent of
-                Nothing -> ""
-                Just c -> ContentDto.getContentText c
-            handleAction Resize
-            newLiveMarkers <- H.liftEffect do
-              session <- Editor.getSession ed
-              document <- Session.getDocument session
+      -- Put the content of the section into the editor and update markers
+      H.gets _.mEditor >>= traverse_ \ed -> do
+        let
+          commentState = state.commentState
+          filMarkers = updateMarkers fCs commentState.markers
+          content = case state.mContent of
+            Nothing -> ""
+            Just c -> ContentDto.getContentText c
+        handleAction Resize
+        newLiveMarkers <- H.liftEffect do
+          session <- Editor.getSession ed
+          document <- Session.getDocument session
 
-              -- Set the content of the editor
-              Document.setValue content
-                document
-              Editor.setReadOnly (state.compareToElement /= Nothing) ed
+          -- Set the content of the editor
+          Document.setValue content document
+          Editor.setReadOnly (state.compareToElement /= Nothing) ed
 
-              -- reset Ref, because loading new content is considered
-              -- changing the existing content, which would set the flag
-              for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
+          -- reset Ref, because loading new content is considered
+          -- changing the existing content, which would set the flag
+          for_ state.saveState.mDirtyRef \r -> Ref.write false r
 
-              -- Reset Undo history
-              undoMgr <- Session.getUndoManager session
-              UndoMgr.reset undoMgr
+          -- Reset Undo history
+          undoMgr <- Session.getUndoManager session
+          UndoMgr.reset undoMgr
 
+          case state.mListener of
+            Nothing -> pure []
+            Just listener -> do
               -- Remove existing markers
               for_ commentState.liveMarkers \lm -> do
                 removeLiveMarker lm session
@@ -1703,24 +1706,26 @@ editor = connect selectTranslator $ H.mkComponent
 
               pure (catMaybes tmp)
 
-            -- Update state with new marker IDs
-            mDeb <- H.gets _.saveState.mPendingDebounceF
-            traverse_ H.kill mDeb
-            mMax <- H.gets _.saveState.mPendingMaxWaitF
-            traverse_ H.kill mMax
-            H.modify_ \st -> st
-              { commentState = st.commentState
-                  { liveMarkers = newLiveMarkers, commentProblem = commentProblem }
-              , saveState = st.saveState
-                  { mPendingDebounceF = Nothing
-                  , mPendingMaxWaitF = Nothing
-                  , isManualSaved = true
-                  }
-              , isLoading = false
+        -- Update state with new marker IDs
+        when (state.compareToElement == Nothing) do
+          mDeb <- H.gets _.saveState.mPendingDebounceF
+          traverse_ H.kill mDeb
+          mMax <- H.gets _.saveState.mPendingMaxWaitF
+          traverse_ H.kill mMax
+        H.modify_ \st -> st
+          { commentState = st.commentState
+              { liveMarkers = newLiveMarkers, commentProblem = commentProblem }
+          , saveState = st.saveState
+              { mPendingDebounceF = Nothing
+              , mPendingMaxWaitF = Nothing
+              , isManualSaved = true
               }
-            -- lastly show html in preview
-            when showHtml $ do
-              H.raise $ ClickedQuery state.html
+          , isLoading = false
+          }
+        -- lastly show html in preview
+        when (showHtml && not state.isOnMerge) $ do
+          html' <- H.gets _.html
+          H.raise $ ClickedQuery html'
 
   -- convert Hashmap to Annotations and show them
   -- H.liftEffect $ setAnnotations commentState.markerAnnoHS state.mEditor
@@ -1745,7 +1750,7 @@ editor = connect selectTranslator $ H.mkComponent
       pure (Just a)
 
     ChangeSection entry rev mTitle a -> do
-      handleAction (ChangeToSection entry rev mTitle)
+      handleAction (ChangeToSection entry rev mTitle false)
       pure (Just a)
 
     ContinueChangeSection fCs commentProblem a -> do
@@ -1895,7 +1900,7 @@ editor = connect selectTranslator $ H.mkComponent
           H.liftEffect $ setMarkerSelectedClass session lm false
         _, _ -> pure unit
       H.modify_ \st -> st
-        { commentState { selectedLiveMarker = Nothing, reAnchor = Nothing } }
+        { commentState = st.commentState { selectedLiveMarker = Nothing, reAnchor = Nothing } }
       pure (Just a)
 
     ToDeleteComment commentProblem a -> do
@@ -1962,6 +1967,24 @@ editor = connect selectTranslator $ H.mkComponent
     SetReAnchor reAnchor a -> do
       H.modify_ \st -> st { commentState = st.commentState { reAnchor = reAnchor } }
       pure (Just a)
+    
+    -- Only used to send draft from main to 2. Editor
+    SetContent draft a -> do
+      state <- H.get
+      H.gets _.mEditor >>= traverse_ \ed -> do
+        handleAction Resize
+        H.liftEffect do
+          session <- Editor.getSession ed
+          document <- Session.getDocument session
+          Document.setValue draft document
+          Editor.setReadOnly true ed
+          -- not sure if necessary. Just to be sure
+          for_ state.saveState.mDirtyRef \r -> H.liftEffect $ Ref.write false r
+          -- Reset Undo history
+          undoMgr <- Session.getUndoManager session
+          UndoMgr.reset undoMgr
+      H.modify_ _ {isLoading = false}
+      pure (Just a)
 
   -- free up the save flags for the next save session
   -- check if there are new requests for saving during saving
@@ -1988,6 +2011,25 @@ editor = connect selectTranslator $ H.mkComponent
     H.modify_ _ { isOnMerge = flag }
     mRef <- H.gets _.saveState.mIsOnMergeRef
     for_ mRef \r -> H.liftEffect $ Ref.write flag r
+
+  setupAce :: Types.Editor -> Int -> Effect Unit
+  setupAce editor_ fontSize = do
+    Editor.setFontSize (show fontSize <> "px") editor_
+    session <- Editor.getSession editor_
+
+    -- Set line break
+    Editor.resize (Just true) editor_
+    Session.setUseWrapMode true session
+
+    -- remove the gray margin line
+    Editor.setShowPrintMargin false editor_
+
+    -- Set the editor's theme and mode
+    Editor.setTheme "ace/theme/github" editor_
+    Session.setMode "ace/mode/custom_mode" session
+
+    -- set read only at the start to prevent users to write in not selected entry
+    Editor.setReadOnly true editor_
 
 -- | Change listener for the editor.
 --
@@ -2149,6 +2191,7 @@ initialState { context, input } =
   , discardPopup: false
   , mDirtyVersion: Nothing
   , isOnMerge: false
+  , loadedIsOnMerge: false
   , upToDateVersion: Nothing
   , isLoading: true
   }

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1086,9 +1086,9 @@ splitview = connect selectTranslator $ H.mkComponent
                 --   Nothing -> emptyTOCEntry
                 --   Just e -> e
                 --handleAction (SetComparison id Nothing)
-              -- mmTitle <- H.request _toc unit TOC.RequestFullTitle
-              -- H.tell _editor 1
-              --   (Editor.ChangeSection entry version.identifier (join mmTitle))
+                -- mmTitle <- H.request _toc unit TOC.RequestFullTitle
+                -- H.tell _editor 1
+                --   (Editor.ChangeSection entry version.identifier (join mmTitle))
                 H.tell _editor 1 (Editor.SetContent draft)
               _ -> pure unit
           _ -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1080,15 +1080,7 @@ splitview = connect selectTranslator $ H.mkComponent
                           )
                       )
                   )
-                -- let
-                -- Nothing case should never occur
-                -- entry = case (findTOCEntry id state.tocEntries) of
-                --   Nothing -> emptyTOCEntry
-                --   Just e -> e
                 --handleAction (SetComparison id Nothing)
-                -- mmTitle <- H.request _toc unit TOC.RequestFullTitle
-                -- H.tell _editor 1
-                --   (Editor.ChangeSection entry version.identifier (join mmTitle))
                 H.tell _editor 1 (Editor.SetContent draft)
               _ -> pure unit
           _ -> do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1052,7 +1052,7 @@ splitview = connect selectTranslator $ H.mkComponent
           _ -> do
             pure unit
 
-      Editor.RaiseMergeMode -> do
+      Editor.RaiseMergeMode draft -> do
         handleAction UpdateMSelectedTocEntry
         state <- H.get
         upToDateVersion <- H.request _toc unit TOC.RequestUpToDateVersion
@@ -1085,10 +1085,11 @@ splitview = connect selectTranslator $ H.mkComponent
                 -- entry = case (findTOCEntry id state.tocEntries) of
                 --   Nothing -> emptyTOCEntry
                 --   Just e -> e
-                handleAction (SetComparison id Nothing)
+                --handleAction (SetComparison id Nothing)
               -- mmTitle <- H.request _toc unit TOC.RequestFullTitle
               -- H.tell _editor 1
               --   (Editor.ChangeSection entry version.identifier (join mmTitle))
+                H.tell _editor 1 (Editor.SetContent draft)
               _ -> pure unit
           _ -> do
             pure unit


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `Editor` component in the FPO frontend, focusing on merge mode handling, section switching, and editor initialization. The changes enhance the robustness of merge state management, improve how section changes are triggered and handled, and refactor editor setup code for clarity and reuse.

**Key changes include:**

**Merge Mode and Section Switching Improvements:**
- Added a new `loadedIsOnMerge` field to the editor state to better track the previous merge state, and updated logic to prevent unnecessary reloads when switching sections if the merge state hasn't changed. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR206-R207) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1569-R1586)
- Modified the `ChangeToSection` action to include an explicit `isOnMerge` parameter, and updated all usages and section change logic to account for this. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL233-R235) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL748-R748) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1569-R1586)
- Improved merge conflict handling: now, when a conflict is detected, the editor raises `RaiseMergeMode` with the relevant content and triggers a section change with `isOnMerge` set, ensuring the editor state and UI remain consistent during merges. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL222-R224) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL993-R1029)

**Editor Initialization and Refactoring:**
- Refactored the editor initialization (`Init` action) to extract Ace editor setup into a new `setupAce` function, improving code clarity and reusability. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR680-R691) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR2026-R2044)
- Adjusted initialization logic to only subscribe to resize events and load content if a comparison element is not present, preventing redundant setup steps. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL685-L715) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL728-L734)

**Draft and Content Loading Logic:**
- Updated draft loading logic to only attempt to load drafts when not in comparison or merge mode, and to track whether a draft was loaded for more accurate editor state. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1585-R1617) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1650-R1663)
- Added a new `SetContent` query to directly set editor content (used for sending drafts between editors), including resetting undo history and dirty flags. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR298) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1982-R1999)

**UI/UX and State Management Tweaks:**
- Improved the comment toolbar button to only enable full features when the current version is "latest".
- Adjusted logic for when to show HTML previews and update the full title, ensuring these only occur outside of merge mode or when appropriate. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL971-L974) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1722-R1737)
- Fixed state mutation patterns for comment state updates to ensure immutability and correct updates.

**Other Minor Fixes:**
- Improved handling of editor listeners and state resets when switching sections or continuing changes. [[1]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1664-L1666) [[2]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fL1681-R1704) [[3]](diffhunk://#diff-b1033cde598c1d48515977d554aa10602abb5837f98977771a59f57c5a221e1fR1719)
- Updated the initial state to include the new `loadedIsOnMerge` field.