### PR TITLE
Frontend header editor #769

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -876,7 +876,7 @@ editor = connect selectTranslator $ H.mkComponent
                   pure unit -- Nothing to do
                 Just [] -> do
                   H.raise $ RenamedNode contentLines [] --update Header without updating the title
-                Just path -> do 
+                Just path -> do
                   H.raise $ RenamedNode contentLines path
                   H.raise UpdateFullTitle
               freeSaveFlagsAndMaybeRerun

--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -874,7 +874,9 @@ editor = connect selectTranslator $ H.mkComponent
               case state.mNodePath of
                 Nothing -> do
                   pure unit -- Nothing to do
-                Just path -> do
+                Just [] -> do
+                  H.raise $ RenamedNode contentLines [] --update Header without updating the title
+                Just path -> do 
                   H.raise $ RenamedNode contentLines path
                   H.raise UpdateFullTitle
               freeSaveFlagsAndMaybeRerun

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1662,18 +1662,24 @@ insertNodeIntoEdgeAtPosition path node (Edge (Node { meta, children, header })) 
 changeNodeHeading
   :: Path -> String -> TOCTree -> TOCTree
 changeNodeHeading _ _ Empty = Empty
-changeNodeHeading path newName (RootTree { children, header }) =
-  let
-    newChildren = mapWithIndex
-      ( \ix (Edge child) ->
-          case uncons path of
-            Just { head, tail } | ix == head ->
-              Edge $ changeNodeHeading' tail newName child
-            _ -> Edge child
-      )
-      children
-  in
-    RootTree { children: newChildren, header }
+changeNodeHeading path newName (RootTree { children, header }) =  
+  if path == [] then
+    let
+      newHeader = updateHeading newName header
+    in 
+      RootTree{children, header: newHeader}
+  else
+    let
+      newChildren = mapWithIndex
+        ( \ix (Edge child) ->
+            case uncons path of
+              Just { head, tail } | ix == head ->
+                Edge $ changeNodeHeading' tail newName child
+              _ -> Edge child
+        )
+        children
+    in
+      RootTree { children: newChildren, header }
 
 changeNodeHeading' :: Path -> String -> Tree TOCEntry -> Tree TOCEntry
 changeNodeHeading' path newName tree = case path of

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1662,12 +1662,12 @@ insertNodeIntoEdgeAtPosition path node (Edge (Node { meta, children, header })) 
 changeNodeHeading
   :: Path -> String -> TOCTree -> TOCTree
 changeNodeHeading _ _ Empty = Empty
-changeNodeHeading path newName (RootTree { children, header }) =  
+changeNodeHeading path newName (RootTree { children, header }) =
   if path == [] then
     let
       newHeader = updateHeading newName header
-    in 
-      RootTree{children, header: newHeader}
+    in
+      RootTree { children, header: newHeader }
   else
     let
       newChildren = mapWithIndex

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1071,6 +1071,12 @@ tocview = connect selectAll $ H.mkComponent
                 [ HH.div
                     [ HP.classes innerDivClasses ]
                     [ HH.span
+                        [ HP.classes
+                            [ HH.ClassName "toc-drag-handle", HB.textMuted, HB.me2 ]
+                        , HP.style ("margin-left: " <> "1" <> "rem;")
+                        ]
+                        (singletonIf (isJust Nothing) $ HH.text "⋮⋮")
+                    , HH.span
                         ( [ HP.classes titleClasses
                           , HP.style "align-self: stretch; flex-basis: 0;"
                           , HP.title "Header"

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1053,53 +1053,44 @@ tocview = connect selectAll $ H.mkComponent
                     ]
                 ]
             ]
-        , HH.div
-            [ HP.classes [ HH.ClassName "toc-list" ] ]
-            [ let
-                selectedClasses = case mSelectedTocEntry of
-                  Just (SelNode [] _) -> [ HH.ClassName "active" ]
-                  _ -> []
-                innerDivClasses =
-                  [ HB.dFlex, HB.alignItemsCenter, HB.py1, HB.positionRelative ]
-                titleClasses =
-                  [ HB.textTruncate, HB.flexGrow1, HB.fwBold, HB.fs5 ]
-              in        
-                HH.div
-                  ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <>
-                    selectedClasses
-                    ]
-                    <>
-                    [ HP.style "cursor: pointer;" ]
-                  )
-                  [ HH.div
+        , let
+            selectedClasses = case mSelectedTocEntry of
+              Just (SelNode [] _) -> [ HH.ClassName "active" ]
+              _ -> []
+            innerDivClasses =
+              [ HB.dFlex, HB.alignItemsCenter, HB.py1, HB.positionRelative ]
+            titleClasses =
+              [ HB.textTruncate, HB.flexGrow1, HB.fwBold, HB.fs5 ]
+            headerItem =
+              HH.div
+                ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <> selectedClasses ]
+                  <> [ HP.style "cursor: pointer;" ]
+                )
+                [ HH.div
                     [ HP.classes innerDivClasses ]
                     [ HH.span
-                      ( [ HP.classes titleClasses
-                        , HP.style "align-self: stretch; flex-basis: 0;"
-                        , HP.title "Header"
-                        , HE.onClick \_ -> JumpToNodeSection []
-                                (getHeading header)
-                                ("Header")
-                        ]
-                        
-                      )
-                      [ HH.text "Kopfzeile" ]
-                  --, addItemInterface
+                        ( [ HP.classes titleClasses
+                          , HP.style "align-self: stretch; flex-basis: 0;"
+                          , HP.title "Header"
+                          , HE.onClick \_ -> JumpToNodeSection [] (getHeading header) "Header"
+                          ]
+                        )
+                        [ HH.text "Kopfzeile" ]
                     ]
-                  ]
-                  
-                
-            <> ( concat $ mapWithIndex
-                ( \ix (Edge child) ->
-                    treeToHTML header state menuPath historyPath 1 mSelectedTocEntry
-                      [ ix ]
-                      now
-                      searchData
-                      child
-                )
-                children
+                ]
+            childItems = concat $ mapWithIndex
+              ( \ix (Edge child) ->
+                  treeToHTML header state menuPath historyPath 1 mSelectedTocEntry
+                    [ ix ]
+                    now
+                    searchData
+                    child
               )
