### PR TITLE
PDF downloads correct revision

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -948,9 +948,10 @@ splitview = connect selectTranslator $ H.mkComponent
       Editor.PostPDF _ -> do
         state <- H.get
         upToDateVersion <- H.request _toc unit TOC.RequestUpToDateVersion
+        currentTocEntry <- H.request _toc unit TOC.RequestCurrentTocEntry
         let
           textElementId :: Int
-          textElementId = case state.mSelectedTocEntry of
+          textElementId = case join currentTocEntry of
             Just (SelLeaf id) -> id
             _ -> -1
 


### PR DESCRIPTION
Fixes #787 

This pull request updates the logic for determining the selected text element in the split view editor. Instead of using the potentially outdated `mSelectedTocEntry` from the local state, it now queries the current TOC entry directly from the TOC component, ensuring the editor always reflects the most recent selection.

- Editor selection logic improvement:
  * In `frontend/src/FPO/Components/Splitview.purs`, the code now requests the current TOC entry via `TOC.RequestCurrentTocEntry` and uses it to determine the `textElementId`, replacing the previous use of `state.mSelectedTocEntry`. This ensures that the selected element is always up to date with the TOC component.