### PR TITLE
fixed some preview not showing bugs

### DIFF
--- a/frontend/src/FPO/Components/Editor/Editor.purs
+++ b/frontend/src/FPO/Components/Editor/Editor.purs
@@ -698,6 +698,7 @@ editor = connect selectTranslator $ H.mkComponent
 
       H.getHTMLElementRef (H.RefLabel "container") >>= traverse_ \el -> do
         editor_ <- H.liftEffect $ Ace.editNode el Ace.ace
+        H.modify_ _ { mEditor = Just editor_ }
         fontSize <- H.gets _.fontSize
 
         -- setting for both instances and later add more specific settings

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1002,6 +1002,8 @@ splitview = connect selectTranslator $ H.mkComponent
 
     SetComparison elementID mVID -> do
       state <- H.get
+      when state.resizeState.previewClosed $
+        handleAction TogglePreview
       let
         tocEntry = fromMaybe
           emptyTOCEntry
@@ -1078,6 +1080,8 @@ splitview = connect selectTranslator $ H.mkComponent
 
       Editor.ClickedQuery html -> do
         state <- H.get
+        when state.resizeState.previewClosed $
+          handleAction TogglePreview
         case state.mSelectedTocEntry of
           Just (SelLeaf tocID) -> do
             -- Only reset comparison data if we're not currently in comparison mode

--- a/frontend/src/FPO/Components/Splitview.purs
+++ b/frontend/src/FPO/Components/Splitview.purs
@@ -1008,14 +1008,16 @@ splitview = connect selectTranslator $ H.mkComponent
         tocEntry = fromMaybe
           emptyTOCEntry
           (findTOCEntry elementID state.tocEntries)
-        title = fromMaybe
-          ""
-          (findTitleTOCEntry elementID state.tocEntries)
+        mTitle = findTitleTOCEntry elementID state.tocEntries
+        title = fromMaybe "" mTitle
+      syncSelectedEntry (SelLeaf elementID) mTitle
       handleAction
         ( ModifyVersionMapping elementID Nothing
             (Just (Just { tocEntry: tocEntry, revID: mVID, title: title }))
         )
       mmTitle <- H.request _toc unit TOC.RequestFullTitle
+      H.tell _editor 0
+        (Editor.ChangeSection tocEntry Nothing (join mmTitle))
       H.tell _editor 1
         (Editor.ChangeSection tocEntry mVID (join mmTitle))
 
@@ -1095,17 +1097,7 @@ splitview = connect selectTranslator $ H.mkComponent
               Just _ -> pure unit -- Don't reset comparison data when in comparison mode
           _ -> pure unit
         -- Always set renderedHtml
-        H.modify_ _
-          { renderedHtml = Just (Loaded html)
-          }
-        -- Only update previewRatio and previewClosed if preview is not already shown
-        when state.resizeState.previewClosed do
-          H.modify_ \st -> st
-            { resizeState = st.resizeState
-                { previewRatio = state.resizeState.lastExpandedPreviewRatio
-                , previewClosed = false
-                }
-            }
+        H.modify_ _ { renderedHtml = Just (Loaded html) }
 
       Editor.PostPDF _ -> do
         state <- H.get


### PR DESCRIPTION
This pull request improves the behavior and state management of the editor and splitview components, particularly around how the preview pane is handled and how editor state is updated in response to user actions. The changes ensure that the preview pane is automatically opened when needed and that editor state is kept in sync with UI actions.

**Preview pane and editor state management improvements:**

* In `splitview`, automatically open the preview pane when handling `SetComparison` and `Editor.ClickedQuery` actions if it is currently closed, ensuring users always see relevant content when performing these actions. [[1]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1005-R1020) [[2]](diffhunk://#diff-6881623327fc39dac1d17ed390fd821cc264862698beae562c16bcf4e5dd583aR1085-R1086)
* Simplified the logic for updating the `renderedHtml` state and removed redundant preview pane state updates, making the code easier to maintain and reducing the risk of inconsistent UI state.

**Editor initialization:**

* In `Editor`, store the created Ace editor instance in the component state (`mEditor`) immediately after initialization, ensuring the editor reference is always available for later use.

**Synchronization between components:**

* In `splitview`, synchronize the selected table of contents (TOC) entry and its title with the editor component when handling `SetComparison`, keeping the editor context in sync with user navigation.This pull request introduces improvements to the editor and splitview components, focusing on better state management and user experience when interacting with the preview panel. The most significant changes ensure that the preview panel is automatically opened when certain actions are performed, and that the editor instance is properly tracked in the application state.

**Splitview preview panel behavior:**

* The preview panel is now automatically opened if it is closed when the `SetComparison` action is triggered, ensuring users always see the preview when comparing content.
* Similarly, when a query is clicked in the editor, the preview panel will open if it was previously closed, improving workflow continuity.

**Editor state management:**

* The editor component now stores the Ace editor instance in its state (`mEditor`), which will facilitate future interactions with the editor instance.