### PR TITLE
Solve resize bug

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -89,7 +89,7 @@ import Simple.I18n.Translator (label, translate)
 import Type.Proxy (Proxy(Proxy))
 import Web.DOM.Document as Document
 import Web.DOM.Element as Element
-import Web.Event.Event (EventType(..), stopPropagation)
+import Web.Event.Event (EventType(..), preventDefault, stopPropagation)
 import Web.File.Url (createObjectURL, revokeObjectURL)
 import Web.HTML (window)
 import Web.HTML as Web.HTML
@@ -99,6 +99,7 @@ import Web.HTML.Window (document)
 import Web.HTML.Window as Web.HTML.Window
 import Web.ResizeObserver (ResizeObserver, disconnect, observe, resizeObserver)
 import Web.UIEvent.MouseEvent (MouseEvent, clientX)
+import Web.UIEvent.MouseEvent as MouseEvent
 
 data DragTarget = LeftResizer | RightResizer
 
@@ -278,6 +279,12 @@ splitview = connect selectTranslator $ H.mkComponent
       contentWidth = state.resizeState.windowWidth - resizersTotalWidth
       ratioScaleFactor = contentWidth / state.resizeState.windowWidth
       absoluteEditorRatio = state.resizeState.editorRatio * ratioScaleFactor
+      isDragging = state.mDragTarget /= Nothing
+      dragStyle =
+        if isDragging then
+          "user-select: none; -webkit-user-select: none;"
+        else
+          ""
     -- toolbarHeight :: Int
     -- toolbarHeight = 31 -- px, height of the toolbar
     in
@@ -288,7 +295,7 @@ splitview = connect selectTranslator $ H.mkComponent
         , HP.classes [ HB.dFlex, HB.overflowHidden ]
         , HP.style
             ( "height: calc(100vh - " <> show navbarHeight <>
-                "px); max-height: 100%; min-height: 0;"
+                "px); max-height: 100%; min-height: 0;" <> dragStyle
             )
         , HP.ref (H.RefLabel "splitview")
         ]
@@ -679,6 +686,7 @@ splitview = connect selectTranslator $ H.mkComponent
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
     StartResize dragTarget mouseEvent -> do
