### PR TITLE
Small changes

### DIFF
--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -421,14 +421,7 @@ splitview = connect selectTranslator $ H.mkComponent
       -- Left Resizer
       , HH.div
           [ HE.onMouseDown (StartResize LeftResizer)
-          , HP.style
-              "width: 8px; \
-              \cursor: col-resize; \
-              \background:rgba(0, 0, 0, 0.3); \
-              \display: flex; \
-              \align-items: center; \
-              \justify-content: center; \
-              \position: relative;"
+          , HP.classes [ H.ClassName "splitview-resizer" ]
           ]
       [ HH.button
           [ HP.classes $
@@ -454,14 +447,7 @@ splitview = connect selectTranslator $ H.mkComponent
   rightResizer state =
     HH.div
       [ HE.onMouseDown (StartResize RightResizer)
-      , HP.style
-          "width: 8px; \
-          \cursor: col-resize; \
-          \background:rgba(0, 0, 0, 0.3); \
-          \display: flex; \
-          \align-items: center; \
-          \justify-content: center; \
-          \position: relative;"
+      , HP.classes [ H.ClassName "splitview-resizer" ]
       ]
       [ HH.button
           [ HP.classes $

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -431,15 +431,22 @@ splitview = connect selectTranslator $ H.mkComponent
               \position: relative;"
           ]
       [ HH.button
-          [ HP.classes [ H.ClassName "splitview-resizer-toggle-btn" ]
+          [ HP.classes $
+              [ H.ClassName "splitview-resizer-toggle-btn"
+              , H.ClassName "splitview-resizer-toggle-btn--left"
+              ] <>
+                if state.resizeState.sidebarClosed then
+                  [ H.ClassName "splitview-resizer-toggle-btn--closed" ]
+                else
+                  []
             -- To prevent the resizer event under the button
           , HE.handler' (EventType "mousedown") \ev ->
               unsafePerformEffect do
                 stopPropagation ev
                 pure Nothing -- Do not trigger the mouse down event under the button
-              , HE.onClick \_ -> ToggleSidebar
-              ]
-              [ HH.text if not state.resizeState.sidebarClosed then "⟨" else "⟩" ]
+          , HE.onClick \_ -> ToggleSidebar
+          ]
+          [ HH.text if not state.resizeState.sidebarClosed then "⟨" else "⟩" ]
           ]
       ]
 
@@ -457,7 +464,14 @@ splitview = connect selectTranslator $ H.mkComponent
           \position: relative;"
       ]
       [ HH.button
-          [ HP.classes [ H.ClassName "splitview-resizer-toggle-btn" ]
+          [ HP.classes $
+              [ H.ClassName "splitview-resizer-toggle-btn"
+              , H.ClassName "splitview-resizer-toggle-btn--right"
+              ] <>
+                if state.resizeState.previewClosed then
+                  [ H.ClassName "splitview-resizer-toggle-btn--closed" ]
+                else
+                  []
             -- To prevent the resizer event under the button
           , HE.handler' (EventType "mousedown") \ev ->
               unsafePerformEffect do

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -423,23 +423,23 @@ splitview = connect selectTranslator $ H.mkComponent
           [ HE.onMouseDown (StartResize LeftResizer)
           , HP.classes [ H.ClassName "splitview-resizer" ]
           ]
-      [ HH.button
-          [ HP.classes $
-              [ H.ClassName "splitview-resizer-toggle-btn"
-              , H.ClassName "splitview-resizer-toggle-btn--left"
-              ] <>
-                if state.resizeState.sidebarClosed then
-                  [ H.ClassName "splitview-resizer-toggle-btn--closed" ]
-                else
-                  []
-            -- To prevent the resizer event under the button
-          , HE.handler' (EventType "mousedown") \ev ->
-              unsafePerformEffect do
-                stopPropagation ev
-                pure Nothing -- Do not trigger the mouse down event under the button
-          , HE.onClick \_ -> ToggleSidebar
-          ]
-          [ HH.text if not state.resizeState.sidebarClosed then "⟨" else "⟩" ]
+          [ HH.button
+              [ HP.classes $
+                  [ H.ClassName "splitview-resizer-toggle-btn"
+                  , H.ClassName "splitview-resizer-toggle-btn--left"
+                  ] <>
+                    if state.resizeState.sidebarClosed then
+                      [ H.ClassName "splitview-resizer-toggle-btn--closed" ]
+                    else
+                      []
+              -- To prevent the resizer event under the button
+              , HE.handler' (EventType "mousedown") \ev ->
+                  unsafePerformEffect do
+                    stopPropagation ev
+                    pure Nothing -- Do not trigger the mouse down event under the button
+              , HE.onClick \_ -> ToggleSidebar
+              ]
+              [ HH.text if not state.resizeState.sidebarClosed then "⟨" else "⟩" ]
           ]
       ]
 
@@ -458,7 +458,7 @@ splitview = connect selectTranslator $ H.mkComponent
                   [ H.ClassName "splitview-resizer-toggle-btn--closed" ]
                 else
                   []
-            -- To prevent the resizer event under the button
+          -- To prevent the resizer event under the button
           , HE.handler' (EventType "mousedown") \ev ->
               unsafePerformEffect do
                 stopPropagation ev

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -430,24 +430,13 @@ splitview = connect selectTranslator $ H.mkComponent
               \justify-content: center; \
               \position: relative;"
           ]
-          [ HH.button
-              [ HP.style
-                  "background:rgba(255, 255, 255, 0.8); \
-                  \border: 0.2px solid #aaa; \
-                  \padding: 0.1rem 0.1rem; \
-                  \font-size: 8px; \
-                  \font-weight: bold; \
-                  \line-height: 1; \
-                  \color:rgba(0, 0, 0, 0.7); \
-                  \border-radius: 3px; \
-                  \cursor: pointer; \
-                  \height: 40px; \
-                  \width: 8px;"
-              -- To prevent the resizer event under the button
-              , HE.handler' (EventType "mousedown") \ev ->
-                  unsafePerformEffect do
-                    stopPropagation ev
-                    pure Nothing -- Do not trigger the mouse down event under the button
+      [ HH.button
+          [ HP.classes [ H.ClassName "splitview-resizer-toggle-btn" ]
+            -- To prevent the resizer event under the button
+          , HE.handler' (EventType "mousedown") \ev ->
+              unsafePerformEffect do
+                stopPropagation ev
+                pure Nothing -- Do not trigger the mouse down event under the button
               , HE.onClick \_ -> ToggleSidebar
               ]
               [ HH.text if not state.resizeState.sidebarClosed then "⟨" else "⟩" ]
@@ -468,19 +457,8 @@ splitview = connect selectTranslator $ H.mkComponent
           \position: relative;"
       ]
       [ HH.button
-          [ HP.style
-              "background:rgba(255, 255, 255, 0.8); \
-              \border: 0.2px solid #aaa; \
-              \padding: 0.1rem 0.1rem; \
-              \font-size: 8px; \
-              \font-weight: bold; \
-              \line-height: 1; \
-              \color:rgba(0, 0, 0, 0.7); \
-              \border-radius: 3px; \
-              \cursor: pointer; \
-              \height: 40px; \
-              \width: 8px;"
-          -- To prevent the resizer event under the button
+          [ HP.classes [ H.ClassName "splitview-resizer-toggle-btn" ]
+            -- To prevent the resizer event under the button
           , HE.handler' (EventType "mousedown") \ev ->
               unsafePerformEffect do
                 stopPropagation ev
@@ -557,19 +535,12 @@ splitview = connect selectTranslator $ H.mkComponent
   closeButton :: Action -> H.ComponentHTML Action Slots m
   closeButton action =
     HH.button
-      [ HP.classes [ HB.btn, HB.btnSm, HB.btnOutlineSecondary ]
-      , HP.style
-          "position: absolute; \
-          \top: 0.5rem; \
-          \right: 0.5rem; \
-          \background-color: #fdecea; \
-          \color: #b71c1c; \
-          \padding: 0.2rem 0.4rem; \
-          \font-size: 0.75rem; \
-          \line-height: 1; \
-          \border: 1px solid #f5c6cb; \
-          \border-radius: 0.2rem; \
-          \z-index: 10;"
+      [ HP.classes
+          [ HB.btn
+          , HB.btnSm
+          , HB.btnOutlineSecondary
+          , H.ClassName "splitview-close-btn"
+          ]
       , HE.onClick \_ -> action
       ]
       [ HH.i [ HP.classes [ HB.bi, H.ClassName "bi-x" ] ] [] ]

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -863,10 +863,11 @@ splitview = connect selectTranslator $ H.mkComponent
 
     -- Switch between CompareEditor, Preview and TogglePreview
     SwitchPreview -> do
-      state <- H.get
-      case state.mSelectedTocEntry of
-        Just _ -> clearSelectedEntry
-        Nothing -> handleAction TogglePreview
+      mSelectedTocEntry <- H.gets _.mSelectedTocEntry
+      -- Previously in case structure the close button would not close at the beginning
+      -- Now after clearSelectedEntry, also TogglePreview
+      when (isJust mSelectedTocEntry) clearSelectedEntry
+      handleAction TogglePreview
 
     -- Toggle the preview area
     TogglePreview -> do

--- a/frontend/static/app.css
+++ b/frontend/static/app.css
@@ -3,6 +3,7 @@
    if you use CSS variables, it must come first */
 @import url("./editor-theme.css");
 @import url("./editor.css");
+@import url("./splitview.css");
 @import url("./comment.css");
 @import url("./highlighting.css");
 @import url("./home.css");

--- a/frontend/static/splitview.css
+++ b/frontend/static/splitview.css
@@ -10,6 +10,25 @@
   cursor: pointer;
   height: 40px;
   width: 8px;
+  position: relative;
+  z-index: 1000;
+  transition: width 140ms ease, height 140ms ease, transform 140ms ease, font-size 140ms ease;
+}
+
+.splitview-resizer-toggle-btn--closed {
+  width: 18px;
+  height: 56px;
+  font-size: 11px;
+  border-width: 1px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
+}
+
+.splitview-resizer-toggle-btn--left.splitview-resizer-toggle-btn--closed {
+  transform: translateX(7px);
+}
+
+.splitview-resizer-toggle-btn--right.splitview-resizer-toggle-btn--closed {
+  transform: translateX(-7px);
 }
 
 .splitview-close-btn {
@@ -23,5 +42,5 @@
   line-height: 1;
   border: 1px solid #f5c6cb;
   border-radius: 0.2rem;
-  z-index: 10;
+  z-index: 1100;
 }

--- a/frontend/static/splitview.css
+++ b/frontend/static/splitview.css
@@ -1,0 +1,27 @@
+.splitview-resizer-toggle-btn {
+  background: rgba(255, 255, 255, 0.8);
+  border: 0.2px solid #aaa;
+  padding: 0.1rem 0.1rem;
+  font-size: 8px;
+  font-weight: bold;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.7);
+  border-radius: 3px;
+  cursor: pointer;
+  height: 40px;
+  width: 8px;
+}
+
+.splitview-close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: #fdecea;
+  color: #b71c1c;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  line-height: 1;
+  border: 1px solid #f5c6cb;
+  border-radius: 0.2rem;
+  z-index: 10;
+}

--- a/frontend/static/splitview.css
+++ b/frontend/static/splitview.css
@@ -1,3 +1,13 @@
+.splitview-resizer {
+  width: 8px;
+  cursor: col-resize;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
 .splitview-resizer-toggle-btn {
   background: rgba(255, 255, 255, 0.8);
   border: 0.2px solid #aaa;


### PR DESCRIPTION
This pull request refactors the styling of splitview-related buttons in the frontend, moving from inline styles in PureScript to CSS classes defined in a new stylesheet. This change improves maintainability and makes it easier to update styles in the future. Additionally, there is a small logic improvement for the preview switching action.

**Styling and CSS refactor:**

* Replaced inline styles for splitview resizer toggle buttons in `Splitview.purs` with CSS classes (`splitview-resizer-toggle-btn`, `splitview-resizer-toggle-btn--left`, `splitview-resizer-toggle-btn--right`, and `splitview-resizer-toggle-btn--closed`) and added corresponding styles in the new `splitview.css` file. The button appearance now depends on sidebar/preview state. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL434-R441) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL471-R474) [[3]](diffhunk://#diff-e231670933d93d7fcf7be9ec05381ff921767c5d4277fc1b834e8093b3ac2c16R1-R46)
* Replaced inline styles for the close button in `Splitview.purs` with a new `splitview-close-btn` CSS class, and added its styles to `splitview.css`. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL560-R557) [[2]](diffhunk://#diff-e231670933d93d7fcf7be9ec05381ff921767c5d4277fc1b834e8093b3ac2c16R1-R46)
* Added an import for the new `splitview.css` stylesheet in `app.css` to ensure the new styles are loaded.

**Behavioral improvement:**

* Updated the `SwitchPreview` action logic so that after clearing the selected TOC entry, it also toggles the preview, ensuring consistent behavior when switching views.
This pull request refactors the styling of splitview controls in the frontend by replacing inline styles with CSS classes, and introduces a new `splitview.css` stylesheet. It also updates the logic for toggling the preview area to ensure consistent behavior. These changes improve maintainability, consistency, and make it easier to update styles in the future.

**Styling refactor and CSS improvements:**

- Replaced inline styles for splitview resizer toggle buttons and close button in `Splitview.purs` with semantic CSS classes (`splitview-resizer-toggle-btn`, `splitview-close-btn`). The buttons now conditionally apply modifier classes based on sidebar or preview state. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL434-R441) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL471-R474) [[3]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aL560-R557)
- Added a new stylesheet `splitview.css` containing all splitview-related styles, and imported it in `app.css`. [[1]](diffhunk://#diff-c27139d82ad89bf3581af27b1641e37a82b2c575028ac1facb405c54527b9e4fR6) [[2]](diffhunk://#diff-e231670933d93d7fcf7be9ec05381ff921767c5d4277fc1b834e8093b3ac2c16R1-R46)

**Behavioral improvements:**

- Updated the `SwitchPreview` action logic to always toggle the preview after clearing a selected table of contents entry, ensuring the close button behaves consistently at all times.