-            ]     
+              children
+          in
+            HH.div
+              [ HP.classes [ HH.ClassName "toc-list" ] ]
+              ( [ headerItem ] <> childItems )     
         ]
     ]
 

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1063,8 +1063,10 @@ tocview = connect selectAll $ H.mkComponent
               [ HB.textTruncate, HB.flexGrow1, HB.fwBold, HB.fs5 ]
             headerItem =
               HH.div
-                ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <> selectedClasses ]
-                  <> [ HP.style "cursor: pointer;" ]
+                ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <>
+                      selectedClasses
+                  ]
+                    <> [ HP.style "cursor: pointer;" ]
                 )
                 [ HH.div
                     [ HP.classes innerDivClasses ]
@@ -1072,7 +1074,8 @@ tocview = connect selectAll $ H.mkComponent
                         ( [ HP.classes titleClasses
                           , HP.style "align-self: stretch; flex-basis: 0;"
                           , HP.title "Header"
-                          , HE.onClick \_ -> JumpToNodeSection [] (getHeading header) "Header"
+                          , HE.onClick \_ -> JumpToNodeSection [] (getHeading header)
+                              "Header"
                           ]
                         )
                         [ HH.text "Kopfzeile" ]
@@ -1090,7 +1093,7 @@ tocview = connect selectAll $ H.mkComponent
           in
             HH.div
               [ HP.classes [ HH.ClassName "toc-list" ] ]
-              ( [ headerItem ] <> childItems )     
+              ([ headerItem ] <> childItems)
         ]
     ]
 

--- a/frontend/src/FPO/Components/TOC.purs
+++ b/frontend/src/FPO/Components/TOC.purs
@@ -1055,7 +1055,41 @@ tocview = connect selectAll $ H.mkComponent
             ]
         , HH.div
             [ HP.classes [ HH.ClassName "toc-list" ] ]
-            ( concat $ mapWithIndex
+            [ let
+                selectedClasses = case mSelectedTocEntry of
+                  Just (SelNode [] _) -> [ HH.ClassName "active" ]
+                  _ -> []
+                innerDivClasses =
+                  [ HB.dFlex, HB.alignItemsCenter, HB.py1, HB.positionRelative ]
+                titleClasses =
+                  [ HB.textTruncate, HB.flexGrow1, HB.fwBold, HB.fs5 ]
+              in        
+                HH.div
+                  ( [ HP.classes $ [ HH.ClassName "toc-item", HB.rounded ] <>
+                    selectedClasses
+                    ]
+                    <>
+                    [ HP.style "cursor: pointer;" ]
+                  )
+                  [ HH.div
+                    [ HP.classes innerDivClasses ]
+                    [ HH.span
+                      ( [ HP.classes titleClasses
+                        , HP.style "align-self: stretch; flex-basis: 0;"
+                        , HP.title "Header"
+                        , HE.onClick \_ -> JumpToNodeSection []
+                                (getHeading header)
+                                ("Header")
+                        ]
+                        
+                      )
+                      [ HH.text "Kopfzeile" ]
+                  --, addItemInterface
+                    ]
+                  ]
+                  
+                
+            <> ( concat $ mapWithIndex
                 ( \ix (Edge child) ->
                     treeToHTML header state menuPath historyPath 1 mSelectedTocEntry
                       [ ix ]
@@ -1064,7 +1098,8 @@ tocview = connect selectAll $ H.mkComponent
                       child
                 )
                 children
-            )
+              )
+            ]     
         ]
     ]
 


### PR DESCRIPTION
I added an extra field in the TOC, that enables the changing of the document header. 
I don't if I missed a setting but I assume that the tree structure causes the field to be on the very left edge of the TOC since the header node is the root node of the tree that is represented in the TOC. If you think that this has to be corrected I can try to find a solution for this.