+      H.liftEffect $ preventDefault (MouseEvent.toEvent mouseEvent)
       H.modify_ \st -> st
         { mDragTarget = Just dragTarget
         , mStartResizeState = Just st.resizeState

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -686,12 +686,20 @@ splitview = connect selectTranslator $ H.mkComponent
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
     StartResize dragTarget mouseEvent -> do
-      H.liftEffect $ preventDefault (MouseEvent.toEvent mouseEvent)
-      H.modify_ \st -> st
-        { mDragTarget = Just dragTarget
-        , mStartResizeState = Just st.resizeState
-        }
-      handleAction $ HandleMouseMove mouseEvent
+      startResizing <- case dragTarget of
+        LeftResizer -> do
+          sidebarClosed <- H.gets _.resizeState.sidebarClosed
+          pure $ not sidebarClosed
+        RightResizer -> do
+          previewClosed <- H.gets _.resizeState.previewClosed
+          pure $ not previewClosed
+      when startResizing $ do
+        H.liftEffect $ preventDefault (MouseEvent.toEvent mouseEvent)
+        H.modify_ \st -> st
+          { mDragTarget = Just dragTarget
+          , mStartResizeState = Just st.resizeState
+          }
+        handleAction $ HandleMouseMove mouseEvent
 
     -- Stop resizing, when mouse is released (is detected by browser)
     -- the parameter cannot be deleted here because there is always a MouseEvent present, we just don't need it here

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -294,8 +294,9 @@ splitview = connect selectTranslator $ H.mkComponent
         , HE.onMouseLeave StopResize
         , HP.classes [ HB.dFlex, HB.overflowHidden ]
         , HP.style
-            ( "height: calc(100vh - " <> show navbarHeight <>
-                "px); max-height: 100%; min-height: 0;" <> dragStyle
+            ( "height: calc(100vh - " <> show navbarHeight
+                <> "px); max-height: 100%; min-height: 0;"
+                <> dragStyle
             )
         , HP.ref (H.RefLabel "splitview")
         ]
@@ -686,20 +687,12 @@ splitview = connect selectTranslator $ H.mkComponent
     -- Resizing as long as mouse is hold down on window
     -- (Or until the browser detects the mouse is released)
     StartResize dragTarget mouseEvent -> do
-      startResizing <- case dragTarget of
-        LeftResizer -> do
-          sidebarClosed <- H.gets _.resizeState.sidebarClosed
-          pure $ not sidebarClosed
-        RightResizer -> do
-          previewClosed <- H.gets _.resizeState.previewClosed
-          pure $ not previewClosed
-      when startResizing $ do
-        H.liftEffect $ preventDefault (MouseEvent.toEvent mouseEvent)
-        H.modify_ \st -> st
-          { mDragTarget = Just dragTarget
-          , mStartResizeState = Just st.resizeState
-          }
-        handleAction $ HandleMouseMove mouseEvent
+      H.liftEffect $ preventDefault (MouseEvent.toEvent mouseEvent)
+      H.modify_ \st -> st
+        { mDragTarget = Just dragTarget
+        , mStartResizeState = Just st.resizeState
+        }
+      handleAction $ HandleMouseMove mouseEvent
 
     -- Stop resizing, when mouse is released (is detected by browser)
     -- the parameter cannot be deleted here because there is always a MouseEvent present, we just don't need it here

--- a/frontend/src/FPO/UI/Resizing.purs
+++ b/frontend/src/FPO/UI/Resizing.purs
@@ -198,7 +198,8 @@ resizeFromRight
           else
             resizeState
               { sidebarRatio = 0.0
-              , editorRatio = resizeState.sidebarRatio + resizeState.editorRatio
+              , previewRatio = previewRatio
+              , editorRatio = 1.0 - previewRatio
               , sidebarClosed = true
               -- Save current sidebar ratio before closing (for later restoration)
               , lastExpandedSidebarRatio = resizeState.sidebarRatio
@@ -241,7 +242,8 @@ resizeFromRight
         else
           resizeState
             { sidebarRatio = 0.0
-            , editorRatio = resizeState.sidebarRatio + resizeState.editorRatio
+            , previewRatio = previewRatio
+            , editorRatio = 1.0 - previewRatio
             , sidebarClosed = true
             -- Save current sidebar ratio before closing (for later restoration)
             , lastExpandedSidebarRatio = resizeState.sidebarRatio

--- a/frontend/src/FPO/UI/Resizing.purs
+++ b/frontend/src/FPO/UI/Resizing.purs
@@ -64,9 +64,49 @@ resizeFromLeft
     previewWidth = contentWidth * resizeState.previewRatio
     editorWidth = contentWidth * resizeState.editorRatio
     sidebarWidth = contentWidth * resizeState.sidebarRatio
+    openSidebarThreshold = 0.05
+    closeSidebarThreshold = 0.05
+    sidebarRatio = mousePxFromLeft / contentWidth
   in
+    if resizeState.sidebarClosed then
+      if mousePercentFromLeft < openSidebarThreshold then
+        resizeState
+      else if
+        mousePxFromLeft <= sidebarWidth
+          -- resizing to the left but not close enough to hide sidebar
+          || (mousePxFromLeft >= sidebarWidth) &&
+            ( editorWidth - (mousePxFromLeft - sidebarWidth - resizerWidth) >=
+                previewWidth
+            )
+      -- OR resizing to the left but preview still bigger than editor
+      then
+        resizeState
+          { sidebarRatio = sidebarRatio
+          , editorRatio = sidebarAndEditor - sidebarRatio
+          , sidebarClosed = false
+          }
+      -- resizing to the right and preview bigger than editor
+      else
+        let
+          newEditorAndPreview = (1.0 - sidebarRatio) / 2.0
+        in
+          if newEditorAndPreview >= minPanelSize then
+            resizeState
+              { sidebarRatio = sidebarRatio
+              , editorRatio = newEditorAndPreview
+              , previewRatio = newEditorAndPreview
+              , sidebarClosed = false
+              }
+          else
+            resizeState
+              { sidebarRatio = sidebarRatio
+              , editorRatio = 1.0 - sidebarRatio
+              , previewRatio = 0.0
+              , previewClosed = true
+              , sidebarClosed = false
+              }
     -- Close sidebar when dragging close enough to left edge (< 5%)
-    if mousePercentFromLeft <= 0.05 then
+    else if mousePercentFromLeft < closeSidebarThreshold then
       resizeState
         { sidebarRatio = 0.0
         , editorRatio = sidebarAndEditor
@@ -83,17 +123,13 @@ resizeFromLeft
           )
     -- OR resizing to the left but preview still bigger than editor
     then
-      let
-        sidebarRatio = mousePxFromLeft / contentWidth
-      in
-        resizeState
-          { sidebarRatio = sidebarRatio
-          , editorRatio = sidebarAndEditor - sidebarRatio
-          }
+      resizeState
+        { sidebarRatio = sidebarRatio
+        , editorRatio = sidebarAndEditor - sidebarRatio
+        }
     -- resizing to the right and preview bigger than editor
     else
       let
-        sidebarRatio = mousePxFromLeft / contentWidth
         newEditorAndPreview = (1.0 - sidebarRatio) / 2.0
       in
         if newEditorAndPreview >= minPanelSize then
@@ -124,9 +160,52 @@ resizeFromRight
     editorWidth = contentWidth * resizeState.editorRatio
     previewWidth = contentWidth * resizeState.previewRatio
     mousePercentFromRight = mousePxFromRight / resizeState.windowWidth
+    openPreviewThreshold = 0.05
+    closePreviewThreshold = 0.10
+    minPreviewRatio = 0.10
+    previewRatio = max minPreviewRatio (mousePxFromRight / contentWidth)
   in
+    if resizeState.previewClosed then
+      if mousePercentFromRight < openPreviewThreshold then
+        resizeState
+      else if
+        mousePxFromRight <= previewWidth
+          -- resizing to the right but not close enough to hide preview
+          || (mousePxFromRight >= previewWidth) &&
+            ( editorWidth - (mousePxFromRight - previewWidth - resizerWidth) >=
+                sidebarWidth
+            )
+      -- OR resizing to the right but sidebar still bigger than editor
+      then
+        resizeState
+          { previewRatio = previewRatio
+          , editorRatio = previewAndEditor - previewRatio
+          , previewClosed = false
+          }
+      -- Hide sidebar when dragging close to left edge (5%)
+      else
+        let
+          newEditorAndSidebar = (1.0 - previewRatio) / 2.0
+        in
+          -- resizing to the left and sidebar bigger than editor - make them equal
+          if newEditorAndSidebar > minSidebarSizeBeforeClosing then
+            resizeState
+              { previewRatio = previewRatio
+              , editorRatio = newEditorAndSidebar
+              , sidebarRatio = newEditorAndSidebar
+              , previewClosed = false
+              }
+          else
+            resizeState
+              { sidebarRatio = 0.0
+              , editorRatio = resizeState.sidebarRatio + resizeState.editorRatio
+              , sidebarClosed = true
+              -- Save current sidebar ratio before closing (for later restoration)
+              , lastExpandedSidebarRatio = resizeState.sidebarRatio
+              , previewClosed = false
+              }
     -- Hide preview when dragging close to right edge (< 10%)
-    if mousePercentFromRight <= 0.10 then
+    else if mousePercentFromRight < closePreviewThreshold then
       resizeState
         { previewRatio = 0.0
         , editorRatio = previewAndEditor
@@ -143,17 +222,13 @@ resizeFromRight
           )
     -- OR resizing to the right but sidebar still bigger than editor
     then
-      let
-        previewRatio = mousePxFromRight / contentWidth
-      in
-        resizeState
-          { previewRatio = previewRatio
-          , editorRatio = previewAndEditor - previewRatio
-          }
+      resizeState
+        { previewRatio = previewRatio
+        , editorRatio = previewAndEditor - previewRatio
+        }
     -- Hide sidebar when dragging close to left edge (5%)
     else
       let
-        previewRatio = mousePxFromRight / contentWidth
         newEditorAndSidebar = (1.0 - previewRatio) / 2.0
       in
         -- resizing to the left and sidebar bigger than editor - make them equal

--- a/frontend/test/Test/UI/Resizing.purs
+++ b/frontend/test/Test/UI/Resizing.purs
@@ -41,6 +41,31 @@ resizeFromLeftTest =
 
       sidebarRatio `shouldBeNear` 0.12
 
+    it "keeps sidebar closed when dragging less than 5% while closed" do
+      let
+        mousePxFromLeft = 4.0
+        { sidebarClosed, sidebarRatio } = resizeFromLeft
+          ( defaultResizeState
+              { sidebarClosed = true, sidebarRatio = 0.0, editorRatio = 0.6 }
+          )
+          mousePxFromLeft
+
+      sidebarClosed `shouldEqual` true
+      sidebarRatio `shouldBeNear` 0.0
+
+    it "opens sidebar when dragging past 5% while closed" do
+      let
+        mousePxFromLeft = 6.0
+        { sidebarClosed, sidebarRatio, editorRatio } = resizeFromLeft
+          ( defaultResizeState
+              { sidebarClosed = true, sidebarRatio = 0.0, editorRatio = 0.6 }
+          )
+          mousePxFromLeft
+
+      sidebarClosed `shouldEqual` false
+      sidebarRatio `shouldBeNear` 0.06
+      editorRatio `shouldBeNear` 0.54
+
     it "makes sidebar ratio 0 when dragging to the left closer than 5%" do
       let mousePxFromLeft = 4.887
 
@@ -128,6 +153,31 @@ resizeFromRightTest =
       let { previewRatio } = resizeFromRight defaultResizeState mousePxFromRight
 
       previewRatio `shouldBeNear` 0.12
+
+    it "keeps preview closed when dragging less than 5% while closed" do
+      let
+        mousePxFromRight = 4.0
+        { previewClosed, previewRatio } = resizeFromRight
+          ( defaultResizeState
+              { previewClosed = true, previewRatio = 0.0, editorRatio = 0.6 }
+          )
+          mousePxFromRight
+
+      previewClosed `shouldEqual` true
+      previewRatio `shouldBeNear` 0.0
+
+    it "opens preview to 10% when dragging past 5% while closed" do
+      let
+        mousePxFromRight = 6.0
+        { previewClosed, previewRatio, editorRatio } = resizeFromRight
+          ( defaultResizeState
+              { previewClosed = true, previewRatio = 0.0, editorRatio = 0.6 }
+          )
+          mousePxFromRight
+
+      previewClosed `shouldEqual` false
+      previewRatio `shouldBeNear` 0.10
+      editorRatio `shouldBeNear` 0.50
 
     it "makes preview ratio 0 when dragging to the right closer than 10%" do
       let mousePxFromRight = 9.887

--- a/frontend/test/Test/UI/Resizing.purs
+++ b/frontend/test/Test/UI/Resizing.purs
@@ -179,6 +179,22 @@ resizeFromRightTest =
       previewRatio `shouldBeNear` 0.10
       editorRatio `shouldBeNear` 0.50
 
+    it "closes sidebar and opens preview when dragging far left while closed" do
+      let
+        mousePxFromRight = 90.0
+        { sidebarClosed, sidebarRatio, previewClosed, previewRatio, editorRatio } =
+          resizeFromRight
+            ( defaultResizeState
+                { previewClosed = true, previewRatio = 0.0, editorRatio = 0.6 }
+            )
+            mousePxFromRight
+
+      sidebarClosed `shouldEqual` true
+      previewClosed `shouldEqual` false
+      sidebarRatio `shouldBeNear` 0.0
+      previewRatio `shouldBeNear` 0.9
+      editorRatio `shouldBeNear` 0.1
+
     it "makes preview ratio 0 when dragging to the right closer than 10%" do
       let mousePxFromRight = 9.887
 


### PR DESCRIPTION
This pull request improves the drag-to-resize behavior and user experience of the split view panels (sidebar and preview) in the UI, making the opening and closing of panels more intuitive and robust. It also updates the associated tests to cover these new behaviors. The most important changes are grouped below.

### Splitview Drag Behavior and UX Improvements

* Added logic to prevent text selection while dragging by dynamically applying a `user-select: none` style when a drag is in progress (`splitview` in `Splitview.purs`). [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR282-R287) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL290-R299)
* Ensured that `preventDefault` is called on the mouse event when starting a resize to avoid unwanted browser behaviors (`splitview` in `Splitview.purs`).

### Sidebar and Preview Panel Resizing Logic

* Refined the logic for reopening and closing the sidebar and preview panels:
  - Panels now only reopen when dragged past a threshold (5% for sidebar, 5% for preview), and remain closed if dragged less than this.
  - When reopening, sidebar and preview ratios are set to minimum sensible values (e.g., preview opens to at least 10%).
  - Improved the logic for distributing space among panels when reopening or closing, ensuring consistent and predictable behavior. (`resizeFromLeft` and `resizeFromRight` in `Resizing.purs`). [[1]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eR67-R109) [[2]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eL86-L96) [[3]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eR163-R208) [[4]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eL146-L156)

### Test Coverage

* Added tests to verify that panels remain closed when dragged less than the open threshold, and that they open with correct ratios when dragged past the threshold (`resizeFromLeftTest` and `resizeFromRightTest` in `Resizing.purs`). [[1]](diffhunk://#diff-9d33d5b051c054fee8d78326062df1311416be248bf4c918c83e439e58fc3df0R44-R68) [[2]](diffhunk://#diff-9d33d5b051c054fee8d78326062df1311416be248bf4c918c83e439e58fc3df0R157-R181)

### Code Quality

* Refactored repeated calculations and clarified threshold constants for opening/closing panels, improving readability and maintainability (`resizeFromLeft` and `resizeFromRight` in `Resizing.purs`). [[1]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eR67-R109) [[2]](diffhunk://#diff-a123b63cb4562e5da443a73e330b7283fd071196a68acc409e492e4c8abadf6eR163-R208)

### Imports and Minor Cleanups

* Added missing imports for `preventDefault` and `MouseEvent` utilities to support the new drag/resize behavior (`Splitview.purs`). [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL92-R92) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR102)

These changes collectively make the split view resizing more user-friendly and reliable, and ensure that the logic is thoroughly tested and easier to maintain.