### PR TITLE
Removed field description if it is not your account #774

### DIFF
--- a/frontend/src/FPO/Page/Profile.purs
+++ b/frontend/src/FPO/Page/Profile.purs
@@ -197,9 +197,11 @@ component =
                                       [ HP.id "usernameHelp"
                                       , HP.classes [ HB.textMuted ]
                                       ]
-                                      [ HH.text $ translate
-                                          (label :: _ "prof_usernameHelp")
-                                          state.translator
+                                      [ if state.isYourProfile then
+                                          HH.text $ translate
+                                            (label :: _ "prof_usernameHelp")
+                                            state.translator
+                                        else HH.text ""
                                       ]
                                   , if state.unsaved then
                                       HH.span


### PR DESCRIPTION
Closes issue #774 
I don't know if the SA was supposed to be able to edit the username of others but I assumed that the permissions were already checked properly, so the SA does now not see the edit description on other profiles anymore.